### PR TITLE
classpathModule Fix

### DIFF
--- a/engine/src/main/java/org/destinationsol/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/ModuleManager.java
@@ -15,6 +15,7 @@
  */
 package org.destinationsol;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Sets;
 import org.destinationsol.assets.AssetHelper;
 import org.destinationsol.assets.Assets;
@@ -27,17 +28,16 @@ import org.destinationsol.game.DebugOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
-import org.terasology.module.Module;
-import org.terasology.module.ModuleEnvironment;
-import org.terasology.module.ModuleFactory;
-import org.terasology.module.ModulePathScanner;
-import org.terasology.module.ModuleRegistry;
-import org.terasology.module.TableModuleRegistry;
+import org.terasology.module.*;
 import org.terasology.module.sandbox.StandardPermissionProviderFactory;
 
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class ModuleManager {
@@ -49,7 +49,11 @@ public class ModuleManager {
     public ModuleManager() {
         try {
             URI engineClasspath = getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
-            Module engineModule = new ModuleFactory().createModule(Paths.get(engineClasspath));
+            Reader reader = new InputStreamReader(getClass().getResourceAsStream("/module.json"), Charsets.UTF_8);
+            ModuleMetadata metadata = new ModuleMetadataJsonAdapter().read(reader);
+            List<Path> paths = new ArrayList<>();
+            paths.add(Paths.get(engineClasspath));
+            Module engineModule = new ModuleFactory().createClasspathModule(paths, metadata);
 
             registry = new TableModuleRegistry();
             Path modulesRoot;

--- a/engine/src/main/java/org/destinationsol/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/ModuleManager.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 
-
 import org.terasology.module.Module;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.ModuleFactory;

--- a/engine/src/main/java/org/destinationsol/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/ModuleManager.java
@@ -28,7 +28,16 @@ import org.destinationsol.game.DebugOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
-import org.terasology.module.*;
+
+
+import org.terasology.module.Module;
+import org.terasology.module.ModuleEnvironment;
+import org.terasology.module.ModuleFactory;
+import org.terasology.module.ModuleMetadata;
+import org.terasology.module.ModuleMetadataJsonAdapter;
+import org.terasology.module.ModulePathScanner;
+import org.terasology.module.ModuleRegistry;
+import org.terasology.module.TableModuleRegistry;
 import org.terasology.module.sandbox.StandardPermissionProviderFactory;
 
 import java.io.InputStreamReader;


### PR DESCRIPTION
# Description
You can now use methods like `ModuleEnvironment`'s `getTypesAnnotatedWith()`.

# Testing
1. Create SampleAnnotation.java:
```
@Retention(RetentionPolicy.RUNTIME)
@Target(ElementType.TYPE)
@interface SampleAnnotation{

}
```
2. Pick any class, and annotate that class with above annotation. Example:
I picked SolApplication:
```
@SampleAnnotation
public class SolApplication implements ApplicationListener {
...
}
```
3. At the end of `ModuleManager.java` 's constructor , put this line:
`Iterable<Class<?>> list = environment.getTypesAnnotatedWith(SampleAnnotation.class);`
Also put a breakpoint on this line.

4. Debug program, and examine value of `list` . It will contain names of all classes annotated with `SampleAnnotation` . 
You will also get a bunch of Debug messages from `Reflections.java` (See below)
# Outstanding Work

However, this has one issue: ALL files in /out/production/engine  (.json, .ogg, .png etc.) are scanned  for annotations. This causes a bunch of scan error messages in the console because `Reflections.java` is trying to scan .json / .ogg / .png files for annotations.

The scanner needs to scan only .class files. 
