### PR TITLE
Fixed light not turning off on certain particle emitters

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/gun/SolGun.java
+++ b/engine/src/main/java/org/destinationsol/game/gun/SolGun.java
@@ -134,7 +134,7 @@ public class SolGun {
         }
 
         boolean shot = shouldShoot && myCoolDown <= 0 && myItem.ammo > 0;
-        game.getPartMan().toggleAllHullEmittersOfType(hull, "shoot", shot);
+        game.getPartMan().updateAllHullEmittersOfType(hull, "shoot", shot);
         if (shot) {
             Vector2 gunSpd = creator.getSpd();
             shoot(gunSpd, game, gunAngle, muzzlePos, faction, creator,  hull);

--- a/engine/src/main/java/org/destinationsol/game/gun/SolGun.java
+++ b/engine/src/main/java/org/destinationsol/game/gun/SolGun.java
@@ -101,7 +101,6 @@ public class SolGun {
         myCoolDown += myItem.config.timeBetweenShots;
         myItem.ammo--;
         game.getSoundManager().play(game, myItem.config.shootSound, muzzlePos, creator);
-        game.getPartMan().fireAllHullEmittersOfType(hull, "shoot");
     }
 
     public void update(ItemContainer ic, SolGame game, float gunAngle, SolObject creator, boolean shouldShoot, Faction faction, Hull hull) {
@@ -135,6 +134,7 @@ public class SolGun {
         }
 
         boolean shot = shouldShoot && myCoolDown <= 0 && myItem.ammo > 0;
+        game.getPartMan().toggleAllHullEmittersOfType(hull, "shoot", shot);
         if (shot) {
             Vector2 gunSpd = creator.getSpd();
             shoot(gunSpd, game, gunAngle, muzzlePos, faction, creator,  hull);

--- a/engine/src/main/java/org/destinationsol/game/particle/DSParticleEmitter.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/DSParticleEmitter.java
@@ -218,6 +218,8 @@ public class DSParticleEmitter {
     }
 
     public void setWorking(boolean working) {
+        light.update(working, relativeAngle, game);
+
         if (!isContinuous()) {
             throw new AssertionError("only continuous emitters can start working");
         }
@@ -231,10 +233,6 @@ public class DSParticleEmitter {
         } else {
             particleEmitter.allowCompletion();
         }
-    }
-
-    public void setLightWorking(boolean working) {
-        light.update(working, relativeAngle, game);
     }
 
     private void setSpeed(Vector2 speed) {

--- a/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
@@ -92,13 +92,13 @@ public class PartMan {
     }
 
     /**
-     * This method turns all of the particle emitters on a Hull with the specified trigger on or off
+     * This method updates all of the particle emitters on a Hull with the specified trigger
      *
      * @param hull Hull containing the particle emitters
      * @param triggerType trigger type of the particle emitters
      * @param on boolean where true turns the particle emitters on and false turns it off
      */
-    public void toggleAllHullEmittersOfType(Hull hull, String triggerType, boolean on) {
+    public void updateAllHullEmittersOfType(Hull hull, String triggerType, boolean on) {
         for (DSParticleEmitter particleEmitter : hull.getParticleEmitters()) {
             if (triggerType.equals(particleEmitter.getTrigger())) {
                 particleEmitter.setWorking(on);

--- a/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
@@ -91,17 +91,18 @@ public class PartMan {
         return s;
     }
 
+    /**
+     * This method turns all of the particle emitters on a Hull with the specified trigger on or off
+     *
+     * @param hull Hull containing the particle emitters
+     * @param triggerType trigger type of the particle emitters
+     * @param on boolean where true turns the particle emitters on and false turns it off
+     */
     public void toggleAllHullEmittersOfType(Hull hull, String triggerType, boolean on) {
         for (DSParticleEmitter particleEmitter : hull.getParticleEmitters()) {
             if (triggerType.equals(particleEmitter.getTrigger())) {
                 particleEmitter.setWorking(on);
-                particleEmitter.setLightWorking(on);
             }
         }
-    }
-
-    public void fireAllHullEmittersOfType(Hull hull, String triggerType) {
-        toggleAllHullEmittersOfType(hull, triggerType, true);
-        toggleAllHullEmittersOfType(hull, triggerType, false);
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
@@ -41,7 +41,7 @@ public class ShipEngine {
                        boolean controlsEnabled, float mass, Hull hull) {
 
         boolean working = applyInput(game, angle, provider, body, spd, controlsEnabled, mass);
-        game.getPartMan().toggleAllHullEmittersOfType(hull, "engine", working);
+        game.getPartMan().updateAllHullEmittersOfType(hull, "engine", working);
         if (working) {
             game.getSoundManager().play(game, myItem.getWorkSound(), owner.getPosition(), owner);
         }

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -57,6 +57,7 @@ public class SolShip implements SolObject {
     public static final float MAX_FIRE_AWAIT = 1f;
     private static final int TRADE_AFTER = 3;
     private static final float ENERGY_DMG_FACTOR = .7f;
+    private boolean colliding;
 
     private final Pilot myPilot;
     private final ItemContainer myItemContainer;
@@ -82,6 +83,7 @@ public class SolShip implements SolObject {
     public SolShip(SolGame game, Pilot pilot, Hull hull, RemoveController removeController, List<Drawable> drawables,
                    ItemContainer container, ShipRepairer repairer, float money, TradeContainer tradeContainer, Shield shield,
                    Armor armor) {
+        colliding = false;
         myRemoveController = removeController;
         myDrawables = drawables;
         myPilot = pilot;
@@ -126,6 +128,7 @@ public class SolShip implements SolObject {
     @Override
     public void handleContact(SolObject other, ContactImpulse impulse, boolean isA, float absImpulse,
                               SolGame game, Vector2 collPos) {
+        colliding = true;
         if (tryCollectLoot(other, game)) {
             ((Loot) other).pickedUp(game, this);
             return;
@@ -138,7 +141,6 @@ public class SolShip implements SolObject {
             }
             receiveDmg((int) dmg, game, collPos, DmgType.CRASH);
         }
-        game.getPartMan().fireAllHullEmittersOfType(myHull, "collision");
     }
 
     @Override
@@ -223,6 +225,7 @@ public class SolShip implements SolObject {
         SolShip nearestEnemy = game.getFactionMan().getNearestEnemy(game, this);
         myPilot.update(game, this, nearestEnemy);
         myHull.update(game, myItemContainer, myPilot, this, nearestEnemy);
+        game.getPartMan().toggleAllHullEmittersOfType(myHull, "collision", colliding);
 
         updateAbility(game);
         updateIdleTime(game);
@@ -260,6 +263,8 @@ public class SolShip implements SolObject {
         if (myAbility instanceof Teleport) {
             ((Teleport) myAbility).maybeTeleport(game, this);
         }
+
+        colliding = false;
     }
 
     private void updateAbility(SolGame game) {

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -225,7 +225,7 @@ public class SolShip implements SolObject {
         SolShip nearestEnemy = game.getFactionMan().getNearestEnemy(game, this);
         myPilot.update(game, this, nearestEnemy);
         myHull.update(game, myItemContainer, myPilot, this, nearestEnemy);
-        game.getPartMan().toggleAllHullEmittersOfType(myHull, "collision", colliding);
+        game.getPartMan().updateAllHullEmittersOfType(myHull, "collision", colliding);
 
         updateAbility(game);
         updateIdleTime(game);

--- a/engine/src/main/java/org/destinationsol/game/ship/hulls/Hull.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/hulls/Hull.java
@@ -141,7 +141,7 @@ public class Hull {
             myBody.setAngularVelocity(angleDiff * SolMath.degRad * fps);
         }
 
-        game.getPartMan().toggleAllHullEmittersOfType(this, "none", true);
+        game.getPartMan().updateAllHullEmittersOfType(this, "none", true);
     }
 
     private void setParamsFromBody() {


### PR DESCRIPTION
Removed the misbehaving `fireAllHullEmittersOfType(hull, "yourTrigger");` method which often failed to turn off the lightSrc on a particle emitter. Now you simply use the same `updateAllHullEmittersOfType(hull, "yourTrigger", true/false)` within an update loop for every trigger.

The following should be changed in the [wiki](https://github.com/MovingBlocks/DestinationSol/wiki/Particle-Emitters#triggers) when this PR is merged:
- [ ] Remove `game.getPartMan().fireAllHullEmittersOfType(hull, "yourTrigger");`
- [ ] Change `toggleAllEmittersOfType(...)` to `updateAllEmittersOfType(...)`.
- [ ] Clarify that it needs to be be called each frame (`update()`)
