### PR TITLE
CrashReporter integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ## General
+*.log
 hs_err_pid*
 .gradle
 /config/metrics

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
     compile "com.badlogicgames.gdx:gdx-controllers-desktop:$gdxVersion"
     compile "com.badlogicgames.gdx:gdx-controllers-platform:$gdxVersion:natives-desktop"
+    compile "org.terasology:CrashReporter-destsol:3.0.0"
 }
 
 task run(type: JavaExec) {

--- a/main/src/org/destinationsol/SolApplication.java
+++ b/main/src/org/destinationsol/SolApplication.java
@@ -28,10 +28,15 @@ import org.destinationsol.game.DebugOptions;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.sound.MusicManager;
 import org.destinationsol.menu.MenuScreens;
-import org.destinationsol.ui.*;
+import org.destinationsol.ui.DebugCollector;
+import org.destinationsol.ui.FontSize;
+import org.destinationsol.ui.SolInputManager;
+import org.destinationsol.ui.SolLayouts;
+import org.destinationsol.ui.UiDrawer;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
 public class SolApplication implements ApplicationListener {
 
   private SolInputManager myInputMan;
@@ -111,6 +116,10 @@ public class SolApplication implements ApplicationListener {
       PrintWriter pw = new PrintWriter(sw);
       t.printStackTrace(pw);
       myFatalErrorTrace = sw.toString();
+
+      if (!myReallyMobile) {
+        throw t;
+      }
     }
   }
 

--- a/main/src/org/destinationsol/SolFileReader.java
+++ b/main/src/org/destinationsol/SolFileReader.java
@@ -16,8 +16,11 @@
 
 package org.destinationsol;
 
+import java.nio.file.Path;
 import java.util.List;
 
 public interface SolFileReader {
-  List<String> read(String fileName);
+    Path create(String fileName, List<String> lines);
+
+    List<String> read(String fileName);
 }


### PR DESCRIPTION
### Contains

A followup to #91 suggested by @msteiger - integrates Destination Sol with [CrashReporter](https://github.com/MovingBlocks/CrashReporter) 2.3.0 (containing the new `UserInfoPanel` from [CrashReporter#28](https://github.com/MovingBlocks/CrashReporter/pull/28)!)

![CrashReporter integration screenshot](https://cloud.githubusercontent.com/assets/13783592/14763605/22c499ae-09a3-11e6-88c3-0513be0f486a.png)

### How to test

- Throw some exceptions in [SolApplication.create()](https://github.com/MovingBlocks/DestinationSol/blob/bbea53620a626a9b27ae47540c75d3a24620c840/main/src/org/destinationsol/SolApplication.java#L58-L76), launch the game.
- Throw some exceptions in [the SolGame constructor](https://github.com/MovingBlocks/DestinationSol/blob/bbea53620a626a9b27ae47540c75d3a24620c840/main/src/org/destinationsol/game/SolGame.java#L106-L151), launch the game and start it.

(Hint: `int i = 1/0;` is the easiest way to cause an unhandled exception!)

### Outstanding before merging

- [ ] Is the current name for the generated log file (`crash-yyyy-dd-MM_HH-mm-ss.log`) appropriate? Should anything but the current exception stack trace be logged?
- [x] The links in the last window still refer to the Terasology-specific support forum and GitHub issue page - support for link changes needs to be added in CrashReporter itself.