### PR TITLE
fix map doesn't look right when the game is paused (issue #119)

### DIFF
--- a/main/src/org/destinationsol/game/SolGame.java
+++ b/main/src/org/destinationsol/game/SolGame.java
@@ -255,7 +255,11 @@ public class SolGame {
   public void update() {
     myDraDebugger.update(this);
 
-    if (myPaused) return;
+    if (myPaused) {
+      myCam.updateMap(this); // update zoom only for map
+      myMapDrawer.update(this); // animate map icons
+      return;
+    }
 
     myTimeFactor = DebugOptions.GAME_SPEED_MULTIPLIER;
     if (myHero != null) {


### PR DESCRIPTION
The issue was that the same camera is used for drawing the game, and the map, and the zoom did not get updated while the game was paused (and the skull icons did not get animated as well).

I extracted the zoom code in SolCamera so that it could be called when the game is paused.
