### PR TITLE
Fixed up issue identified in PR19

### DIFF
--- a/main/src/com/miloshpetrov/sol2/ui/SolInputManager.java
+++ b/main/src/com/miloshpetrov/sol2/ui/SolInputManager.java
@@ -125,6 +125,9 @@ public class SolInputManager {
   }
 
   public void update(SolApplication cmp) {
+    boolean mobile = cmp.isMobile();
+    if (!mobile) maybeFixMousePos();
+
     updatePtrs();
 
     boolean consumed = false;
@@ -233,7 +236,7 @@ public class SolInputManager {
     int h = Gdx.graphics.getHeight();
     mouseX = (int)SolMath.clamp(mouseX, 0, w);
     mouseY = (int)SolMath.clamp(mouseY, 0, h);
-    Gdx.input.setCursorPosition(mouseX, h - mouseY);
+    Gdx.input.setCursorPosition(mouseX, mouseY);
   }
 
   private void updatePtrs() {


### PR DESCRIPTION
As mentioned at: https://github.com/MovingBlocks/DestinationSol/pull/19. The mouse is supposed to be "clamped" so it doesn't go off the edge of the screen. Includes the fix to prevent the two mouse pointers due to this change: https://github.com/libgdx/libgdx/issues/1003