### PR TITLE
Spawn stations

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -15,8 +15,14 @@
  */
 package org.destinationsol.assets;
 
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.destinationsol.assets.audio.OggMusic;
 import org.destinationsol.assets.audio.OggSound;
 import org.destinationsol.assets.emitters.Emitter;
@@ -26,11 +32,8 @@ import org.destinationsol.assets.textures.DSTexture;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.module.ModuleEnvironment;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 
 /**
  * A high-level wrapper over the AssetHelper class.
@@ -40,6 +43,8 @@ import java.util.Set;
 public abstract class Assets {
     private static AssetHelper assetHelper;
     private static Set<ResourceUrn> textureList;
+    // This map is initialized after the player selects their ship, it maps the human readable names of ships to their internal URIs
+    public static Map<String, String> playerSpawnConfigIdMap = new HashMap<String, String>();
 
     /**
      * Initializes the class for loading assets using the given environment.

--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -43,8 +43,6 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 public abstract class Assets {
     private static AssetHelper assetHelper;
     private static Set<ResourceUrn> textureList;
-    // This map is initialized after the player selects their ship, it maps the human readable names of ships to their internal URIs
-    public static Map<String, String> playerSpawnConfigIdMap = new HashMap<String, String>();
 
     /**
      * Initializes the class for loading assets using the given environment.

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -142,8 +142,8 @@ public class GalaxyFiller {
         // Associates each ship with it's module
         game.getShipsModules();
         
-        String moduleName = game.playerSpawnConfigIdMap.get(game.getShipName());
-        moduleName = moduleName.split(":")[0];
+        String shipName = game.getShipName();
+        String moduleName = shipName.split(":")[0];
         
         Json json = Assets.getJson(moduleName + ":startingStation");
         JsonValue rootNode = getRootNode(json);

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -38,6 +38,7 @@ import org.destinationsol.game.planet.SolSystem;
 import org.destinationsol.game.planet.SysConfig;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.hulls.HullConfig;
+import org.destinationsol.menu.NewShipScreen;
 
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.JsonValue;
@@ -139,7 +140,7 @@ public class GalaxyFiller {
         createStarPorts(game);
         ArrayList<SolSystem> systems = game.getPlanetMan().getSystems();
 
-        String moduleName = Assets.playerSpawnConfigIdMap.get(game.getShipName());
+        String moduleName = NewShipScreen.playerSpawnConfigIdMap.get(game.getShipName());
         moduleName = moduleName.split(":")[0];
         
         Json json = Assets.getJson(moduleName + ":startingStation");

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -138,9 +138,6 @@ public class GalaxyFiller {
         }
         createStarPorts(game);
         ArrayList<SolSystem> systems = game.getPlanetMan().getSystems();
-
-        // Associates each ship with it's module
-        game.getShipsModules();
         
         String shipName = game.getShipName();
         String moduleName = shipName.split(":")[0];

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -15,8 +15,8 @@
  */
 package org.destinationsol.game;
 
-import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.utils.JsonValue;
+import java.util.ArrayList;
+
 import org.destinationsol.Const;
 import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.json.Json;
@@ -39,7 +39,9 @@ import org.destinationsol.game.planet.SysConfig;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
-import java.util.ArrayList;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.JsonValue;
+import com.google.gson.JsonParseException;
 
 public class GalaxyFiller {
     private static final float STATION_CONSUME_SECTOR = 45f;
@@ -120,6 +122,15 @@ public class GalaxyFiller {
         }
         return s;
     }
