### PR TITLE
Fixes gradle working with eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ Contributors
 * [vampcat](https://github.com/vampcat)
 * [Malanius](https://github.com/Malanius)
 * [AonoZan](https://github.com/AonoZan)
+* [ererbe](https://github.com/ererbe)
+* [SurajDutta](https://github.com/SurajDuta)
+* [jasyohuang](https://github.com/jasyohuang)
+* [Steampunkery](https://github.com/Steampunkery)
+* [Graviton48](https://github.com/Graviton48)
+* [Adrijaned](https://github.com/Adrijaned)
+* [MaxBorsch](https://github.com/MaxBorsch)
+* [sohil123](https://github.com/sohil123)
+* [FieryPheonix909](https://github.com/FieryPheonix909)
+* [digitalripperynr](https://github.com/digitalripperynr)
+* [NicholasBatesNZ](https://github.com/NicholasBatesNZ)
 
 ... and your name here? :-) More coming!
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -59,6 +59,7 @@ eclipse {
         name = appName + "-desktop"
         linkedResource name: 'assets', type: '2', location: 'PARENT-1-PROJECT_LOC/android/assets'
     }
+    // Hack to allow the game to run via eclipse. See #209 for more information.
     classpath {
         file {
             withXml { xml ->

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -59,6 +59,17 @@ eclipse {
         name = appName + "-desktop"
         linkedResource name: 'assets', type: '2', location: 'PARENT-1-PROJECT_LOC/android/assets'
     }
+    classpath {
+        file {
+            withXml { xml ->
+                def node = xml.asNode()
+                node.appendNode('classpathentry', [kind: 'src', path: '/engine' ])
+            }
+            whenMerged {
+                entries.removeAll { it.kind == 'src' && it.path == '/DestinationSol-main' }
+            }
+        }
+    }
 }
 
 task afterEclipseImport(description: "Post processing after project generation", group: "IDE") {

--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -47,6 +47,7 @@ public abstract class Assets {
     /**
      * Initializes the class for loading assets using the given environment.
      * This function -has- to be called upon startup, and whenever the environment is changed.
+     *
      * @param environment The ModuleEnvironment to load assets from.
      */
     public static void initialize(ModuleEnvironment environment) {
@@ -95,6 +96,7 @@ public abstract class Assets {
 
     /**
      * Loads an OggMusic (.ogg) from the current environment. Throws an exception if the asset is not found.
+     *
      * @param path A String specifying the desired asset.
      * @return The loaded OggMusic.
      */
@@ -110,6 +112,7 @@ public abstract class Assets {
 
     /**
      * Loads a BitmapFont (.font) from the current environment. Throws an exception if the asset is not found.
+     *
      * @param path A String specifying the desired asset.
      * @return The loaded Font.
      */
@@ -125,6 +128,7 @@ public abstract class Assets {
 
     /**
      * Loads an emitter (.emitter) from the current environment. Throws an exception if the asset is not found.
+     *
      * @param path A String specifying the desired asset.
      * @return The loaded Emitter.
      */
@@ -140,6 +144,7 @@ public abstract class Assets {
 
     /**
      * Loads a Json (.json) from the current environment. Throws an exception if the asset is not found.
+     *
      * @param path A String specifying the desired asset.
      * @return The loaded Json.
      */
@@ -155,6 +160,7 @@ public abstract class Assets {
 
     /**
      * Loads a Texture (.png) from the current environment. Throws an exception if the asset is not found.
+     *
      * @param path A String specifying the desired asset.
      * @return The loaded Texture.
      */
@@ -170,6 +176,7 @@ public abstract class Assets {
 
     /**
      * A wrapper function over getDSTexture() that creates an AtlasRegion out of the given Texture, to use in drawing functions.
+     *
      * @param path A String specifying the desired asset.
      * @param textureFilter The texture filtering method for minification and magnification.
      * @return An AtlasRegion representing the loaded Texture.
@@ -186,6 +193,7 @@ public abstract class Assets {
     /**
      * A wrapper function over getDSTexture() that creates an AtlasRegion out of the given Texture, to use in drawing functions.
      * This overloaded variant of the function defaults to the Nearest texture filtering method, which is the default for DestSol.
+     *
      * @param path A String specifying the desired asset.
      * @return An AtlasRegion representing the loaded Texture.
      */

--- a/modules/caution/assets/configs/projectilesConfig.json
+++ b/modules/caution/assets/configs/projectilesConfig.json
@@ -4,7 +4,7 @@
         "dmgType": "energy",
         "spdLen": 6,
 
-        "tex": "rbc",
+        "tex": "caution:rbc",
         "texSz": 0.15,
 
         "collisionEffect": {

--- a/modules/syndicate/assets/configs/projectilesConfig.json
+++ b/modules/syndicate/assets/configs/projectilesConfig.json
@@ -3,7 +3,7 @@
     "dmg": 500,
     "spdLen": 2,
     "dmgType": "explosion",
-    "tex": "bazook",
+    "tex": "syndicate:bazook",
     "texSz": 0.018,
     "stretch": true,
     "collisionEffect": {


### PR DESCRIPTION
# Description
This PR fixes setting up a workspace using gradle with eclipse. Important changes:

1. Adding `engine` to the classpath
2. Removing `DestinationSol-main` from the classpath

# Testing
Clone [the DestinationSol repo](https://github.com/MovingBlocks/DestinationSol) and run `./gradlew eclipse`. Then open the workspace in eclipse and see that there are no errors upon loading the project. Trying to launch the game will, however result in a crash because the resources path is messed up. This will be addressed in my next PR.

# Notes
There is a more elegant way to remove `DestinationSol-main` from the classpath. If anyone knows where it gets added to the classpath, let me know. I simply used a hook to remove it after the fact.