### PR TITLE
Fixes issue #61

### DIFF
--- a/main/src/com/miloshpetrov/sol2/ui/SolInputManager.java
+++ b/main/src/com/miloshpetrov/sol2/ui/SolInputManager.java
@@ -23,6 +23,7 @@ public class SolInputManager {
   private static final float CURSOR_SHOW_TIME = 3;
   public static final float CURSOR_SZ = .07f;
   public static final float WARN_PERC_GROWTH_TIME = 1f;
+  private static final float initialRatio = ((float) Gdx.graphics.getWidth()) / ((float) Gdx.graphics.getHeight());
 
   private final List<SolUiScreen> myScreens;
   private final List<SolUiScreen> myToRemove;
@@ -120,7 +121,9 @@ public class SolInputManager {
 
   private static void setPtrPos(Ptr ptr, int screenX, int screenY) {
     int h = Gdx.graphics.getHeight();
-    ptr.x = 1f * screenX / h;
+    float currentRatio = ((float) Gdx.graphics.getWidth()) / ((float) Gdx.graphics.getHeight());
+
+    ptr.x = 1f * screenX / h * (initialRatio / currentRatio);
     ptr.y = 1f * screenY / h;
   }
 


### PR DESCRIPTION
The screen UI uses a ratio to determine where the items appear on the screen. The x and y coordinates of the screen are converted to a float, where the top is y=0 and the bottom is y=1. The left is x=0 and the right is x=ratio (width / height), e.g. in 800x600 the right hand side is 1.33.

The ratio that the UI elements is used is initialised when the game starts, so once the screen resolution is changed to something like 1366x768, ratio of 1.78, the UI elements are not reinitialised. This isn't too much of a problem, but you will observe some oddities, like the text "Controls: KB + Mouse" don't fit in to the button, but after a restart the will.

The possible options are:
1. Restart the game, but there's no easy way other than asking the user. 
2. Reinitialise everything that uses this ratio - which is every UI element. This seems like it's essentially restarting the game while the game is running. 
3. Scale the mouse pointer by the same ratio so that it's in the correct place.

I've gone with option 3 which scales the mouse x pointer by the ratio of the initial ratio over the current ratio. I've written up steps to reproduce the issue in #61.