### PR TITLE
Improved uncaught exception handler

### DIFF
--- a/desktop/src/org/destinationsol/desktop/SolDesktop.java
+++ b/desktop/src/org/destinationsol/desktop/SolDesktop.java
@@ -3,6 +3,7 @@ package org.destinationsol.desktop;
 import com.badlogic.gdx.Files;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.google.common.base.Throwables;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.destinationsol.SolFileReader;
@@ -56,9 +57,10 @@ public class SolDesktop {
 
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
-            public void uncaughtException (Thread thread, final Throwable ex) {
-                System.err.println("Critical Failure " + ex.getLocalizedMessage());
-                Sys.alert("Critical Failure ", ex.getLocalizedMessage());
+            public void uncaughtException(Thread thread, final Throwable ex) {
+                String exceptionString = Throwables.getStackTraceAsString(ex) + "Message: " + ex.getLocalizedMessage();
+                System.err.println("Uncaught exception: " + exceptionString);
+                Sys.alert("Uncaught Exception", exceptionString);
             }
         });
 

--- a/desktop/src/org/destinationsol/desktop/SolDesktop.java
+++ b/desktop/src/org/destinationsol/desktop/SolDesktop.java
@@ -3,7 +3,6 @@ package org.destinationsol.desktop;
 import com.badlogic.gdx.Files;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
-import com.google.common.base.Throwables;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.destinationsol.SolFileReader;
@@ -14,6 +13,8 @@ import org.lwjgl.Sys;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +59,11 @@ public class SolDesktop {
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread thread, final Throwable ex) {
-                String exceptionString = Throwables.getStackTraceAsString(ex) + "Message: " + ex.getLocalizedMessage();
+                StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter);
+                ex.printStackTrace(printWriter);
+
+                String exceptionString = stringWriter.getBuffer().toString() + "Message: " + ex.getLocalizedMessage();
                 System.err.println("Uncaught exception: " + exceptionString);
                 Sys.alert("Uncaught Exception", exceptionString);
             }


### PR DESCRIPTION
### Contains

A fix for the game's UncaughtExceptionHandler that makes it output the exception's stack trace along with the message. Useful for debugging purposes - the current exception handler makes it nearly impossible to trace an exception without a dedicated debugger.

**Before:**

![Exception handler before the PR](http://i.imgur.com/qpvtsOk.png)

**After:**

![Exception handler after the PR](http://i.imgur.com/Cs3xNAc.png)

### How to test

Simply throw some exceptions in [SolApplication#create](https://github.com/MovingBlocks/DestinationSol/blob/259925154be691912c9804d72d936b2781e477a2/main/src/org/destinationsol/SolApplication.java#L58-L76) or any other method.

### Outstanding before merging

No outstanding issues.