+    
+    public JsonValue checkRootNull(Json json) {
+    	JsonValue node = json.getJsonValue();
+    	if (node.isNull()) {
+    		throw new JsonParseException(String.format("Root node was not found in asset %s", node.name, json.toString()));
+    	} else {
+    		return node;
+    	}
+    }
 
     public void fill(SolGame game, HullConfigManager hullConfigManager, ItemManager itemManager) {
         if (DebugOptions.NO_OBJS) {
@@ -128,8 +139,11 @@ public class GalaxyFiller {
         createStarPorts(game);
         ArrayList<SolSystem> systems = game.getPlanetMan().getSystems();
 
-        Json json = Assets.getJson("engine:mainStationConfig");
-        JsonValue rootNode = json.getJsonValue();
+        String moduleName = Assets.playerSpawnConfigIdMap.get(game.getShipName());
+        moduleName = moduleName.split(":")[0];
+        
+        Json json = Assets.getJson(moduleName + ":startingStation");
+        JsonValue rootNode = checkRootNull(json);
 
         ShipConfig mainStationCfg = ShipConfig.load(hullConfigManager, rootNode, itemManager);
 

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -124,7 +124,7 @@ public class GalaxyFiller {
         return s;
     }
     
-    public JsonValue checkRootNull(Json json) {
+    public JsonValue getRootNode(Json json) {
     	JsonValue node = json.getJsonValue();
     	if (node.isNull()) {
     		throw new JsonParseException(String.format("Root node was not found in asset %s", node.name, json.toString()));
@@ -144,7 +144,7 @@ public class GalaxyFiller {
         moduleName = moduleName.split(":")[0];
         
         Json json = Assets.getJson(moduleName + ":startingStation");
-        JsonValue rootNode = checkRootNull(json);
+        JsonValue rootNode = getRootNode(json);
 
         ShipConfig mainStationCfg = ShipConfig.load(hullConfigManager, rootNode, itemManager);
 

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -38,7 +38,6 @@ import org.destinationsol.game.planet.SolSystem;
 import org.destinationsol.game.planet.SysConfig;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.hulls.HullConfig;
-import org.destinationsol.menu.NewShipScreen;
 
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.JsonValue;
@@ -140,7 +139,10 @@ public class GalaxyFiller {
         createStarPorts(game);
         ArrayList<SolSystem> systems = game.getPlanetMan().getSystems();
 
-        String moduleName = NewShipScreen.playerSpawnConfigIdMap.get(game.getShipName());
+        // Associates each ship with it's module
+        game.getShipsModules();
+        
+        String moduleName = game.playerSpawnConfigIdMap.get(game.getShipName());
         moduleName = moduleName.split(":")[0];
         
         Json json = Assets.getJson(moduleName + ":startingStation");

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -61,13 +61,15 @@ public class SaveManager {
         return new FileHandle(Paths.get(path).toFile()).exists();
     }
 
-    public static ShipConfig readShip(HullConfigManager hullConfigs, ItemManager itemManager) {
+    public static ShipConfig readShip(HullConfigManager hullConfigs, ItemManager itemManager, SolGame game) {
         IniReader ir = new IniReader(FILE_NAME, null);
 
         String hullName = ir.getString("hull", null);
         if (hullName == null) {
             return null;
         }
+        
+        game.setShipName(hullName);
 
         HullConfig hull = hullConfigs.getConfig(hullName);
         if (hull == null) {

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -55,7 +55,7 @@ public class ShipConfig {
         return res;
     }
 
-    public static ShipConfig load(HullConfigManager hullConfigs, String shipName, ItemManager itemManager) {
+    public static ShipConfig load(HullConfigManager hullConfigs, String shipName, ItemManager itemManager, SolGame game) {
         Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-z]*:playerSpawnConfig");
 
         ShipConfig shipConfig = null;
@@ -67,6 +67,7 @@ public class ShipConfig {
             for (JsonValue node : rootNode) {
                 if (node.name.equals(shipName)) {
                     shipConfig = load(hullConfigs, node, itemManager);
+                    game.setShipName(node.getString("hull"));
                     break;
                 }
             }

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -17,10 +17,14 @@ package org.destinationsol.game;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.JsonValue;
+
 import org.destinationsol.CommonDrawer;
 import org.destinationsol.Const;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.assets.Assets;
+import org.destinationsol.assets.json.Json;
 import org.destinationsol.common.DebugCol;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.files.HullConfigManager;
@@ -57,9 +61,13 @@ import org.destinationsol.game.sound.SpecialSounds;
 import org.destinationsol.ui.DebugCollector;
 import org.destinationsol.ui.TutorialManager;
 import org.destinationsol.ui.UiDrawer;
+import org.terasology.assets.ResourceUrn;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class SolGame {
     private final GameScreens gameScreens;
@@ -100,6 +108,9 @@ public class SolGame {
     private float timeFactor;
     private float respawnMoney;
     private HullConfig respawnHull;
+    
+    // This map is initialized after the player selects their ship, it maps the human readable names of ships to their internal URIs
+    public Map<String, String> playerSpawnConfigIdMap = new HashMap<String, String>();
 
     public SolGame(SolApplication cmp, String shipName, boolean tut, CommonDrawer commonDrawer) {
         solApplication = cmp;
@@ -204,6 +215,21 @@ public class SolGame {
 
         objectManager.addObjDelayed(hero);
         objectManager.resetDelays();
+    }
+    
+    public void getShipsModules() {  	
+        Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-z]*:playerSpawnConfig");
+
+        for (ResourceUrn configUrn : configUrnList) {
+            Json json = Assets.getJson(configUrn.toString());
+            JsonValue rootNode = json.getJsonValue();
+
+            for (JsonValue node : rootNode) {
+                playerSpawnConfigIdMap.put(node.name, node.getString("hull"));
+            }
+
+            json.dispose();
+        }       
     }
 
     public void onGameEnd() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -15,16 +15,13 @@
  */
 package org.destinationsol.game;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.utils.JsonValue;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.destinationsol.CommonDrawer;
 import org.destinationsol.Const;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
-import org.destinationsol.assets.Assets;
-import org.destinationsol.assets.json.Json;
 import org.destinationsol.common.DebugCol;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.files.HullConfigManager;
@@ -61,13 +58,9 @@ import org.destinationsol.game.sound.SpecialSounds;
 import org.destinationsol.ui.DebugCollector;
 import org.destinationsol.ui.TutorialManager;
 import org.destinationsol.ui.UiDrawer;
-import org.terasology.assets.ResourceUrn;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.Vector2;
 
 public class SolGame {
     private final GameScreens gameScreens;
@@ -108,9 +101,6 @@ public class SolGame {
     private float timeFactor;
     private float respawnMoney;
     private HullConfig respawnHull;
-    
-    // This map is initialized after the player selects their ship, it maps the human readable names of ships to their internal URIs
-    public Map<String, String> playerSpawnConfigIdMap = new HashMap<String, String>();
 
     public SolGame(SolApplication cmp, String shipName, boolean tut, CommonDrawer commonDrawer) {
         solApplication = cmp;
@@ -215,21 +205,6 @@ public class SolGame {
 
         objectManager.addObjDelayed(hero);
         objectManager.resetDelays();
-    }
-    
-    public void getShipsModules() {  	
-        Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-z]*:playerSpawnConfig");
-
-        for (ResourceUrn configUrn : configUrnList) {
-            Json json = Assets.getJson(configUrn.toString());
-            JsonValue rootNode = json.getJsonValue();
-
-            for (JsonValue node : rootNode) {
-                playerSpawnConfigIdMap.put(node.name, node.getString("hull"));
-            }
-
-            json.dispose();
-        }       
     }
 
     public void onGameEnd() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -148,7 +148,6 @@ public class SolGame {
         mountDetectDrawer = new MountDetectDrawer();
         respawnItems = new ArrayList<>();
         timeFactor = 1;
-        this.shipName = shipName;
 
         // from this point we're ready!
         planetManager.fill(solNames);
@@ -158,7 +157,7 @@ public class SolGame {
 
     // uh, this needs refactoring
     private void createPlayer(String shipName) {
-    	ShipConfig shipConfig = shipName == null ? SaveManager.readShip(hullConfigManager, itemManager, this) : ShipConfig.load(hullConfigManager, shipName, itemManager);
+        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(hullConfigManager, itemManager, this) : ShipConfig.load(hullConfigManager, shipName, itemManager, this);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -92,6 +92,7 @@ public class SolGame {
     private final GalaxyFiller galaxyFiller;
     private final ArrayList<SolItem> respawnItems;
     private SolShip hero;
+    private String shipName; // Not updated in-game. Can be changed using setter
     private float timeStep;
     private float time;
     private boolean paused;
@@ -136,6 +137,7 @@ public class SolGame {
         mountDetectDrawer = new MountDetectDrawer();
         respawnItems = new ArrayList<>();
         timeFactor = 1;
+        this.shipName = shipName;
 
         // from this point we're ready!
         planetManager.fill(solNames);
@@ -516,6 +518,14 @@ public class SolGame {
 
     public TutorialManager getTutMan() {
         return tutorialManager;
+    }
+    
+    public String getShipName() {
+    	return shipName;
+    }
+    
+    public void setShipName(String newName) {
+    	shipName = newName;
     }
 
     public void beforeHeroDeath() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,13 +152,19 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        galaxyFiller.fill(this, hullConfigManager, itemManager);
         createPlayer(shipName);
         SolMath.checkVectorsTaken(null);
     }
 
     // uh, this needs refactoring
     private void createPlayer(String shipName) {
+    	ShipConfig shipConfig = shipName == null ? SaveManager.readShip(hullConfigManager, itemManager, this) : ShipConfig.load(hullConfigManager, shipName, itemManager);
+
+        // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
+        assert shipConfig != null;
+        
+        galaxyFiller.fill(this, hullConfigManager, itemManager);
+    	
         Vector2 pos = galaxyFiller.getPlayerSpawnPos(this);
         camera.setPos(pos);
 
@@ -169,11 +175,6 @@ public class SolGame {
         } else {
             pilot = new UiControlledPilot(gameScreens.mainScreen);
         }
-
-        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(hullConfigManager, itemManager) : ShipConfig.load(hullConfigManager, shipName, itemManager);
-
-        // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
-        assert shipConfig != null;
 
         float money = respawnMoney != 0 ? respawnMoney : tutorialManager != null ? 200 : shipConfig.money;
 

--- a/engine/src/main/java/org/destinationsol/menu/NewGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/NewGameScreen.java
@@ -36,13 +36,13 @@ public class NewGameScreen implements SolUiScreen {
 
     private final ArrayList<SolUiControl> controls = new ArrayList<>();
     private final SolUiControl backControl;
-    private final SolUiControl previousControl;
+    private final SolUiControl continueControl;
     private final SolUiControl newControl;
 
     NewGameScreen(MenuLayout menuLayout, GameOptions gameOptions) {
-        previousControl = new SolUiControl(menuLayout.buttonRect(-1, 1), true, gameOptions.getKeyShoot());
-        previousControl.setDisplayName("Continue");
-        controls.add(previousControl);
+        continueControl = new SolUiControl(menuLayout.buttonRect(-1, 1), true, gameOptions.getKeyShoot());
+        continueControl.setDisplayName("Continue");
+        controls.add(continueControl);
 
         newControl = new SolUiControl(menuLayout.buttonRect(-1, 2), true);
         newControl.setDisplayName("New game");
@@ -62,7 +62,7 @@ public class NewGameScreen implements SolUiScreen {
 
     @Override
     public void onAdd(SolApplication solApplication) {
-        previousControl.setEnabled(SaveManager.hasPrevShip());
+        continueControl.setEnabled(SaveManager.hasPrevShip());
     }
 
     @Override
@@ -73,7 +73,7 @@ public class NewGameScreen implements SolUiScreen {
             im.setScreen(solApplication, screens.main);
             return;
         }
-        if (previousControl.isJustOff()) {
+        if (continueControl.isJustOff()) {
             solApplication.loadNewGame(false, null);
             return;
         }

--- a/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
@@ -33,7 +33,9 @@ import org.destinationsol.ui.UiDrawer;
 import org.terasology.assets.ResourceUrn;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class NewShipScreen implements SolUiScreen {
@@ -46,6 +48,8 @@ public class NewShipScreen implements SolUiScreen {
     private SolUiControl playerSpawnConfigControl;
     private int playerSpawnConfigIndex = 0;
     private List<String> playerSpawnConfigNames = new ArrayList<>();
+    // This map is initialized after the player selects their ship, it maps the human readable names of ships to their internal URIs
+    public static Map<String, String> playerSpawnConfigIdMap = new HashMap<String, String>();
 
     NewShipScreen(MenuLayout menuLayout, GameOptions gameOptions) {
         loadPlayerSpawnConfigs();
@@ -121,7 +125,7 @@ public class NewShipScreen implements SolUiScreen {
 
             for (JsonValue node : rootNode) {
                 playerSpawnConfigNames.add(node.name);
-                Assets.playerSpawnConfigIdMap.put(node.name, node.getString("hull"));
+                playerSpawnConfigIdMap.put(node.name, node.getString("hull"));
             }
 
             json.dispose();

--- a/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
@@ -16,9 +16,10 @@
 
 package org.destinationsol.menu;
 
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.TextureAtlas;
-import com.badlogic.gdx.utils.JsonValue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.destinationsol.assets.Assets;
@@ -32,11 +33,9 @@ import org.destinationsol.ui.SolUiScreen;
 import org.destinationsol.ui.UiDrawer;
 import org.terasology.assets.ResourceUrn;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.utils.JsonValue;
 
 public class NewShipScreen implements SolUiScreen {
     private final TextureAtlas.AtlasRegion bgTex;
@@ -48,8 +47,6 @@ public class NewShipScreen implements SolUiScreen {
     private SolUiControl playerSpawnConfigControl;
     private int playerSpawnConfigIndex = 0;
     private List<String> playerSpawnConfigNames = new ArrayList<>();
-    // This map is initialized after the player selects their ship, it maps the human readable names of ships to their internal URIs
-    public static Map<String, String> playerSpawnConfigIdMap = new HashMap<String, String>();
 
     NewShipScreen(MenuLayout menuLayout, GameOptions gameOptions) {
         loadPlayerSpawnConfigs();
@@ -125,7 +122,6 @@ public class NewShipScreen implements SolUiScreen {
 
             for (JsonValue node : rootNode) {
                 playerSpawnConfigNames.add(node.name);
-                playerSpawnConfigIdMap.put(node.name, node.getString("hull"));
             }
 
             json.dispose();

--- a/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
@@ -121,6 +121,7 @@ public class NewShipScreen implements SolUiScreen {
 
             for (JsonValue node : rootNode) {
                 playerSpawnConfigNames.add(node.name);
+                Assets.playerSpawnConfigIdMap.put(node.name, node.getString("hull"));
             }
 
             json.dispose();

--- a/modules/core/assets/configs/startingStation.json
+++ b/modules/core/assets/configs/startingStation.json
@@ -1,0 +1,10 @@
+{
+    "hull": "core:station",
+    "items": "core:gun core:gun",
+
+    "guard": {
+        "hull": "core:imperialBig",
+        "items": "core:fixedGun core:fixedShotGun core:mediumArmor+core:heavyArmor core:shield+core:bigShield",
+        "density": 3
+    }
+}

--- a/modules/federal/assets/configs/startingStation.json
+++ b/modules/federal/assets/configs/startingStation.json
@@ -1,0 +1,10 @@
+{
+    "hull": "core:station",
+    "items": "core:gun core:gun",
+
+    "guard": {
+        "hull": "core:imperialBig",
+        "items": "core:fixedGun core:fixedShotGun core:mediumArmor+core:heavyArmor core:shield+core:bigShield",
+        "density": 3
+    }
+}

--- a/modules/organic/assets/configs/startingStation.json
+++ b/modules/organic/assets/configs/startingStation.json
@@ -1,0 +1,10 @@
+{
+    "hull": "core:station",
+    "items": "core:gun core:gun",
+
+    "guard": {
+        "hull": "core:imperialBig",
+        "items": "core:fixedGun core:fixedShotGun core:mediumArmor+core:heavyArmor core:shield+core:bigShield",
+        "density": 3
+    }
+}

--- a/modules/organic/assets/configs/startingStation.json
+++ b/modules/organic/assets/configs/startingStation.json
@@ -1,5 +1,5 @@
 {
-    "hull": "core:station",
+    "hull": "core:organicStation",
     "items": "core:gun core:gun",
 
     "guard": {

--- a/modules/organic/assets/configs/startingStation.json
+++ b/modules/organic/assets/configs/startingStation.json
@@ -1,9 +1,9 @@
 {
-    "hull": "core:organicStation",
+    "hull": "organic:organicStation",
     "items": "core:gun core:gun",
 
     "guard": {
-        "hull": "core:imperialBig",
+        "hull": "organic:organicBig",
         "items": "core:fixedGun core:fixedShotGun core:mediumArmor+core:heavyArmor core:shield+core:bigShield",
         "density": 3
     }


### PR DESCRIPTION
# Description
This PR allows each module to set the space station to use when a ship from said module spawns into the game. This is achieved by deleting the `mainStationConfig.json` file and adding a `startingStation.json` file as is shown in the commits. There were also minor modifications to the java files that control spawning in the starting station.

# Testing
Testable by launching the game with these modifications.