### PR TITLE
Item overflow error fix

### DIFF
--- a/main/src/org/destinationsol/game/item/ItemContainer.java
+++ b/main/src/org/destinationsol/game/item/ItemContainer.java
@@ -22,8 +22,9 @@ import org.destinationsol.common.SolMath;
 import java.util.*;
 
 public class ItemContainer implements Iterable<List<SolItem>> {
-  public static final int MAX_GROUP_COUNT = 4 * Const.ITEM_GROUPS_PER_PAGE;
-  public static final int MAX_GROUP_SZ = 30;
+  public static final int MAX_INVENTORY_PAGES = 4;
+  public static final int MAX_GROUP_COUNT = MAX_INVENTORY_PAGES * Const.ITEM_GROUPS_PER_PAGE;
+  public static final int MAX_STACK_SIZE = 30; // e.g.: ammo, repair kit
 
   private List<List<SolItem>> myGroups;
   private Set<List<SolItem>> myNewGroups;
@@ -57,7 +58,7 @@ public class ItemContainer implements Iterable<List<SolItem>> {
     for (int i = 0, myGroupsSize = myGroups.size(); i < myGroupsSize; i++) {
       List<SolItem> group = myGroups.get(i);
       SolItem item = group.get(0);
-      if (item.isSame(example)) return group.size() < MAX_GROUP_SZ;
+      if (item.isSame(example)) return group.size() < MAX_STACK_SIZE;
     }
     return myGroups.size() < MAX_GROUP_COUNT;
   }
@@ -68,15 +69,14 @@ public class ItemContainer implements Iterable<List<SolItem>> {
       List<SolItem> group = myGroups.get(i);
       SolItem item = group.get(0);
       if (item.isSame(addedItem)) {
-        if ((group.size() < MAX_GROUP_SZ))
-        {
+        if ((group.size() < MAX_STACK_SIZE)) {
         	group.add(addedItem);
         }
         return;
-        
       }
     }
-    if (myGroups.size() >= MAX_GROUP_COUNT) throw new AssertionError("reached group count limit");
+    // From now on, silently ignore if by some chance an extra inventory page is created
+    //if (myGroups.size() >= MAX_GROUP_COUNT) throw new AssertionError("reached group count limit");
     ArrayList<SolItem> group = new ArrayList<>();
     group.add(addedItem);
     myGroups.add(0, group);

--- a/main/src/org/destinationsol/game/item/ItemContainer.java
+++ b/main/src/org/destinationsol/game/item/ItemContainer.java
@@ -27,7 +27,6 @@ public class ItemContainer implements Iterable<List<SolItem>> {
 
   private List<List<SolItem>> myGroups;
   private Set<List<SolItem>> myNewGroups;
-  private int mySize;
 
   public ItemContainer() {
     myGroups = new ArrayList<List<SolItem>>();
@@ -72,17 +71,15 @@ public class ItemContainer implements Iterable<List<SolItem>> {
         if ((group.size() < MAX_GROUP_SZ))
         {
         	group.add(addedItem);
-        	mySize++;
         }
         return;
         
       }
     }
     if (myGroups.size() >= MAX_GROUP_COUNT) throw new AssertionError("reached group count limit");
-    ArrayList<SolItem> group = new ArrayList<SolItem>();
+    ArrayList<SolItem> group = new ArrayList<>();
     group.add(addedItem);
     myGroups.add(0, group);
-    mySize++;
     myNewGroups.add(group);
   }
 
@@ -93,10 +90,6 @@ public class ItemContainer implements Iterable<List<SolItem>> {
 
   public int groupCount() {
     return myGroups.size();
-  }
-
-  public int size() {
-    return mySize;
   }
 
   public boolean contains(SolItem item) {
@@ -116,7 +109,6 @@ public class ItemContainer implements Iterable<List<SolItem>> {
       if (group.isEmpty()) remGroup = group;
       if (removed) break;
     }
-    if (removed) mySize--;
     if (remGroup != null) {
       myGroups.remove(remGroup);
       myNewGroups.remove(remGroup);
@@ -165,7 +157,6 @@ public class ItemContainer implements Iterable<List<SolItem>> {
   public void clear() {
     myGroups.clear();
     myNewGroups.clear();
-    mySize = 0;
   }
 
   private class Itr implements Iterator<List<SolItem>> {


### PR DESCRIPTION
Second part to #114 and also a fix to http://forum.terasology.org/threads/crash-related-to-full-inventory.1643/

If somehow the player got an item that spanned to the 5th page of the inventory, quit the game, and then tried to play again, then an assertion error was thrown because of the 5th page. For example having a ship with a small and a large gun, filling up all the inventory space, then buying a ship with 2*large guns, the small gun would get unequipped and forms the 5th page.

I removed that assertion error, and verified that the game can start now. It is not possible to pick up an item that would add another entry to the 5th page (so you can pick up ammo and buy repair kits, if they stack with existing items), and after the player sells the excess items, he/she can pick up items normally.