### PR TITLE
Added Module Dependency Retrieval to Groovyw Script

### DIFF
--- a/module.groovy
+++ b/module.groovy
@@ -14,7 +14,7 @@ new File("gradle.properties").withInputStream {
 println "Properties: " + properties
 
 // Groovy Elvis operator woo! Defaults to "DestinationSol" if an override isn't set
-githubHome = properties.alternativeGithubHome ?: "digitalripperynr"
+githubHome = properties.alternativeGithubHome ?: "DestinationSol"
 
 //println "githubHome is: $githubHome"
 


### PR DESCRIPTION
This PR adds a dependency retrieval feature to Groovyw module script.
The dependencies are defined in module.json of each module.
The dependencies should include "core" but it is not necessary because it would be skipped anyway.