### PR TITLE
Fix for approxRadius. 

### DIFF
--- a/main/src/com/miloshpetrov/sol2/files/HullConfigManager.java
+++ b/main/src/com/miloshpetrov/sol2/files/HullConfigManager.java
@@ -142,6 +142,7 @@ public final class HullConfigManager {
         JsonValue jsonNode = jsonReader.parse(propertiesFile);
 
         configData.size = jsonNode.getFloat("size");
+        configData.approxRadius = 0.4f * configData.size;
         configData.maxLife = jsonNode.getInt("maxLife");
 
         configData.e1Pos = readVector2(jsonNode, "e1Pos", new Vector2());


### PR DESCRIPTION
Pull request for the hullrebased branch. This fixes the approxRadius being set to zero. The multiplication of size by 0.4f was lost during the refactor: https://github.com/MovingBlocks/DestinationSol/blob/852dd290cb2e9ba1f52be31f1550be34396976ac/main/src/com/miloshpetrov/sol2/game/ship/HullConfig.java#L53