### PR TITLE
Improvement to Configuring Controls

### DIFF
--- a/main/src/com/miloshpetrov/sol2/menu/InputMapControllerScreen.java
+++ b/main/src/com/miloshpetrov/sol2/menu/InputMapControllerScreen.java
@@ -22,7 +22,6 @@ public class InputMapControllerScreen implements InputMapOperations {
     private static final String HEADER_TEXT = "Controller Inputs";
 
     private final ArrayList<SolUiControl> controls;
-    private final SolUiControl changeCtrl;
     private boolean isEnterNewKey;
     private List<InputConfigItem> itemsList = new ArrayList<InputConfigItem>();
     private int selectedIndex;
@@ -30,9 +29,6 @@ public class InputMapControllerScreen implements InputMapOperations {
 
     public InputMapControllerScreen(InputMapScreen inputMapScreen, GameOptions gameOptions) {
         controls = new ArrayList<SolUiControl>();
-        changeCtrl = new SolUiControl(inputMapScreen.itemCtrl(0), true);
-        changeCtrl.setDisplayName("Change");
-        controls.add(changeCtrl);
     }
 
     private InputConfigItem InitItem(int axis, int button, String displayName) {
@@ -171,33 +167,39 @@ public class InputMapControllerScreen implements InputMapOperations {
 
     @Override
     public void updateCustom(SolApplication cmp, SolInputManager.Ptr[] ptrs, boolean clickedOutside) {
-        if (changeCtrl.isJustOff()) {
-            isEnterNewKey = !isEnterNewKey;
+    }
 
-            // Can cancel the key entering by clicking this button a second time
-            if (!isEnterNewKey) {
-                Gdx.input.setInputProcessor(null);
-                Controllers.clearListeners();
-                return;
-            }
+    @Override
+    public void setEnterNewKey(boolean newKey){
+        isEnterNewKey = newKey;
 
+        // Cancel the key input
+        if (!isEnterNewKey) {
+            Gdx.input.setInputProcessor(null);
+            Controllers.clearListeners();
+        } else {
+            // Capture the new key input
             // Keyboard items
-                Gdx.input.setInputProcessor(new InputAdapter() {
-                    @Override
-                    public boolean keyUp(int keycode) {
-                        if (selectedIndex >= controllerItems) {
-                            InputConfigItem item = itemsList.get(selectedIndex);
-                            item.setInputKey(Input.Keys.toString(keycode));
-                            itemsList.set(selectedIndex, item);
-                        }
+            Gdx.input.setInputProcessor(new InputAdapter() {
+                @Override
+                public boolean keyUp(int keycode) {
+                    // Don't capture the escape key
+                    if (keycode == Input.Keys.ESCAPE) return true;
 
-                        Gdx.input.setInputProcessor(null);
-                        Controllers.clearListeners();
-
-                        isEnterNewKey = false;
-                        return true; // return true to indicate the event was handled
+                    if (selectedIndex >= controllerItems) {
+                        InputConfigItem item = itemsList.get(selectedIndex);
+                        item.setInputKey(Input.Keys.toString(keycode));
+                        itemsList.set(selectedIndex, item);
                     }
-                });
+
+                    Gdx.input.setInputProcessor(null);
+                    Controllers.clearListeners();
+
+                    isEnterNewKey = false;
+                    return true; // return true to indicate the event was handled
+                }
+            });
+
             // Controller items
             // setup the listener that prints events to the console
             Controllers.addListener(new ControllerListener() {

--- a/main/src/com/miloshpetrov/sol2/menu/InputMapKeyboardScreen.java
+++ b/main/src/com/miloshpetrov/sol2/menu/InputMapKeyboardScreen.java
@@ -16,16 +16,12 @@ public class InputMapKeyboardScreen implements InputMapOperations {
     private static final String HEADER_TEXT = "Keyboard Inputs";
 
     private final ArrayList<SolUiControl> controls;
-    private final SolUiControl changeCtrl;
     private boolean isEnterNewKey;
     private List<InputConfigItem> itemsList = new ArrayList<InputConfigItem>();
     private int selectedIndex;
 
     public InputMapKeyboardScreen(InputMapScreen inputMapScreen, GameOptions gameOptions) {
         controls = new ArrayList<SolUiControl>();
-        changeCtrl = new SolUiControl(inputMapScreen.itemCtrl(0), true);
-        changeCtrl.setDisplayName("Change");
-        controls.add(changeCtrl);
     }
 
     private void InitialiseList(GameOptions gameOptions) {
@@ -170,18 +166,23 @@ public class InputMapKeyboardScreen implements InputMapOperations {
 
     @Override
     public void updateCustom(SolApplication cmp, SolInputManager.Ptr[] ptrs, boolean clickedOutside) {
-        if (changeCtrl.isJustOff()) {
-            isEnterNewKey = !isEnterNewKey;
+    }
 
-            // Can cancel the key entering by clicking this button a second time
-            if (!isEnterNewKey) {
-                Gdx.input.setInputProcessor(null);
-                return;
-            }
+    @Override
+    public void setEnterNewKey(boolean newKey){
+        isEnterNewKey = newKey;
 
+        // Cancel the key input
+        if (!isEnterNewKey) {
+            Gdx.input.setInputProcessor(null);
+        } else {
+            // Capture the new key input
             Gdx.input.setInputProcessor(new InputAdapter() {
                 @Override
-                public boolean keyUp (int keycode) {
+                public boolean keyUp(int keycode) {
+                    // Don't capture the escape key
+                    if (keycode == Input.Keys.ESCAPE) return true;
+
                     InputConfigItem item = itemsList.get(selectedIndex);
                     item.setInputKey(Input.Keys.toString(keycode));
                     itemsList.set(selectedIndex, item);

--- a/main/src/com/miloshpetrov/sol2/menu/InputMapMixedScreen.java
+++ b/main/src/com/miloshpetrov/sol2/menu/InputMapMixedScreen.java
@@ -17,18 +17,12 @@ public class InputMapMixedScreen implements InputMapOperations {
     private static final String HEADER_TEXT = "Keyboard and Mouse Inputs";
 
     private final ArrayList<SolUiControl> controls;
-    private final SolUiControl changeCtrl;
     private boolean isEnterNewKey;
     private List<InputConfigItem> itemsList = new ArrayList<InputConfigItem>();
     private int selectedIndex;
 
     public InputMapMixedScreen(InputMapScreen inputMapScreen, GameOptions gameOptions) {
         controls = new ArrayList<SolUiControl>();
-
-        changeCtrl = new SolUiControl(inputMapScreen.itemCtrl(0), true);
-        changeCtrl.setDisplayName("Change");
-        controls.add(changeCtrl);
-
     }
 
     private void InitialiseList(GameOptions gameOptions) {
@@ -137,18 +131,23 @@ public class InputMapMixedScreen implements InputMapOperations {
 
     @Override
     public void updateCustom(SolApplication cmp, SolInputManager.Ptr[] ptrs, boolean clickedOutside) {
-        if (changeCtrl.isJustOff()) {
-            isEnterNewKey = !isEnterNewKey;
+    }
 
-            // Can cancel the key entering by clicking this button a second time
-            if (!isEnterNewKey) {
-                Gdx.input.setInputProcessor(null);
-                return;
-            }
+    @Override
+    public void setEnterNewKey(boolean newKey){
+        isEnterNewKey = newKey;
 
+        // Cancel the key input
+        if (!isEnterNewKey) {
+            Gdx.input.setInputProcessor(null);
+        } else {
+            // Capture the new key input
             Gdx.input.setInputProcessor(new InputAdapter() {
                 @Override
                 public boolean keyUp (int keycode) {
+                    // Don't capture the escape key
+                    if (keycode == Input.Keys.ESCAPE) return true;
+
                     InputConfigItem item = itemsList.get(selectedIndex);
                     item.setInputKey(Input.Keys.toString(keycode));
                     itemsList.set(selectedIndex, item);

--- a/main/src/com/miloshpetrov/sol2/menu/InputMapOperations.java
+++ b/main/src/com/miloshpetrov/sol2/menu/InputMapOperations.java
@@ -33,6 +33,12 @@ public interface InputMapOperations extends SolUiScreen {
     boolean isEnterNewKey();
 
     /**
+     * Enter a new input key
+     * @param newKey The value to set
+     */
+    void setEnterNewKey(boolean newKey);
+
+    /**
      * States which item in the list is currently selected
      * @param index The index
      */

--- a/main/src/com/miloshpetrov/sol2/menu/InputMapScreen.java
+++ b/main/src/com/miloshpetrov/sol2/menu/InputMapScreen.java
@@ -135,9 +135,14 @@ public class InputMapScreen implements SolUiScreen {
             im.setScreen(cmp, screens.options);
         }
 
-        // Cancel - return to options screen without saving
         if (cancelCtrl.isJustOff()) {
-            im.setScreen(cmp, screens.options);
+            if (operations.isEnterNewKey()) {
+                // Cancel - cancel the current key being entered
+                operations.setEnterNewKey(false);
+            } else {
+                // Cancel - return to options screen without saving
+                im.setScreen(cmp, screens.options);
+            }
         }
 
         // Disable handling of key inputs while entering a new input key
@@ -146,10 +151,16 @@ public class InputMapScreen implements SolUiScreen {
             nextCtrl.setEnabled(false);
             upCtrl.setEnabled(false);
             downCtrl.setEnabled(false);
+            for (int i = 0; i < itemCtrls.length; i++) {
+                itemCtrls[i].setEnabled(false);
+            }
             return;
         } else {
             upCtrl.setEnabled(true);
             downCtrl.setEnabled(true);
+            for (int i = 0; i < itemCtrls.length; i++) {
+                itemCtrls[i].setEnabled(true);
+            }
         }
 
         // Defaults - Reset the input keys back to their default values
@@ -168,6 +179,7 @@ public class InputMapScreen implements SolUiScreen {
             SolUiControl itemCtrl = itemCtrls[i];
             if (itemCtrl.isJustOff()) {
                 selectedIndex = i + offset;
+                operations.setEnterNewKey(true);
             }
         }
 

--- a/main/src/com/miloshpetrov/sol2/menu/MainScreen.java
+++ b/main/src/com/miloshpetrov/sol2/menu/MainScreen.java
@@ -43,7 +43,7 @@ public class MainScreen implements SolUiScreen {
     myOptionsCtrl.setDisplayName("Options");
     myControls.add(myOptionsCtrl);
 
-    myExitCtrl = new SolUiControl(menuLayout.buttonRect(-1, 4), true);
+    myExitCtrl = new SolUiControl(menuLayout.buttonRect(-1, 4), true, gameOptions.getKeyEscape());
     myExitCtrl.setDisplayName("Exit");
     myControls.add(myExitCtrl);
 

--- a/main/src/com/miloshpetrov/sol2/menu/OptionsScreen.java
+++ b/main/src/com/miloshpetrov/sol2/menu/OptionsScreen.java
@@ -28,7 +28,7 @@ public class OptionsScreen implements SolUiScreen {
     myControls.add(myControlTypeCtrl);
 
     inputMapCtrl = new SolUiControl(menuLayout.buttonRect(-1, 3), true, Input.Keys.M);
-    inputMapCtrl.setDisplayName("Input Map");
+    inputMapCtrl.setDisplayName("Controls");
     myControls.add(inputMapCtrl);
 
     myBackCtrl = new SolUiControl(menuLayout.buttonRect(-1, 4), true, gameOptions.getKeyEscape());


### PR DESCRIPTION
Improvements to configuring the controls from feedback from @Cervator. 

1. Changed "Input Map" to "Controls"
2. Removed the "Change" button - change the input by clicking the row with the mouse
3. Escape is used to cancel so can't map a button to the escape key

Also made a change to the main screen so you can quit by pressing Escape. Useful for anyone affected by issue #48, 