### PR TITLE
Move sounds from Engine to Particle Emitters

### DIFF
--- a/engine/src/main/java/org/destinationsol/files/HullConfigManager.java
+++ b/engine/src/main/java/org/destinationsol/files/HullConfigManager.java
@@ -21,12 +21,9 @@ import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.json.Json;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.AbilityCommonConfigs;
-import org.destinationsol.game.GameColors;
 import org.destinationsol.game.item.Engine;
 import org.destinationsol.game.item.ItemManager;
 import org.destinationsol.game.particle.DSParticleEmitter;
-import org.destinationsol.game.particle.EffectConfig;
-import org.destinationsol.game.particle.EffectTypes;
 import org.destinationsol.game.ship.AbilityConfig;
 import org.destinationsol.game.ship.EmWave;
 import org.destinationsol.game.ship.KnockBack;
@@ -36,7 +33,9 @@ import org.destinationsol.game.ship.UnShield;
 import org.destinationsol.game.ship.hulls.GunSlot;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public final class HullConfigManager {
@@ -127,20 +126,20 @@ public final class HullConfigManager {
         }
     }
 
-    private void parseParticleEmitterSlots(JsonValue containerNode, HullConfig.Data configData) {
+    private void parseParticleEmitters(JsonValue containerNode, HullConfig.Data configData) {
         Vector2 builderOrigin = new Vector2(configData.shipBuilderOrigin);
 
-        for (JsonValue particleEmitterSlotNode : containerNode) {
-            Vector2 position = readVector2(particleEmitterSlotNode, "position", null);
+        for (JsonValue particleEmitterNode : containerNode) {
+            Vector2 position = readVector2(particleEmitterNode, "position", null);
             position.sub(builderOrigin).scl(configData.size);
 
-            String trigger = particleEmitterSlotNode.getString("trigger", null);
-            float angleOffset = particleEmitterSlotNode.getFloat("angleOffset", 0f);
-            boolean hasLight = particleEmitterSlotNode.getBoolean("hasLight", false);
-            JsonValue particleNode = particleEmitterSlotNode.get("particle");
-            EffectConfig effectConfig = EffectConfig.load(particleNode, new EffectTypes(), new GameColors());
+            String trigger = particleEmitterNode.getString("trigger", null);
+            float angleOffset = particleEmitterNode.getFloat("angleOffset", 0f);
+            boolean hasLight = particleEmitterNode.getBoolean("hasLight", false);
+            JsonValue particleNode = particleEmitterNode.get("particle");
+            List<String> workSounds = Arrays.asList(particleEmitterNode.get("workSounds").asStringArray());
 
-            configData.particleEmitters.add(new DSParticleEmitter(position, trigger, angleOffset, hasLight, effectConfig));
+            configData.particleEmitters.add(new DSParticleEmitter(position, trigger, angleOffset, hasLight, particleNode, workSounds));
         }
     }
 
@@ -170,7 +169,7 @@ public final class HullConfigManager {
 
         parseGunSlotList(rootNode.get("gunSlots"), configData);
         if (rootNode.has("particleEmitters")) {
-            parseParticleEmitterSlots(rootNode.get("particleEmitters"), configData);
+            parseParticleEmitters(rootNode.get("particleEmitters"), configData);
         }
     }
 

--- a/engine/src/main/java/org/destinationsol/files/HullConfigManager.java
+++ b/engine/src/main/java/org/destinationsol/files/HullConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.destinationsol.game.ship.hulls.GunSlot;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +138,11 @@ public final class HullConfigManager {
             float angleOffset = particleEmitterNode.getFloat("angleOffset", 0f);
             boolean hasLight = particleEmitterNode.getBoolean("hasLight", false);
             JsonValue particleNode = particleEmitterNode.get("particle");
-            List<String> workSounds = Arrays.asList(particleEmitterNode.get("workSounds").asStringArray());
+
+            List<String> workSounds = new ArrayList<>();
+            if (particleEmitterNode.hasChild("workSounds")) {
+                workSounds = Arrays.asList(particleEmitterNode.get("workSounds").asStringArray());
+            }
 
             configData.particleEmitters.add(new DSParticleEmitter(position, trigger, angleOffset, hasLight, particleNode, workSounds));
         }

--- a/engine/src/main/java/org/destinationsol/game/item/Engine.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Engine.java
@@ -18,17 +18,8 @@ package org.destinationsol.game.item;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.utils.JsonValue;
 import org.destinationsol.assets.Assets;
-import org.destinationsol.assets.audio.PlayableSound;
 import org.destinationsol.assets.json.Json;
-import org.destinationsol.game.GameColors;
 import org.destinationsol.game.SolGame;
-import org.destinationsol.game.particle.EffectConfig;
-import org.destinationsol.game.particle.EffectTypes;
-import org.destinationsol.game.sound.OggSoundManager;
-import org.destinationsol.game.sound.OggSoundSet;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class Engine implements SolItem {
     private final Config config;
@@ -103,14 +94,6 @@ public class Engine implements SolItem {
 
     }
 
-    public PlayableSound getWorkSound() {
-        return config.workSound;
-    }
-
-    public EffectConfig getEffectConfig() {
-        return config.effectConfig;
-    }
-
     public static class Config {
         public final String displayName;
         public final int price;
@@ -120,13 +103,11 @@ public class Engine implements SolItem {
         public final float maxRotationSpeed;
         public final boolean isBig;
         public final Engine exampleEngine;
-        public final PlayableSound workSound;
         public final TextureAtlas.AtlasRegion icon;
-        public final EffectConfig effectConfig;
         public final String code;
 
         private Config(String displayName, int price, String description, float rotationAcceleration, float acceleration, float maxRotationSpeed, boolean isBig,
-                       PlayableSound workSound, TextureAtlas.AtlasRegion icon, EffectConfig effectConfig, String code) {
+                       TextureAtlas.AtlasRegion icon, String code) {
             this.displayName = displayName;
             this.price = price;
             this.description = description;
@@ -134,14 +115,12 @@ public class Engine implements SolItem {
             this.acceleration = acceleration;
             this.maxRotationSpeed = maxRotationSpeed;
             this.isBig = isBig;
-            this.workSound = workSound;
             this.icon = icon;
-            this.effectConfig = effectConfig;
             this.code = code;
             this.exampleEngine = new Engine(this);
         }
 
-        public static Config load(String engineName, OggSoundManager soundManager, EffectTypes effectTypes, GameColors cols) {
+        public static Config load(String engineName) {
             Json json = Assets.getJson(engineName);
             JsonValue rootNode = json.getJsonValue();
 
@@ -149,15 +128,12 @@ public class Engine implements SolItem {
             float rotationAcceleration = isBig ? 100f : 515f;
             float acceleration = 2f;
             float maxRotationSpeed = isBig ? 40f : 230f;
-            List<String> workSoundUrns = Arrays.asList(rootNode.get("workSounds").asStringArray());
-            OggSoundSet workSoundSet = new OggSoundSet(soundManager, workSoundUrns);
-            EffectConfig effectConfig = EffectConfig.load(rootNode.get("effect"), effectTypes, cols);
 
             json.dispose();
 
             // TODO: VAMPCAT: The icon / displayName was initially set to null. Is that correct?
 
-            return new Config(null, 0, null, rotationAcceleration, acceleration, maxRotationSpeed, isBig, workSoundSet, null, effectConfig, engineName);
+            return new Config(null, 0, null, rotationAcceleration, acceleration, maxRotationSpeed, isBig, null, engineName);
         }
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/item/ItemManager.java
+++ b/engine/src/main/java/org/destinationsol/game/item/ItemManager.java
@@ -174,7 +174,7 @@ public class ItemManager {
     }
 
     public Engine.Config getEngineConfig(String engineName) {
-        return engineConfigs.computeIfAbsent(engineName, engineConfig -> Engine.Config.load(engineConfig, soundManager, effectTypes, gameColors));
+        return engineConfigs.computeIfAbsent(engineName, engineConfig -> Engine.Config.load(engineConfig));
     }
 
     public SolItem random() {

--- a/engine/src/main/java/org/destinationsol/game/particle/DSParticleEmitter.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/DSParticleEmitter.java
@@ -91,7 +91,12 @@ public class DSParticleEmitter {
         this.trigger = particleEmitter.getTrigger();
         this.position = particleEmitter.getPosition();
         this.config = particleEmitter.getEffectConfig();
-        this.workSoundSet = new OggSoundSet(game.getSoundManager(), particleEmitter.getWorkSounds());
+        if (!particleEmitter.getWorkSounds().isEmpty()) {
+            this.workSoundSet = new OggSoundSet(game.getSoundManager(), particleEmitter.getWorkSounds());
+        }
+        else {
+            this.workSoundSet = null;
+        }
         Vector2 shipPos = ship.getPosition();
         Vector2 shipSpeed = ship.getSpeed();
 

--- a/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
@@ -20,7 +20,6 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.SolGame;
-import org.destinationsol.game.SolObject;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.item.Engine;
 import org.destinationsol.game.ship.hulls.Hull;
@@ -37,13 +36,11 @@ public class ShipEngine {
         myItem = engine;
     }
 
-    public void update(float angle, SolGame game, Pilot provider, Body body, Vector2 speed, SolObject owner,
-                       boolean controlsEnabled, float mass, Hull hull) {
+    public void update(float angle, SolGame game, Pilot provider, Body body, Vector2 speed, boolean controlsEnabled,
+                       float mass, Hull hull) {
+
         boolean working = applyInput(game, angle, provider, body, speed, controlsEnabled, mass);
         game.getPartMan().updateAllHullEmittersOfType(hull, "engine", working);
-        if (working) {
-            game.getSoundManager().play(game, myItem.getWorkSound(), owner.getPosition(), owner);
-        }
     }
 
     private boolean applyInput(SolGame cmp, float shipAngle, Pilot provider, Body body, Vector2 speed,

--- a/engine/src/main/java/org/destinationsol/game/ship/hulls/Hull.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/hulls/Hull.java
@@ -110,7 +110,7 @@ public class Hull {
         boolean controlsEnabled = ship.isControlsEnabled() && !SolCam.DIRECT_CAM_CONTROL;
 
         if (engine != null) {
-            engine.update(angle, game, provider, body, speed, ship, controlsEnabled, mass, this);
+            engine.update(angle, game, provider, body, speed, controlsEnabled, mass, this);
         }
 
         Faction faction = ship.getPilot().getFaction();

--- a/modules/core/assets/items/engines/desertBigEngine/desertBigEngine.json
+++ b/modules/core/assets/items/engines/desertBigEngine/desertBigEngine.json
@@ -1,10 +1,3 @@
 {
-    "big": true,
-    "workSounds": [
-        "core:medEngineWork0",
-        "core:medEngineWork1",
-        "core:medEngineWork2",
-        "core:medEngineWork3",
-        "core:medEngineWork4"
-    ]
+    "big": true
 }

--- a/modules/core/assets/items/engines/desertEngine/desertEngine.json
+++ b/modules/core/assets/items/engines/desertEngine/desertEngine.json
@@ -1,10 +1,3 @@
 {
-    "big": false,
-    "workSounds": [
-        "core:medEngineWork0",
-        "core:medEngineWork1",
-        "core:medEngineWork2",
-        "core:medEngineWork3",
-        "core:medEngineWork4"
-    ]
+    "big": false
 }

--- a/modules/core/assets/items/engines/imperialBigEngine/imperialBigEngine.json
+++ b/modules/core/assets/items/engines/imperialBigEngine/imperialBigEngine.json
@@ -1,10 +1,3 @@
 {
-    "big": true,
-    "workSounds": [
-        "core:medEngineWork0",
-        "core:medEngineWork1",
-        "core:medEngineWork2",
-        "core:medEngineWork3",
-        "core:medEngineWork4"
-    ]
+    "big": true
 }

--- a/modules/core/assets/items/engines/imperialEngine/imperialEngine.json
+++ b/modules/core/assets/items/engines/imperialEngine/imperialEngine.json
@@ -1,10 +1,3 @@
 {
-    "big": false,
-    "workSounds": [
-        "core:medEngineWork0",
-        "core:medEngineWork1",
-        "core:medEngineWork2",
-        "core:medEngineWork3",
-        "core:medEngineWork4"
-    ]
+    "big": false
 }

--- a/modules/core/assets/items/engines/minerEngine/minerEngine.json
+++ b/modules/core/assets/items/engines/minerEngine/minerEngine.json
@@ -1,8 +1,3 @@
 {
-    "big": false,
-    "workSounds": [
-        "core:diesel",
-        "core:diesel2",
-        "core:diesel3"
-    ]
+    "big": false
 }

--- a/modules/core/assets/items/engines/pirateBigEngine/pirateBigEngine.json
+++ b/modules/core/assets/items/engines/pirateBigEngine/pirateBigEngine.json
@@ -1,10 +1,3 @@
 {
-    "big": true,
-    "workSounds": [
-        "core:medEngineWork0",
-        "core:medEngineWork1",
-        "core:medEngineWork2",
-        "core:medEngineWork3",
-        "core:medEngineWork4"
-    ]
+    "big": true
 }

--- a/modules/core/assets/items/engines/pirateEngine/pirateEngine.json
+++ b/modules/core/assets/items/engines/pirateEngine/pirateEngine.json
@@ -1,10 +1,3 @@
 {
-    "big": false,
-    "workSounds": [
-        "core:medEngineWork0",
-        "core:medEngineWork1",
-        "core:medEngineWork2",
-        "core:medEngineWork3",
-        "core:medEngineWork4"
-    ]
+    "big": false
 }

--- a/modules/core/assets/items/engines/techieEngine/techieEngine.json
+++ b/modules/core/assets/items/engines/techieEngine/techieEngine.json
@@ -1,8 +1,3 @@
 {
-    "big": false,
-    "workSounds": [
-        "core:techie",
-        "core:techie2",
-        "core:techie3"
-    ]
+    "big": false
 }

--- a/modules/core/assets/ships/bus/bus.json
+++ b/modules/core/assets/ships/bus/bus.json
@@ -250,7 +250,14 @@
                 "size": 0.3,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.09 0.62",
@@ -261,7 +268,14 @@
                 "size": 0.3,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/desertBoss/desertBoss.json
+++ b/modules/core/assets/ships/desertBoss/desertBoss.json
@@ -134,7 +134,14 @@
                 "size": 0.3,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0 0.75",
@@ -145,7 +152,14 @@
                 "size": 0.3,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/desertMedium/desertMedium.json
+++ b/modules/core/assets/ships/desertMedium/desertMedium.json
@@ -140,7 +140,14 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.02 0.69",
@@ -151,7 +158,14 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/desertOrbiter/desertOrbiter.json
+++ b/modules/core/assets/ships/desertOrbiter/desertOrbiter.json
@@ -78,7 +78,14 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0 0.67",
@@ -89,7 +96,14 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/desertSmall/desertSmall.json
+++ b/modules/core/assets/ships/desertSmall/desertSmall.json
@@ -101,7 +101,14 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.02 0.54",
@@ -112,7 +119,14 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "fire"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/imperialBig/imperialBig.json
+++ b/modules/core/assets/ships/imperialBig/imperialBig.json
@@ -105,7 +105,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.11 0.57",
@@ -116,7 +123,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/imperialCapital/imperialCapital.json
+++ b/modules/core/assets/ships/imperialCapital/imperialCapital.json
@@ -443,7 +443,14 @@
                 "size": 0.3,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.08 0.63",
@@ -454,7 +461,14 @@
                 "size": 0.3,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/imperialMedium/imperialMedium.json
+++ b/modules/core/assets/ships/imperialMedium/imperialMedium.json
@@ -105,7 +105,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.15 0.62",
@@ -116,7 +123,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/imperialSmall/imperialSmall.json
+++ b/modules/core/assets/ships/imperialSmall/imperialSmall.json
@@ -85,7 +85,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.14 0.57",
@@ -96,7 +103,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/imperialTiny/imperialTiny.json
+++ b/modules/core/assets/ships/imperialTiny/imperialTiny.json
@@ -85,7 +85,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.15 0.50",
@@ -96,7 +103,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 140 20 65"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/minerBoss/minerBoss.json
+++ b/modules/core/assets/ships/minerBoss/minerBoss.json
@@ -80,7 +80,12 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "smoke"
-            }
+            },
+            "workSounds": [
+                "core:diesel",
+                "core:diesel2",
+                "core:diesel3"
+            ]
         },
         {
             "position": "0.18 0.7",
@@ -91,7 +96,12 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "smoke"
-            }
+            },
+            "workSounds": [
+                "core:diesel",
+                "core:diesel2",
+                "core:diesel3"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/minerMedium/minerMedium.json
+++ b/modules/core/assets/ships/minerMedium/minerMedium.json
@@ -94,7 +94,12 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "smoke"
-            }
+            },
+            "workSounds": [
+                "core:diesel",
+                "core:diesel2",
+                "core:diesel3"
+            ]
         },
         {
             "position": "0.2 0.72",
@@ -105,7 +110,12 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "smoke"
-            }
+            },
+            "workSounds": [
+                "core:diesel",
+                "core:diesel2",
+                "core:diesel3"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/minerSmall/minerSmall.json
+++ b/modules/core/assets/ships/minerSmall/minerSmall.json
@@ -106,7 +106,12 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "smoke"
-            }
+            },
+            "workSounds": [
+                "core:diesel",
+                "core:diesel2",
+                "core:diesel3"
+            ]
         },
         {
             "position": "0.1 0.8",
@@ -117,7 +122,12 @@
                 "size": 0.07,
                 "tex": "core:smoke",
                 "tint": "smoke"
-            }
+            },
+            "workSounds": [
+                "core:diesel",
+                "core:diesel2",
+                "core:diesel3"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/pirateMedium/pirateMedium.json
+++ b/modules/core/assets/ships/pirateMedium/pirateMedium.json
@@ -176,7 +176,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.04 0.59",
@@ -187,7 +194,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/pirateOrbiter/pirateOrbiter.json
+++ b/modules/core/assets/ships/pirateOrbiter/pirateOrbiter.json
@@ -174,7 +174,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.35 0.61",
@@ -185,7 +192,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/pirateSmall/pirateSmall.json
+++ b/modules/core/assets/ships/pirateSmall/pirateSmall.json
@@ -133,7 +133,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.01 0.5",
@@ -144,7 +151,14 @@
                 "size": 0.07,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/techieOrbiter/techieOrbiter.json
+++ b/modules/core/assets/ships/techieOrbiter/techieOrbiter.json
@@ -115,7 +115,12 @@
                 "effectFile": "core:techieEngine",
                 "tex": "core:techieTrail",
                 "tint": "white"
-            }
+            },
+            "workSounds": [
+                "core:techie",
+                "core:techie2",
+                "core:techie3"
+            ]
         },
         {
             "position": "0.16 0.62",
@@ -125,7 +130,12 @@
                 "effectFile": "core:techieEngine",
                 "tex": "core:techieTrail",
                 "tint": "white"
-            }
+            },
+            "workSounds": [
+                "core:techie",
+                "core:techie2",
+                "core:techie3"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/techieSmall/techieSmall.json
+++ b/modules/core/assets/ships/techieSmall/techieSmall.json
@@ -131,7 +131,12 @@
                 "effectFile": "core:techieEngine",
                 "tex": "core:techieTrail",
                 "tint": "white"
-            }
+            },
+            "workSounds": [
+                "core:techie",
+                "core:techie2",
+                "core:techie3"
+            ]
         },
         {
             "position": "0.1 0.5",
@@ -141,7 +146,12 @@
                 "effectFile": "core:techieEngine",
                 "tex": "core:techieTrail",
                 "tint": "white"
-            }
+            },
+            "workSounds": [
+                "core:techie",
+                "core:techie2",
+                "core:techie3"
+            ]
         }
     ]
 }

--- a/modules/core/assets/ships/truck/truck.json
+++ b/modules/core/assets/ships/truck/truck.json
@@ -97,7 +97,14 @@
                 "size": 0.3,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         },
         {
             "position": "0.06 0.6",
@@ -108,7 +115,14 @@
                 "size": 0.3,
                 "tex": "core:fire",
                 "tint": "hsb 8 75 100"
-            }
+            },
+            "workSounds": [
+                "core:medEngineWork0",
+                "core:medEngineWork1",
+                "core:medEngineWork2",
+                "core:medEngineWork3",
+                "core:medEngineWork4"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Particle Emitters now control engine sounds thus engines now have no visual or aural representation.
Residual emitter configurations have been removed and `workSounds` has been moved from all engine json files to the ship json and is optional to allow for silent emitters.
### Testing:
Fly around in any ship with your sound turned on
### Todo:
- [ ] Add `workSounds` to the [wiki](https://github.com/MovingBlocks/DestinationSol/wiki/Particle-Emitters)
- [ ] Update all modules (I just need to push the changes when this PR is merged)
### Next steps:
[The engine simplification PR](https://github.com/NicholasBatesNZ/DestinationSol/pull/1) requires this