### PR TITLE
Roll back Gestalt to v5.1.3 due to a release quirk 

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     compile "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
     compile "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
-    compile "org.terasology:gestalt-util:6.0.0"
-    compile "org.terasology:gestalt-module:6.0.0"
-    compile "org.terasology:gestalt-asset-core:6.0.0"
-    compile "org.terasology:gestalt-entity-system:6.0.0"
+    compile "org.terasology:gestalt-util:5.1.3"
+    compile "org.terasology:gestalt-module:5.1.3"
+    compile "org.terasology:gestalt-asset-core:5.1.3"
+    compile "org.terasology:gestalt-entity-system:5.1.3"
 }
 
 sourceSets {

--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -25,7 +25,6 @@ import org.destinationsol.common.SolColor;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.DebugOptions;
 import org.destinationsol.game.SolGame;
-import org.destinationsol.game.components.AsteroidComponent;
 import org.destinationsol.game.sound.OggMusicManager;
 import org.destinationsol.game.sound.OggSoundManager;
 import org.destinationsol.menu.MenuScreens;
@@ -36,28 +35,21 @@ import org.destinationsol.ui.SolLayouts;
 import org.destinationsol.ui.UiDrawer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.entitysystem.component.CodeGenComponentManager;
-import org.terasology.entitysystem.core.EntityManager;
-import org.terasology.entitysystem.core.EntityRef;
-import org.terasology.entitysystem.entity.inmemory.InMemoryEntityManager;
-import org.terasology.entitysystem.transaction.TransactionManager;
 import org.terasology.valuetype.TypeHandler;
 import org.terasology.valuetype.TypeLibrary;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Iterator;
-import java.util.Optional;
 
 public class SolApplication implements ApplicationListener {
     private static Logger logger = LoggerFactory.getLogger(SolApplication.class);
 
     @SuppressWarnings("FieldCanBeLocal")
     private ModuleManager moduleManager;
-    @SuppressWarnings("FieldCanBeLocal")
-    private TransactionManager transactionManager;
-    @SuppressWarnings("FieldCanBeLocal")
-    private EntityManager entityManager;
+    //@SuppressWarnings("FieldCanBeLocal")
+    //private TransactionManager transactionManager;
+    //@SuppressWarnings("FieldCanBeLocal")
+    //private EntityManager entityManager;
 
     private OggMusicManager musicManager;
     private OggSoundManager soundManager;
@@ -93,8 +85,8 @@ public class SolApplication implements ApplicationListener {
         TypeLibrary typeLibrary = new TypeLibrary();
         typeLibrary.addHandler(new TypeHandler<>(Integer.class, Integer::new));
         typeLibrary.addHandler(new TypeHandler<>(Vector3.class, Vector3::new));
-        transactionManager = new TransactionManager();
-        entityManager = new InMemoryEntityManager(new CodeGenComponentManager(typeLibrary), transactionManager);
+        //transactionManager = new TransactionManager();
+        //entityManager = new InMemoryEntityManager(new CodeGenComponentManager(typeLibrary), transactionManager);
 
         /*
         transactionManager.begin();

--- a/engine/src/main/java/org/destinationsol/game/components/AsteroidComponent.java
+++ b/engine/src/main/java/org/destinationsol/game/components/AsteroidComponent.java
@@ -15,9 +15,9 @@
  */
 package org.destinationsol.game.components;
 
-import org.terasology.entitysystem.core.Component;
+//import org.terasology.entitysystem.core.Component;
 
-public interface AsteroidComponent extends Component {
+public interface AsteroidComponent { //extends Component {
     Integer getSize();
     void setSize(Integer value);
 }


### PR DESCRIPTION
Some bad v6 artifacts got loose and were stuck in a few Gradle caches here and there. Artifactory has been tidied up and Jenkins' Gradle cache cleaned. Not sure if anybody else got the bad version other than me and @vampcat - but if `develop` doesn't compile after a `gradlew cleanIdea idea` for anybody else that's a thing to try :-)

We'll try a round two for adopting v6 soon enough, but this way we can start building and doing little things again.