### PR TITLE
custom engine speeds and accelerations and relevant json changes

### DIFF
--- a/engine/src/main/java/org/destinationsol/common/SolMath.java
+++ b/engine/src/main/java/org/destinationsol/common/SolMath.java
@@ -487,9 +487,13 @@ public class SolMath {
         }
         return res;
     }
+    
+    public static boolean canAccelerateCustom(float accAngle, Vector2 spd, float maxSpeedModifier) {
+        return spd.len() < Const.MAX_MOVE_SPD * maxSpeedModifier || angleDiff(angle(spd), accAngle) > 90;
+    }
 
     public static boolean canAccelerate(float accAngle, Vector2 spd) {
-        return spd.len() < Const.MAX_MOVE_SPD || angleDiff(angle(spd), accAngle) > 90;
+        return canAccelerateCustom(accAngle, spd, 1.0f);
     }
 
     public static String nice(float v) {

--- a/engine/src/main/java/org/destinationsol/game/item/Engine.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Engine.java
@@ -59,6 +59,10 @@ public class Engine implements SolItem {
     public float getAcc() {
         return myConfig.acc;
     }
+    
+    public float getTopSpeedMultiplier() {
+        return myConfig.topSpeedMultiplier;
+    }
 
     public float getMaxRotSpd() {
         return myConfig.maxRotSpd;
@@ -117,6 +121,7 @@ public class Engine implements SolItem {
         public final String desc;
         public final float rotAcc;
         public final float acc;
+        public final float topSpeedMultiplier;
         public final float maxRotSpd;
         public final boolean big;
         public final Engine example;
@@ -125,13 +130,14 @@ public class Engine implements SolItem {
         public final EffectConfig effectConfig;
         public final String code;
 
-        private Config(String displayName, int price, String desc, float rotAcc, float acc, float maxRotSpd, boolean big,
+        private Config(String displayName, int price, String desc, float rotAcc, float acc, float topSpeedMultiplier, float maxRotSpd, boolean big,
                        PlayableSound workSound, TextureAtlas.AtlasRegion icon, EffectConfig effectConfig, String code) {
             this.displayName = displayName;
             this.price = price;
             this.desc = desc;
             this.rotAcc = rotAcc;
             this.acc = acc;
+            this.topSpeedMultiplier = topSpeedMultiplier;
             this.maxRotSpd = maxRotSpd;
             this.big = big;
             this.workSound = workSound;
@@ -147,7 +153,8 @@ public class Engine implements SolItem {
 
             boolean big = rootNode.getBoolean("big");
             float rotAcc = big ? 100f : 515f;
-            float acc = 2f;
+            float acc = 2f * rootNode.getFloat("acceleration");
+            float topSpeedMultiplier = rootNode.getFloat("topSpeedMultiplier");
             float maxRotSpd = big ? 40f : 230f;
             List<String> workSoundUrns = Arrays.asList(rootNode.get("workSounds").asStringArray());
             OggSoundSet workSoundSet = new OggSoundSet(soundManager, workSoundUrns);
@@ -157,7 +164,7 @@ public class Engine implements SolItem {
 
             // TODO: VAMPCAT: The icon / displayName was initially set to null. Is that correct?
 
-            return new Config(null, 0, null, rotAcc, acc, maxRotSpd, big, workSoundSet, null, effectConfig, engineName);
+            return new Config(null, 0, null, rotAcc, acc, topSpeedMultiplier, maxRotSpd, big, workSoundSet, null, effectConfig, engineName);
         }
     }
 }

--- a/modules/core/assets/items/engines/desertBigEngine/desertBigEngine.json
+++ b/modules/core/assets/items/engines/desertBigEngine/desertBigEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": true,
     "effect": {
         "effectFile": "core:flame",
@@ -6,6 +7,7 @@
         "tex": "core:smoke",
         "tint": "fire"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:medEngineWork0",
         "core:medEngineWork1",

--- a/modules/core/assets/items/engines/desertEngine/desertEngine.json
+++ b/modules/core/assets/items/engines/desertEngine/desertEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": false,
     "effect": {
         "effectFile": "core:flame",
@@ -6,6 +7,7 @@
         "tex": "core:smoke",
         "tint": "fire"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:medEngineWork0",
         "core:medEngineWork1",

--- a/modules/core/assets/items/engines/imperialBigEngine/imperialBigEngine.json
+++ b/modules/core/assets/items/engines/imperialBigEngine/imperialBigEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": true,
     "effect": {
         "effectFile": "core:flame",
@@ -6,6 +7,7 @@
         "tex": "core:fire",
         "tint": "hsb 140 20 65"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:medEngineWork0",
         "core:medEngineWork1",

--- a/modules/core/assets/items/engines/imperialEngine/imperialEngine.json
+++ b/modules/core/assets/items/engines/imperialEngine/imperialEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": false,
     "effect": {
         "effectFile": "core:flame",
@@ -6,6 +7,7 @@
         "tex": "core:fire",
         "tint": "hsb 140 20 65"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:medEngineWork0",
         "core:medEngineWork1",

--- a/modules/core/assets/items/engines/minerEngine/minerEngine.json
+++ b/modules/core/assets/items/engines/minerEngine/minerEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": false,
     "effect": {
         "effectFile": "core:smokeEngine",
@@ -6,6 +7,7 @@
         "tex": "core:smoke",
         "tint": "smoke"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:diesel",
         "core:diesel2",

--- a/modules/core/assets/items/engines/pirateBigEngine/pirateBigEngine.json
+++ b/modules/core/assets/items/engines/pirateBigEngine/pirateBigEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": true,
     "effect": {
         "effectFile": "core:flame",
@@ -6,6 +7,7 @@
         "tex": "core:fire",
         "tint": "hsb 8 75 100"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:medEngineWork0",
         "core:medEngineWork1",

--- a/modules/core/assets/items/engines/pirateEngine/pirateEngine.json
+++ b/modules/core/assets/items/engines/pirateEngine/pirateEngine.json
@@ -1,4 +1,5 @@
 {
+    "acceleration": 1,
     "big": false,
     "effect": {
         "effectFile": "core:flame",
@@ -6,6 +7,7 @@
         "tex": "core:fire",
         "tint": "hsb 8 75 100"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:medEngineWork0",
         "core:medEngineWork1",

--- a/modules/core/assets/items/engines/techieEngine/techieEngine.json
+++ b/modules/core/assets/items/engines/techieEngine/techieEngine.json
@@ -1,10 +1,12 @@
 {
+    "acceleration": 1,
     "big": false,
     "effect": {
         "effectFile": "core:techieEngine",
         "tex": "core:techieTrail",
         "tint": "white"
     },
+    "topSpeedMultiplier": 1,
     "workSounds": [
         "core:techie",
         "core:techie2",


### PR DESCRIPTION
# Description
This PR allows creators of engines to specify a top speed for their engine and a custom acceleration. This means that engines can have varying speeds for different prices. `topSpeedMultiplier` and `acceleration` are not values dictating the top speed and acceleration of the engine, but rather multipliers. So, an acceleration of 2 and a topSpeedMultiplier of 1 means that the ship accelerates to the normal top speed twice as fast while an acceleration of 1 and a topSpeedMultiplier of 2 means the ship accelerates like normal but reaches a speed of twice as fast as normal.