### PR TITLE
Fixes issue #10: Exception When Changing Ships

### DIFF
--- a/main/src/com/miloshpetrov/sol2/game/ship/ShipBuilder.java
+++ b/main/src/com/miloshpetrov/sol2/game/ship/ShipBuilder.java
@@ -127,7 +127,9 @@ public class ShipBuilder {
     }
     if (gun2 != null) {
       GunMount m2 = hull.getGunMount(true);
-      if (m2.isFixed() == gun2.config.fixed) m2.setGun(game, ship, gun2, hullConfig.g2UnderShip);
+      if (m2 != null) {
+        if (m2.isFixed() == gun2.config.fixed) m2.setGun(game, ship, gun2, hullConfig.g2UnderShip);
+      }
     }
     return ship;
   }


### PR DESCRIPTION
Fixes issue https://github.com/MovingBlocks/DestinationSol/issues/10

Problem was trying to mount the old secondary gun on the smaller ship when the smaller ship didn't have a second gun slot. Added a check that new ship has a secondary gun slot before trying to mount. The ini file is below for testing. Nice bug report @theotherjay, made it easy to reproduce.

prevship.ini
hull=desertMedium
money=2104
items=bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip bulletClip rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep rep teleportCharge teleportCharge teleportCharge teleportCharge teleportCharge teleportCharge teleportCharge teleportCharge teleportCharge teleportCharge fixedGun a4 s3 fixedShotGun shellClip shellClip shellClip shellClip shellClip shellClip shellClip shellClip shellClip fixedGun plasmaGun plasmaClip plasmaGun s1 plasmaGun unShieldCharge s2 blaster