### PR TITLE
Display a message box with the error as to why the game didn't start.

### DIFF
--- a/desktop/src/com/miloshpetrov/sol2/desktop/SolDesktop.java
+++ b/desktop/src/com/miloshpetrov/sol2/desktop/SolDesktop.java
@@ -9,6 +9,7 @@ import com.miloshpetrov.sol2.SolApplication;
 import com.miloshpetrov.sol2.SolFileReader;
 import com.miloshpetrov.sol2.game.DebugOptions;
 import com.miloshpetrov.sol2.soundtest.SoundTestListener;
+import org.lwjgl.Sys;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -53,6 +54,14 @@ public class SolDesktop {
         } else {
             c.addIcon(DebugOptions.DEV_ROOT_PATH + "res/icon.png", Files.FileType.Absolute);
         }
+
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException (Thread thread, final Throwable ex) {
+                System.err.println("Critical Failure" + ex.getLocalizedMessage());
+                Sys.alert("Critical Failure", ex.getLocalizedMessage());
+            }
+        });
 
         new LwjglApplication(new SolApplication(), c);
     }


### PR DESCRIPTION
Fix for #71. Displays a message box with the error as to why the game didn't start. Taken from http://badlogicgames.com/forum/viewtopic.php?f=11&t=11305

Tried it out and think this provides a good solution for the two scenarios in #71. Screenshots below of the message box for these scenarios.

![image](https://cloud.githubusercontent.com/assets/7613950/9106072/70b92c60-3c71-11e5-9125-00573a15d61c.png)

![image](https://cloud.githubusercontent.com/assets/7613950/9106084/7fe39464-3c71-11e5-9657-b81527c181b8.png)

Note: The images are different styles as one is from Windows 7 and the other is Windows 10