### PR TITLE
Corrected the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-Destination Sol
-==========
-
-<p align="center"><img src="/main/imgSrcs/ui/title.png" alt="Destination Sol"/></p>
+<p align="center"><img src="/main/imgSrcs/ui/engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png" alt="Destination Sol"/></p>
 
 This is the official open source home for the arcade space shooter Destination Sol, originally started by Milosh Petrov and a small team on [Steam](http://store.steampowered.com/app/342980/) and [SourceForge](http://sourceforge.net/projects/destinationsol)
 


### PR DESCRIPTION
Due to previous re-structuring of the game assets, the main logo of the main that was supposed to be displayed on the front page was showing up as a broken link. This PR fixes that, and renames README.markdown to README.md to maintain consistency with Terasology.