### PR TITLE
Use updated CrashReporter version and dependency format.

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
     compile "com.badlogicgames.gdx:gdx-controllers-desktop:$gdxVersion"
     compile "com.badlogicgames.gdx:gdx-controllers-platform:$gdxVersion:natives-desktop"
-    compile "org.terasology:CrashReporter-destsol:3.0.0"
+
+    compile group: 'org.terasology.crashreporter', name: 'cr-destsol', version: '4.0.0'
 }
 
 task run(type: JavaExec) {


### PR DESCRIPTION
Making PR just for documentation purposes. Main bulk of the work is documented over at https://github.com/MovingBlocks/Terasology/pull/2386

While the DS Gradle setup isn't as mature as Terasology's yet we could allow the CR to embed here as well, probably around the same time we properly add gestalt-module and modules in their own Git sub-roots.