### PR TITLE
game balance: lowered time between shots for blaster

### DIFF
--- a/modules/core/assets/items/guns/blaster/blaster.json
+++ b/modules/core/assets/items/guns/blaster/blaster.json
@@ -2,7 +2,7 @@
     "maxAngleVar": 30,
     "angleVarDamp": 6,
     "angleVarPerShot": 2,
-    "timeBetweenShots": 0.9,
+    "timeBetweenShots": 0.7,
     "reloadTime": 3,
     "price": 50,
     "clipName": "core:blasterClip",


### PR DESCRIPTION
I reduced the time between shots for the blaster so when starting out you have a better chance to take out enemies, and also makes shooting asteroids less tedious.