### PR TITLE
fix issue #106: highlight items to unequip

### DIFF
--- a/main/src/org/destinationsol/game/SolGame.java
+++ b/main/src/org/destinationsol/game/SolGame.java
@@ -108,7 +108,7 @@ public class SolGame {
     myDraMan = new DraMan(drawer);
     myCam = new SolCam(drawer.r);
     myScreens = new GameScreens(drawer.r, cmp);
-    myTutorialManager = tut ? new TutorialManager(commonDrawer.r, myScreens, cmp.isMobile(), cmp.getOptions()) : null;
+    myTutorialManager = tut ? new TutorialManager(commonDrawer.r, myScreens, cmp.isMobile(), cmp.getOptions(), this) : null;
     myTextureManager = textureManager;
     myFarBackgroundManagerOld = new FarBackgroundManagerOld(myTextureManager);
     myShipBuilder = new ShipBuilder();

--- a/main/src/org/destinationsol/game/screens/InventoryScreen.java
+++ b/main/src/org/destinationsol/game/screens/InventoryScreen.java
@@ -325,4 +325,22 @@ public class InventoryScreen implements SolUiScreen {
   public int getPage() {
     return myPage;
   }
+
+  public List<SolUiControl> getEquippedItemUIControlsForTutorial(SolGame game) {
+    List<SolUiControl> controls = new ArrayList<>();
+    ItemContainer ic = myOperations.getItems(game);
+    if (ic == null) return controls;
+
+    for (int i = 0; i < itemCtrls.length; i++) {
+      int groupIdx = myPage * Const.ITEM_GROUPS_PER_PAGE + i;
+      int groupCount = ic.groupCount();
+      if (groupCount <= groupIdx) continue;
+      SolUiControl itemCtrl = itemCtrls[i];
+      List<SolItem> group = ic.getGroup(groupIdx);
+      SolItem item = group.get(0);
+      if (myOperations.isUsing(game, item))
+        controls.add(itemCtrl);
+    }
+    return controls;
+  }
 }


### PR DESCRIPTION
An enhancement for https://github.com/MovingBlocks/DestinationSol/issues/106

I added an extra step to the tutorial where the player has to select an equipped item, so the unequip step will not be confusing. The text states that the "using" keyword marks equipped items, and also all the equipped items on the current tab are highlighted.
To implement this I subclassed Step in TutorialManager, and made  InventoryScreen:getEquippedItemUIControlsForTutorial to get the controls for items that are equipped
![tutorial_unequip_step](https://cloud.githubusercontent.com/assets/18668703/18818719/42176c52-8381-11e6-8c7f-6d8045af6340.jpg)
