### PR TITLE
Fixes Issue #23 - Repair Item Lost on Restart

### DIFF
--- a/main/src/com/miloshpetrov/sol2/game/ship/ShipRepairer.java
+++ b/main/src/com/miloshpetrov/sol2/game/ship/ShipRepairer.java
@@ -14,6 +14,11 @@ public class ShipRepairer {
   }
 
   public float tryRepair(SolGame game, ItemContainer ic, float life, HullConfig config) {
+    // Don't attempt to repair if already at full health
+    if (life == config.maxLife){
+      return 0;
+    }
+
     float ts = game.getTimeStep();
     if (myRepairPoints <= 0 && ic.tryConsumeItem(game.getItemMan().getRepairExample())) {
       myRepairPoints = RepairItem.LIFE_AMT;


### PR DESCRIPTION
The current repair behaviour works by consuming a repair item and converting it in to Repair Points. These Repair Points persist during your current game session and are consumed as needed when repairing your ship (when your ship is idle). 

The issue is that if your Repair Points were zero, as they would be at the start of a game, and a repair item is available in your inventory it would immediately get removed and converted to Repair Points. This would happen regardless of whether or not your ship needed repairing.

I've added a check at the start of the tryRepair function that will see if the ship needs repairing before attempting to repair it by consuming a repair item. I think this function gets called to repair all ships, not just the player's ship.

I've tested that repair items don't get consumed unless required and that the repair process still occurs when needed.