### PR TITLE
Bumps the version of the metrics config files to fix a Checkstyle issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ configurations {
 
 dependencies {
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
-    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.1.0', ext: 'zip'
+    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.2.0', ext: 'zip'
 }
 
 task extractConfig(type: Copy) {


### PR DESCRIPTION
Forgot to do this for DestSol back when https://github.com/MovingBlocks/TeraConfig/pull/5 was merged and released. 

Without it you'd get warnings in IntelliJ about failing to parse Checkstyle config and it wouldn't work, which naturally is rather problematic if you're trying to use Checkstyle.

After merging this be sure to rerun `gradlew idea` so the updated metrics config files get retrieved and extracted. Then try running Checkstyle on something (may have to force a rule reload in IntelliJ)