### PR TITLE
Add .recommenders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ local.properties
 .classpath
 .project
 .metadata
+.recommenders
 **/bin/
 tmp/
 *.tmp


### PR DESCRIPTION
# Description
This PR adds the `.recommenders` directory to `.gitignore`. `.recommenders` is a new directory for code recommendations from the latest eclipse update and as such should be excluded from the repo.