### PR TITLE
Fix music assets folder in AssetHelper

### DIFF
--- a/main/src/org/destinationsol/assets/AssetHelper.java
+++ b/main/src/org/destinationsol/assets/AssetHelper.java
@@ -53,7 +53,7 @@ public class AssetHelper {
             public OggMusic build(ResourceUrn urn, AssetType<OggMusic, OggMusicData> assetType, OggMusicData data) {
                 return new OggMusic(urn, assetType, data);
             }
-        }, "sounds");
+        }, "music");
 
         assetTypeManager.switchEnvironment(environment);
     }


### PR DESCRIPTION
### Contains

Music assets have been searched in "sound" subfolder and as the Optionals are not checked for isPresent() in AssetHelper, this led to NoSuchElementException on game startup.
Pointing to the right "music" subfolder for music assets fixes this.

Fixes #173 

### How to test

Check out the original 2.0. branch and try to start the game. It will crash on NoSuchElementException.
Check out my fixed branch and try to start the game - it won't crash and can be played.

### Outstanding before merging
I'm not sure what will be done with the branch, maybe renamed, but at least the game can be played if anyone tries to run it from this branch.