### PR TITLE
Mercs now start with weapons in their inventory

### DIFF
--- a/main/res/configs/planets.json
+++ b/main/res/configs/planets.json
@@ -70,7 +70,7 @@
       mercenaries: [
         {
           hull: pirateSmall,
-          items: "rep:1:3 s1",
+          items: "blaster|gun s1 rep:1:3",
           money: 100,
         },
       ],
@@ -156,7 +156,7 @@
       mercenaries: [
         {
           hull: desertOrbiter,
-          items: "rep:1:3 s1",
+          items: "fixedBombGun a1:.25 rep:1:3",
           money: 150,
         },
       ],

--- a/main/src/org/destinationsol/game/ship/SolShip.java
+++ b/main/src/org/destinationsol/game/ship/SolShip.java
@@ -180,6 +180,11 @@ public class SolShip implements SolObject {
     boolean canAdd = c.canAdd(i);
     if (canAdd) {
       c.add(i);
+      if(c == myItemContainer&&myPilot.getMapHint()=="Merc")
+      {
+    	  //System.out.println("Merc could try to equip");
+    	  //insert equip code here, if it's something we want to do
+      }
     }
     return canAdd;
   }


### PR DESCRIPTION
The planets.json config file has the mercenary item listings, and neither one was starting with weapons in their inventory. I added weapons, and everything else worked ok. I also added a placeholder block for code for mercenaries equipping items dropped on them. I don't think we should have them do that, though- not having to worry about equipping mercenaries is easier for the player. 