### PR TITLE
Add "Can't sell equipped items" option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -119,6 +119,7 @@ Contributors
 * [LadySerenaKitty](https://github.com/LadySerenaKitty)
 * [askneller](https://github.com/askneller)
 * [JGelfand](https://github.com/JGelfand)
+* [AvaLanCS](https://github.com/Avalancs)
 
 ... and your name here? :-) More coming!
 

--- a/main/src/org/destinationsol/GameOptions.java
+++ b/main/src/org/destinationsol/GameOptions.java
@@ -71,6 +71,7 @@ public class GameOptions {
   public int controlType;
   public float volMul;
   public float musicMul;
+  public boolean canSellEquippedItems;
   private String keyUpMouseName;
   private String keyDownMouseName;
   private String keyUpName;
@@ -149,6 +150,7 @@ public class GameOptions {
     controllerButtonRight = r.getInt("controllerButtonRight", DEFAULT_BUTTON_RIGHT);
     controllerButtonUp = r.getInt("controllerButtonUp", DEFAULT_BUTTON_UP);
     controllerButtonDown = r.getInt("controllerButtonDown", DEFAULT_BUTTON_DOWN);
+    canSellEquippedItems = r.getBoolean("canSellEquippedItems", false);
   }
 
   public void advanceReso() {
@@ -228,6 +230,7 @@ public class GameOptions {
    */
   public void save() {
     IniReader.write(FILE_NAME, "x", x, "y", y, "fullscreen", fullscreen, "controlType", controlType, "vol", volMul,
+            "canSellEquippedItems", canSellEquippedItems,
             "keyUpMouse", getKeyUpMouseName(), "keyDownMouse", getKeyDownMouseName(), "keyUp", getKeyUpName(), "keyDown", keyDownName,
             "keyLeft", keyLeftName, "keyRight", keyRightName, "keyShoot", keyShootName, "keyShoot2", getKeyShoot2Name(),
             "keyAbility", getKeyAbilityName(), "keyEscape", getKeyEscapeName(), "keyMap", keyMapName, "keyInventory", keyInventoryName,

--- a/main/src/org/destinationsol/game/screens/MenuScreen.java
+++ b/main/src/org/destinationsol/game/screens/MenuScreen.java
@@ -36,10 +36,14 @@ public class MenuScreen implements SolUiScreen {
   private final SolUiControl myRespawnCtrl;
   private final SolUiControl mySoundVolCtrl;
   private final SolUiControl myMusVolCtrl;
+  private final SolUiControl myDoNotSellEquippedControl;
 
   public MenuScreen(MenuLayout menuLayout, GameOptions gameOptions) {
     myControls = new ArrayList<SolUiControl>();
 
+    myDoNotSellEquippedControl = new SolUiControl(menuLayout.buttonRect(-1, -1), true);
+    myDoNotSellEquippedControl.setDisplayName("Can't sell equipped items");
+    myControls.add(myDoNotSellEquippedControl);
     mySoundVolCtrl = new SolUiControl(menuLayout.buttonRect(-1, 1), true);
     mySoundVolCtrl.setDisplayName("Sound Vol");
     myControls.add(mySoundVolCtrl);
@@ -87,6 +91,11 @@ public class MenuScreen implements SolUiScreen {
     if (myCloseCtrl.isJustOff()) {
       g.setPaused(false);
       im.setScreen(cmp, g.getScreens().mainScreen);
+    }
+    myDoNotSellEquippedControl.setDisplayName("Can't sell equipped items: " +
+            (options.canSellEquippedItems ? "No" : "Yes"));
+    if (myDoNotSellEquippedControl.isJustOff()) {
+      options.canSellEquippedItems = !options.canSellEquippedItems;
     }
   }
 

--- a/main/src/org/destinationsol/game/screens/SellItems.java
+++ b/main/src/org/destinationsol/game/screens/SellItems.java
@@ -22,6 +22,7 @@ import org.destinationsol.game.SolGame;
 import org.destinationsol.game.item.ItemContainer;
 import org.destinationsol.game.item.SolItem;
 import org.destinationsol.game.ship.SolShip;
+import org.destinationsol.menu.OptionsScreen;
 import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.SolUiControl;
 import org.destinationsol.ui.UiDrawer;
@@ -82,10 +83,27 @@ public class SellItems implements InventoryOperations {
       return;
     }
     SolItem selItem = is.getSelectedItem();
-    boolean enabled = selItem != null && target.getTradeContainer().getItems().canAdd(selItem);
-    sellCtrl.setDisplayName(enabled ? "Sell" : "---");
-    sellCtrl.setEnabled(enabled);
-    if (!enabled) return;
+    if(selItem == null) {
+        sellCtrl.setDisplayName("----");
+        sellCtrl.setEnabled(false);
+        return;
+    }
+
+    boolean isWornAndCanBeSold = isItemEquippedAndSellable(selItem, target, game, cmp.getOptions());
+    boolean enabled = isItemSellable(selItem, target);
+
+    if(enabled && isWornAndCanBeSold) {
+        sellCtrl.setDisplayName("Sell");
+        sellCtrl.setEnabled(true);
+    } else if(enabled && !isWornAndCanBeSold) {
+        sellCtrl.setDisplayName("Unequip it!");
+        sellCtrl.setEnabled(false);
+    } else {
+        sellCtrl.setDisplayName("----");
+        sellCtrl.setEnabled(false);
+    }
+
+    if (!enabled || !isWornAndCanBeSold) return;
     if (sellCtrl.isJustOff()) {
       ItemContainer ic = hero.getItemContainer();
       is.setSelected(ic.getSelectionAfterRemove(is.getSelected()));
@@ -93,6 +111,18 @@ public class SellItems implements InventoryOperations {
       target.getTradeContainer().getItems().add(selItem);
       hero.setMoney(hero.getMoney() + selItem.getPrice() * PERC);
     }
+  }
+
+  private boolean isItemSellable(SolItem item, SolShip target) {
+      return target.getTradeContainer().getItems().canAdd(item);
+  }
+
+  // return true if the item is not worn, or is worn and canSellEquippedItems is true
+  private boolean isItemEquippedAndSellable(SolItem item, SolShip target, SolGame game, GameOptions options) {
+      if(item.isEquipped()==0 || ((item.isEquipped() != 0) && options.canSellEquippedItems)) {
+          return true;
+      }
+      return false;
   }
 
   @Override

--- a/main/src/org/destinationsol/menu/MenuLayout.java
+++ b/main/src/org/destinationsol/menu/MenuLayout.java
@@ -26,14 +26,15 @@ public class MenuLayout {
   public final float row0;
   private final float rowH;
   private final float myPad;
+  private static final int numberOfRowsTotal = 5;
 
   public MenuLayout(float r) {
-    btnW = .25f * r;
+    btnW = .30f * r;
     btnH = .1f;
     myPad = .1f * btnH;
     rowH = btnH + myPad;
     colCenter = .5f * r - btnW / 2;
-    row0 = 1 - myPad - 5 * rowH;
+    row0 = 1 - myPad - numberOfRowsTotal * rowH;
   }
 
   public Rectangle buttonRect(int col, int row) {


### PR DESCRIPTION
Add a new option "Can't sell equipped items" in menu. When enabled, selecting an equipped item in the sell window will have a disabled button "unequip it!" instead of "sell".
![menu](https://cloud.githubusercontent.com/assets/18668703/18725543/f97eaa52-8040-11e6-84f3-629b3b586c1e.jpg)
![sell window](https://cloud.githubusercontent.com/assets/18668703/18725542/f97e92ba-8040-11e6-9a94-5b117fe69970.jpg)

