### PR TITLE
Test and extract create player from SolGame

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
     testCompile group: 'org.jboss.shrinkwrap', name: 'shrinkwrap-depchain-java7', version: '1.1.3'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.0'
 }
 
 sourceSets {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -47,7 +47,7 @@ class PlayerCreator {
 
         String items = findItems(shipConfig, respawnState);
 
-        boolean giveAmmo = isNewShip && respawnState.getRespawnItems().isEmpty();
+        boolean giveAmmo = shouldGiveAmmo(respawnState, isNewShip);
         Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, items, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnState.getRespawnItems().isEmpty()) {
@@ -81,6 +81,10 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private boolean shouldGiveAmmo(RespawnState respawnState, boolean isNewShip) {
+        return isNewShip && respawnState.getRespawnItems().isEmpty();
     }
 
     private String findItems(ShipConfig shipConfig, RespawnState respawnState) {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -45,10 +45,10 @@ class PlayerCreator {
 
         HullConfig hull = findHullConfig(shipConfig, respawnState);
 
-        String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.getItems();
+        String items = findItems(shipConfig, respawnState);
 
         boolean giveAmmo = isNewShip && respawnState.getRespawnItems().isEmpty();
-        Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
+        Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, items, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnState.getRespawnItems().isEmpty()) {
             for (SolItem item : respawnState.getRespawnItems()) {
@@ -81,6 +81,13 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private String findItems(ShipConfig shipConfig, RespawnState respawnState) {
+        if (!respawnState.getRespawnItems().isEmpty()) {
+            return "";
+        }
+        return shipConfig.getItems();
     }
 
     private HullConfig findHullConfig(ShipConfig shipConfig, RespawnState respawnState) {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -28,6 +28,9 @@ import org.destinationsol.game.item.TradeConfig;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
 class PlayerCreator {
+
+    private static final int TUTORIAL_MONEY_AMOUNT = 200;
+
     Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
         // If we continue a game, we should spawn from the same position
         Vector2 position = findPlayerSpawnPosition(shipConfig, shouldSpawnOnGalaxySpawnPosition, game);
@@ -38,7 +41,7 @@ class PlayerCreator {
         }
         Pilot pilot = createPilot(game, isMouseControl);
 
-        float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.getMoney();
+        float money = grantPlayerMoney(shipConfig, respawnState, game);
 
         HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.getHull();
 
@@ -78,6 +81,16 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private float grantPlayerMoney(ShipConfig shipConfig, RespawnState respawnState, SolGame game) {
+        if (respawnState.getRespawnMoney() != 0) {
+            return respawnState.getRespawnMoney();
+        }
+        if (game.getTutMan() != null) {
+            return TUTORIAL_MONEY_AMOUNT;
+        }
+        return shipConfig.getMoney();
     }
 
     private Pilot createPilot(SolGame game, boolean isMouseControl) {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -35,7 +35,7 @@ class PlayerCreator {
         if (shouldSpawnOnGalaxySpawnPosition) {
             position = game.getGalaxyFiller().getPlayerSpawnPos(game);
         } else {
-            position = shipConfig.spawnPos;
+            position = shipConfig.getSpawnPos();
         }
         game.getCam().setPos(position);
 

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -25,11 +25,15 @@ import org.destinationsol.game.item.Gun;
 import org.destinationsol.game.item.ItemContainer;
 import org.destinationsol.game.item.SolItem;
 import org.destinationsol.game.item.TradeConfig;
+import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
 class PlayerCreator {
 
     private static final int TUTORIAL_MONEY_AMOUNT = 200;
+    private static final int SHIP_SPAWN_ANGLE = 0;
+    private static final int SHIP_SPAWN_ROTATION_SPEED = 0;
+    private static final boolean SHIP_SPAWN_HAS_REPAIRER = true;
 
     Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
         // If we continue a game, we should spawn from the same position
@@ -48,7 +52,7 @@ class PlayerCreator {
         String items = findItems(shipConfig, respawnState);
 
         boolean giveAmmo = shouldGiveAmmo(respawnState, isNewShip);
-        Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, items, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
+        Hero hero = createHero(position, pilot, money, hull, items, giveAmmo, game);
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnState.getRespawnItems().isEmpty()) {
             for (SolItem item : respawnState.getRespawnItems()) {
@@ -81,6 +85,23 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private Hero createHero(Vector2 position, Pilot pilot, float money, HullConfig hull, String items, boolean giveAmmo, SolGame game) {
+        FarShip farShip = game.getShipBuilder().buildNewFar(game,
+                new Vector2(position),
+                null,
+                SHIP_SPAWN_ANGLE,
+                SHIP_SPAWN_ROTATION_SPEED,
+                pilot,
+                items,
+                hull,
+                null,
+                SHIP_SPAWN_HAS_REPAIRER,
+                money,
+                new TradeConfig(),
+                giveAmmo);
+        return new Hero(farShip.toObject(game));
     }
 
     private boolean shouldGiveAmmo(RespawnState respawnState, boolean isNewShip) {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -64,10 +64,14 @@ class PlayerCreator {
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnState.getRespawnItems().isEmpty()) {
             addAndEquipRespawnItems(hero, respawnState, itemContainer, game);
-        } else if (game.getTutMan() != null) {
+        } else if (isTutorialMode(game)) {
             addRandomTutorialItems(game, itemContainer);
         }
         itemContainer.markAllAsSeen();
+    }
+
+    private boolean isTutorialMode(SolGame game) {
+        return game.getTutMan() != null;
     }
 
     private void addRandomTutorialItems(SolGame game, ItemContainer itemContainer) {
@@ -142,7 +146,7 @@ class PlayerCreator {
         if (respawnState.getRespawnMoney() != 0) {
             return respawnState.getRespawnMoney();
         }
-        if (game.getTutMan() != null) {
+        if (isTutorialMode(game)) {
             return TUTORIAL_MONEY_AMOUNT;
         }
         return shipConfig.getMoney();

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -51,7 +51,7 @@ class PlayerCreator {
 
         HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.getHull();
 
-        String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.items;
+        String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.getItems();
 
         boolean giveAmmo = isNewShip && respawnState.getRespawnItems().isEmpty();
         Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -33,13 +33,10 @@ class PlayerCreator {
         Vector2 position = findPlayerSpawnPosition(shipConfig, shouldSpawnOnGalaxySpawnPosition, game);
         game.getCam().setPos(position);
 
-        Pilot pilot;
         if (isMouseControl) {
             game.getBeaconHandler().init(game, position);
-            pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
-        } else {
-            pilot = new UiControlledPilot(game.getScreens().mainScreen);
         }
+        Pilot pilot = createPilot(game, isMouseControl);
 
         float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.getMoney();
 
@@ -81,6 +78,14 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private Pilot createPilot(SolGame game, boolean isMouseControl) {
+        if (isMouseControl) {
+            return new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
+        } else {
+            return new UiControlledPilot(game.getScreens().mainScreen);
+        }
     }
 
     private Vector2 findPlayerSpawnPosition(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, SolGame game) {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -38,30 +38,25 @@ class PlayerCreator {
     private static final float MAX_NUMBER_OF_TUTORIAL_ITEM_GROUPS = 1.5f * Const.ITEM_GROUPS_PER_PAGE;
 
     Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
-        // If we continue a game, we should spawn from the same position
         Vector2 position = findPlayerSpawnPosition(shipConfig, shouldSpawnOnGalaxySpawnPosition, game);
         game.getCam().setPos(position);
-
         if (isMouseControl) {
             game.getBeaconHandler().init(game, position);
         }
+        Hero hero = configureAndCreateHero(shipConfig, respawnState, game, isMouseControl, isNewShip, position);
+        game.getObjectManager().addObjDelayed(hero.getShip());
+        game.getObjectManager().resetDelays();
+        return hero;
+    }
+
+    private Hero configureAndCreateHero(ShipConfig shipConfig, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip, Vector2 position) {
         Pilot pilot = createPilot(game, isMouseControl);
-
         float money = grantPlayerMoney(shipConfig, respawnState, game);
-
         HullConfig hull = findHullConfig(shipConfig, respawnState);
-
         String items = findItems(shipConfig, respawnState);
-
         boolean giveAmmo = shouldGiveAmmo(respawnState, isNewShip);
         Hero hero = createHero(position, pilot, money, hull, items, giveAmmo, game);
         addAndEquipItems(hero, respawnState, game);
-
-        // Don't change equipped items across load/respawn
-        //AiPilot.reEquip(this, myHero);
-
-        game.getObjectManager().addObjDelayed(hero.getShip());
-        game.getObjectManager().resetDelays();
         return hero;
     }
 

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -28,15 +28,9 @@ import org.destinationsol.game.item.TradeConfig;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
 class PlayerCreator {
-    // uh, this needs refactoring
     Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
         // If we continue a game, we should spawn from the same position
-        Vector2 position;
-        if (shouldSpawnOnGalaxySpawnPosition) {
-            position = game.getGalaxyFiller().getPlayerSpawnPos(game);
-        } else {
-            position = shipConfig.getSpawnPos();
-        }
+        Vector2 position = findPlayerSpawnPosition(shipConfig, shouldSpawnOnGalaxySpawnPosition, game);
         game.getCam().setPos(position);
 
         Pilot pilot;
@@ -87,5 +81,13 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private Vector2 findPlayerSpawnPosition(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, SolGame game) {
+        if (shouldSpawnOnGalaxySpawnPosition) {
+            return game.getGalaxyFiller().getPlayerSpawnPos(game);
+        } else {
+            return shipConfig.getSpawnPos();
+        }
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -47,7 +47,7 @@ class PlayerCreator {
             pilot = new UiControlledPilot(game.getScreens().mainScreen);
         }
 
-        float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.money;
+        float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.getMoney();
 
         HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.hull;
 

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -89,13 +89,16 @@ class PlayerCreator {
     private void addAndEquipRespawnItems(Hero hero, RespawnState respawnState, ItemContainer itemContainer, SolGame game) {
         for (SolItem item : respawnState.getRespawnItems()) {
             itemContainer.add(item);
-            // Ensure that previously equipped items stay equipped
-            if (item.isEquipped() > 0) {
-                if (item instanceof Gun) {
-                    hero.maybeEquip(game, item, item.isEquipped() == 2, true);
-                } else {
-                    hero.maybeEquip(game, item, true);
-                }
+            ensurePreviouslyEquippedItemStaysEquipped(item, hero, game);
+        }
+    }
+
+    private void ensurePreviouslyEquippedItemStaysEquipped(SolItem item, Hero hero, SolGame game) {
+        if (item.isEquipped() > 0) {
+            if (item instanceof Gun) {
+                hero.maybeEquip(game, item, item.isEquipped() == 2, true);
+            } else {
+                hero.maybeEquip(game, item, true);
             }
         }
     }

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -49,7 +49,7 @@ class PlayerCreator {
 
         float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.getMoney();
 
-        HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.hull;
+        HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.getHull();
 
         String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.items;
 

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -43,7 +43,7 @@ class PlayerCreator {
 
         float money = grantPlayerMoney(shipConfig, respawnState, game);
 
-        HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.getHull();
+        HullConfig hull = findHullConfig(shipConfig, respawnState);
 
         String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.getItems();
 
@@ -81,6 +81,13 @@ class PlayerCreator {
         game.getObjectManager().addObjDelayed(hero.getShip());
         game.getObjectManager().resetDelays();
         return hero;
+    }
+
+    private HullConfig findHullConfig(ShipConfig shipConfig, RespawnState respawnState) {
+        if (respawnState.getRespawnHull() != null) {
+            return respawnState.getRespawnHull();
+        }
+        return shipConfig.getHull();
     }
 
     private float grantPlayerMoney(ShipConfig shipConfig, RespawnState respawnState, SolGame game) {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game;
+
+import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.Const;
+import org.destinationsol.game.input.AiPilot;
+import org.destinationsol.game.input.BeaconDestProvider;
+import org.destinationsol.game.input.Pilot;
+import org.destinationsol.game.input.UiControlledPilot;
+import org.destinationsol.game.item.Gun;
+import org.destinationsol.game.item.ItemContainer;
+import org.destinationsol.game.item.SolItem;
+import org.destinationsol.game.item.TradeConfig;
+import org.destinationsol.game.ship.hulls.HullConfig;
+
+class PlayerCreator {
+    // uh, this needs refactoring
+    Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
+        // If we continue a game, we should spawn from the same position
+        Vector2 position;
+        if (shouldSpawnOnGalaxySpawnPosition) {
+            position = game.getGalaxyFiller().getPlayerSpawnPos(game);
+        } else {
+            position = shipConfig.spawnPos;
+        }
+        game.getCam().setPos(position);
+
+        Pilot pilot;
+        if (isMouseControl) {
+            game.getBeaconHandler().init(game, position);
+            pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
+        } else {
+            pilot = new UiControlledPilot(game.getScreens().mainScreen);
+        }
+
+        float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.money;
+
+        HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.hull;
+
+        String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.items;
+
+        boolean giveAmmo = isNewShip && respawnState.getRespawnItems().isEmpty();
+        Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
+        ItemContainer itemContainer = hero.getItemContainer();
+        if (!respawnState.getRespawnItems().isEmpty()) {
+            for (SolItem item : respawnState.getRespawnItems()) {
+                itemContainer.add(item);
+                // Ensure that previously equipped items stay equipped
+                if (item.isEquipped() > 0) {
+                    if (item instanceof Gun) {
+                        hero.maybeEquip(game, item, item.isEquipped() == 2, true);
+                    } else {
+                        hero.maybeEquip(game, item, true);
+                    }
+                }
+            }
+        } else if (game.getTutMan() != null) {
+            for (int i = 0; i < 50; i++) {
+                if (itemContainer.groupCount() > 1.5f * Const.ITEM_GROUPS_PER_PAGE) {
+                    break;
+                }
+                SolItem it = game.getItemMan().random();
+                if (!(it instanceof Gun) && it.getIcon(game) != null && itemContainer.canAdd(it)) {
+                    itemContainer.add(it.copy());
+                }
+            }
+        }
+        itemContainer.markAllAsSeen();
+
+        // Don't change equipped items across load/respawn
+        //AiPilot.reEquip(this, myHero);
+
+        game.getObjectManager().addObjDelayed(hero.getShip());
+        game.getObjectManager().resetDelays();
+        return hero;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/RespawnState.java
+++ b/engine/src/main/java/org/destinationsol/game/RespawnState.java
@@ -15,9 +15,15 @@
  */
 package org.destinationsol.game;
 
+import org.destinationsol.game.item.SolItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class RespawnState {
 
     private boolean isPlayerRespawned;
+    private final List<SolItem> respawnItems = new ArrayList<>();
 
 
     public boolean isPlayerRespawned() {
@@ -26,5 +32,9 @@ public class RespawnState {
 
     public void setPlayerRespawned(boolean playerRespawned) {
         isPlayerRespawned = playerRespawned;
+    }
+
+    public List<SolItem> getRespawnItems() {
+        return respawnItems;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/RespawnState.java
+++ b/engine/src/main/java/org/destinationsol/game/RespawnState.java
@@ -26,6 +26,7 @@ public class RespawnState {
     private boolean isPlayerRespawned;
     private final List<SolItem> respawnItems = new ArrayList<>();
     private HullConfig respawnHull;
+    private float respawnMoney;
 
 
     public boolean isPlayerRespawned() {
@@ -46,5 +47,13 @@ public class RespawnState {
 
     public void setRespawnHull(HullConfig respawnHull) {
         this.respawnHull = respawnHull;
+    }
+
+    public float getRespawnMoney() {
+        return respawnMoney;
+    }
+
+    public void setRespawnMoney(float respawnMoney) {
+        this.respawnMoney = respawnMoney;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/RespawnState.java
+++ b/engine/src/main/java/org/destinationsol/game/RespawnState.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game;
+
+public class RespawnState {
+
+    private boolean isPlayerRespawned;
+
+
+    public boolean isPlayerRespawned() {
+        return isPlayerRespawned;
+    }
+
+    public void setPlayerRespawned(boolean playerRespawned) {
+        isPlayerRespawned = playerRespawned;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/RespawnState.java
+++ b/engine/src/main/java/org/destinationsol/game/RespawnState.java
@@ -16,6 +16,7 @@
 package org.destinationsol.game;
 
 import org.destinationsol.game.item.SolItem;
+import org.destinationsol.game.ship.hulls.HullConfig;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ public class RespawnState {
 
     private boolean isPlayerRespawned;
     private final List<SolItem> respawnItems = new ArrayList<>();
+    private HullConfig respawnHull;
 
 
     public boolean isPlayerRespawned() {
@@ -36,5 +38,13 @@ public class RespawnState {
 
     public List<SolItem> getRespawnItems() {
         return respawnItems;
+    }
+
+    public HullConfig getRespawnHull() {
+        return respawnHull;
+    }
+
+    public void setRespawnHull(HullConfig respawnHull) {
+        this.respawnHull = respawnHull;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -47,7 +47,7 @@ public class SaveManager {
 
     private static final String FILE_NAME = "prevShip.ini";
 
-    public static void writeShips(HullConfig hull, float money, ArrayList<SolItem> itemsList, SolGame game) {
+    public static void writeShips(HullConfig hull, float money, List<SolItem> itemsList, SolGame game) {
         String hullName = game.getHullConfigs().getName(hull);
 
         writeMercs(game);
@@ -64,7 +64,7 @@ public class SaveManager {
      * @param items A list of SolItems to be encoded as a string
      * @return A string of items suitable for saving
      */
-    private static String itemsToString(ArrayList<SolItem> items) {
+    private static String itemsToString(List<SolItem> items) {
         StringBuilder sb = new StringBuilder();
 
         for (SolItem i : items) {

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -64,6 +64,10 @@ public class ShipConfig {
         return hull;
     }
 
+    public String getItems(){
+        return items;
+    }
+
     public static ArrayList<ShipConfig> loadList(JsonValue shipListJson, HullConfigManager hullConfigs, ItemManager itemManager) {
         ArrayList<ShipConfig> res = new ArrayList<>();
         if (shipListJson == null) {

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -55,6 +55,10 @@ public class ShipConfig {
         return spawnPos;
     }
 
+    public int getMoney(){
+        return money;
+    }
+
     public static ArrayList<ShipConfig> loadList(JsonValue shipListJson, HullConfigManager hullConfigs, ItemManager itemManager) {
         ArrayList<ShipConfig> res = new ArrayList<>();
         if (shipListJson == null) {

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -22,6 +22,7 @@ import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.json.Json;
 import org.destinationsol.files.HullConfigManager;
 import org.destinationsol.game.item.ItemManager;
+import org.destinationsol.game.ship.hulls.Hull;
 import org.destinationsol.game.ship.hulls.HullConfig;
 import org.terasology.assets.ResourceUrn;
 
@@ -57,6 +58,10 @@ public class ShipConfig {
 
     public int getMoney(){
         return money;
+    }
+
+    public HullConfig getHull(){
+        return hull;
     }
 
     public static ArrayList<ShipConfig> loadList(JsonValue shipListJson, HullConfigManager hullConfigs, ItemManager itemManager) {

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -45,10 +45,14 @@ public class ShipConfig {
         this.guard = guard;
         dps = HardnessCalc.getShipConfDps(this, itemManager);
     }
-    
+
     public ShipConfig(HullConfig hull, String items, int money, float density, ShipConfig guard, ItemManager itemManager, Vector2 spawnPos) {
         this(hull, items, money, density, guard, itemManager);
         this.spawnPos = spawnPos;
+    }
+
+    public Vector2 getSpawnPos() {
+        return spawnPos;
     }
 
     public static ArrayList<ShipConfig> loadList(JsonValue shipListJson, HullConfigManager hullConfigs, ItemManager itemManager) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -160,7 +160,7 @@ public class SolGame {
     }
 
     private void createGame(String shipName, boolean isNewGame) {
-        createPlayer(shipName,
+        hero = createPlayer(shipName,
                 isNewGame,
                 isPlayerRespawned,
                 this,
@@ -171,7 +171,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
+    private Hero createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
         ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
@@ -205,8 +205,7 @@ public class SolGame {
         String itemsStr = !respawnItems.isEmpty() ? "" : shipConfig.items;
 
         boolean giveAmmo = shipName != null && respawnItems.isEmpty();
-        hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
-
+        Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnItems.isEmpty()) {
             for (SolItem item : respawnItems) {
@@ -238,6 +237,7 @@ public class SolGame {
 
         objectManager.addObjDelayed(hero.getShip());
         objectManager.resetDelays();
+        return hero;
     }
 
     private void createAndSpawnMercenariesFromSave() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -235,8 +235,8 @@ public class SolGame {
         // Don't change equipped items across load/respawn
         //AiPilot.reEquip(this, myHero);
 
-        objectManager.addObjDelayed(hero.getShip());
-        objectManager.resetDelays();
+        game.getObjectManager().addObjDelayed(hero.getShip());
+        game.getObjectManager().resetDelays();
         return hero;
     }
 

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,11 +152,22 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull, respawnItems);
+        createGame(shipName, isNewGame);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
         }
         SolMath.checkVectorsTaken(null);
+    }
+
+    private void createGame(String shipName, boolean isNewGame) {
+        createPlayer(shipName,
+                isNewGame,
+                isPlayerRespawned,
+                this,
+                solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE,
+                respawnMoney,
+                respawnHull,
+                respawnItems);
     }
 
     // uh, this needs refactoring
@@ -430,7 +441,7 @@ public class SolGame {
             }
         }
         // TODO: Consider whether we want to treat respawn as a newGame or not.
-        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull, respawnItems);
+        createGame(null, true);
     }
 
     public FactionManager getFactionMan() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -167,13 +167,13 @@ public class SolGame {
         assert shipConfig != null;
 
         if (!isPlayerRespawned) {
-            galaxyFiller.fill(this, game.getHullConfigs(), game.getItemMan());
+            game.getGalaxyFiller().fill(this, game.getHullConfigs(), game.getItemMan());
         }
 
         // If we continue a game, we should spawn from the same position
         Vector2 position;
         if (isNewGame) {
-            position = galaxyFiller.getPlayerSpawnPos(this);
+            position = game.getGalaxyFiller().getPlayerSpawnPos(this);
         } else {
             position = shipConfig.spawnPos;
         }

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,7 +152,7 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney);
+        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
         }
@@ -160,7 +160,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney) {
+    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull) {
         ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
@@ -430,7 +430,7 @@ public class SolGame {
             }
         }
         // TODO: Consider whether we want to treat respawn as a newGame or not.
-        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney);
+        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull);
     }
 
     public FactionManager getFactionMan() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -181,7 +181,7 @@ public class SolGame {
 
         Pilot pilot;
         if (isMouseControl) {
-            beaconHandler.init(game, position);
+            game.getBeaconHandler().init(game, position);
             pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
         } else {
             pilot = new UiControlledPilot(gameScreens.mainScreen);

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -205,7 +205,7 @@ public class SolGame {
         String itemsStr = !respawnItems.isEmpty() ? "" : shipConfig.items;
 
         boolean giveAmmo = shipName != null && respawnItems.isEmpty();
-        hero = new Hero(shipBuilder.buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
+        hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
 
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnItems.isEmpty()) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,7 +152,7 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        createPlayer(shipName, isNewGame,isPlayerRespawned, this);
+        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
         }
@@ -160,7 +160,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game) {
+    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl) {
         ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, itemManager, game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
@@ -180,7 +180,7 @@ public class SolGame {
         game.getCam().setPos(position);
 
         Pilot pilot;
-        if (solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE) {
+        if (isMouseControl) {
             beaconHandler.init(game, position);
             pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
         } else {
@@ -430,7 +430,7 @@ public class SolGame {
             }
         }
         // TODO: Consider whether we want to treat respawn as a newGame or not.
-        createPlayer(null, true, isPlayerRespawned, this);
+        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE);
     }
 
     public FactionManager getFactionMan() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -156,7 +156,7 @@ public class SolGame {
         SolMath.checkVectorsTaken(null);
     }
 
-    private void createGame(String shipName, boolean isNewGame, SolGame game) {
+    private void createGame(String shipName, boolean shouldSpawnOnGalaxySpawnPosition, SolGame game) {
         /*
          * shipName will be null on respawn and continue, meaning the old ship will be loaded.
          * If shipName is not null then a new ship has to be created.
@@ -167,7 +167,7 @@ public class SolGame {
             game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
         }
         hero = createPlayer(shipConfig,
-                isNewGame,
+                shouldSpawnOnGalaxySpawnPosition,
                 respawnState,
                 this,
                 solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE,
@@ -183,10 +183,10 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
+    private Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
         // If we continue a game, we should spawn from the same position
         Vector2 position;
-        if (isNewGame) {
+        if (shouldSpawnOnGalaxySpawnPosition) {
             position = game.getGalaxyFiller().getPlayerSpawnPos(game);
         } else {
             position = shipConfig.spawnPos;
@@ -443,7 +443,6 @@ public class SolGame {
                 objectManager.removeObjDelayed(hero.getTranscendentHero());
             }
         }
-        // TODO: Consider whether we want to treat respawn as a newGame or not.
         createGame(null, true, this);
     }
 

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -158,6 +158,9 @@ public class SolGame {
 
     private void createGame(String shipName, boolean isNewGame, SolGame game) {
         ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, game);
+        if (!respawnState.isPlayerRespawned()) {
+            game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
+        }
         hero = createPlayer(shipConfig,
                 isNewGame,
                 respawnState,
@@ -175,11 +178,6 @@ public class SolGame {
 
     // uh, this needs refactoring
     private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl) {
-
-        if (!respawnState.isPlayerRespawned()) {
-            game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
-        }
-
         // If we continue a game, we should spawn from the same position
         Vector2 position;
         if (isNewGame) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -157,7 +157,12 @@ public class SolGame {
     }
 
     private void createGame(String shipName, boolean isNewGame, SolGame game) {
-        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, game);
+        /*
+         * shipName will be null on respawn and continue, meaning the old ship will be loaded.
+         * If shipName is not null then a new ship has to be created.
+         */
+        boolean isNewShip = shipName != null;
+        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, game, isNewShip);
         if (!respawnState.isPlayerRespawned()) {
             game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
         }
@@ -165,11 +170,12 @@ public class SolGame {
                 isNewGame,
                 respawnState,
                 this,
-                solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE);
+                solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE,
+                isNewShip);
     }
 
-    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, SolGame game) {
-        if (shipName != null) {
+    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, SolGame game, boolean isNewShip) {
+        if (isNewShip) {
             return ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
         } else {
             return SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game);
@@ -177,7 +183,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl) {
+    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
         // If we continue a game, we should spawn from the same position
         Vector2 position;
         if (isNewGame) {
@@ -201,7 +207,7 @@ public class SolGame {
 
         String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.items;
 
-        boolean giveAmmo = shipName != null && respawnState.getRespawnItems().isEmpty();
+        boolean giveAmmo = isNewShip && respawnState.getRespawnItems().isEmpty();
         Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnState.getRespawnItems().isEmpty()) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -160,7 +160,7 @@ public class SolGame {
     }
 
     private void createGame(String shipName, boolean isNewGame, SolGame game) {
-        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
+        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, game);
         hero = createPlayer(shipConfig,
                 isNewGame,
                 isPlayerRespawned,
@@ -169,6 +169,14 @@ public class SolGame {
                 respawnMoney,
                 respawnHull,
                 respawnItems);
+    }
+
+    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, SolGame game) {
+        if (shipName != null) {
+            return ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
+        } else {
+            return SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game);
+        }
     }
 
     // uh, this needs refactoring

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,15 +152,16 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        createGame(shipName, isNewGame);
+        createGame(shipName, isNewGame, this);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
         }
         SolMath.checkVectorsTaken(null);
     }
 
-    private void createGame(String shipName, boolean isNewGame) {
-        hero = createPlayer(shipName,
+    private void createGame(String shipName, boolean isNewGame, SolGame game) {
+        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
+        hero = createPlayer(shipConfig,
                 isNewGame,
                 isPlayerRespawned,
                 this,
@@ -171,8 +172,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private Hero createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
-        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
+    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;
@@ -441,7 +441,7 @@ public class SolGame {
             }
         }
         // TODO: Consider whether we want to treat respawn as a newGame or not.
-        createGame(null, true);
+        createGame(null, true, this);
     }
 
     public FactionManager getFactionMan() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -111,7 +111,7 @@ public class SolGame {
     private float timeFactor;
     private float respawnMoney;
     private HullConfig respawnHull;
-    private boolean isPlayerRespawned;
+    private RespawnState respawnState;
 
     public SolGame(SolApplication cmp, String shipName, boolean tut, boolean isNewGame, CommonDrawer commonDrawer) {
         solApplication = cmp;
@@ -152,6 +152,7 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
+        respawnState = new RespawnState();
         createGame(shipName, isNewGame, this);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
@@ -163,7 +164,7 @@ public class SolGame {
         ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, game);
         hero = createPlayer(shipConfig,
                 isNewGame,
-                isPlayerRespawned,
+                respawnState,
                 this,
                 solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE,
                 respawnMoney,
@@ -180,12 +181,12 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
+    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;
 
-        if (!isPlayerRespawned) {
+        if (!respawnState.isPlayerRespawned()) {
             game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
         }
 
@@ -589,7 +590,7 @@ public class SolGame {
         respawnMoney = .75f * money;
         respawnHull = hullConfig;
         respawnItems.clear();
-        isPlayerRespawned = true;
+        respawnState.setPlayerRespawned(true);
         for (List<SolItem> group : ic) {
             for (SolItem item : group) {
                 boolean equipped = hero.isTranscendent() || hero.maybeUnequip(this, item, false);

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -292,7 +292,7 @@ public class SolGame {
 
         HullConfig hull;
         float money;
-        ArrayList<SolItem> items;
+        List<SolItem> items;
 
         if (hero.isAlive()) {
             hull = hero.isTranscendent() ? hero.getTranscendentHero().getShip().getHullConfig() : hero.getHull().config;
@@ -306,7 +306,7 @@ public class SolGame {
         } else {
             hull = respawnHull;
             money = respawnMoney;
-            items = new ArrayList<>(respawnState.getRespawnItems());
+            items = respawnState.getRespawnItems();
         }
 
         SaveManager.writeShips(hull, money, items, this);

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -161,7 +161,7 @@ public class SolGame {
 
     // uh, this needs refactoring
     private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl) {
-        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, itemManager, game);
+        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -109,7 +109,6 @@ public class SolGame {
     private boolean paused;
     private float timeFactor;
     private float respawnMoney;
-    private HullConfig respawnHull;
     private RespawnState respawnState;
 
     public SolGame(SolApplication cmp, String shipName, boolean tut, boolean isNewGame, CommonDrawer commonDrawer) {
@@ -165,8 +164,7 @@ public class SolGame {
                 respawnState,
                 this,
                 solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE,
-                respawnMoney,
-                respawnHull);
+                respawnMoney);
     }
 
     private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, SolGame game) {
@@ -178,7 +176,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull) {
+    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl, float respawnMoney) {
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;
@@ -206,7 +204,7 @@ public class SolGame {
 
         float money = respawnMoney != 0 ? respawnMoney : game.getTutMan() != null ? 200 : shipConfig.money;
 
-        HullConfig hull = respawnHull != null ? respawnHull : shipConfig.hull;
+        HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.hull;
 
         String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.items;
 
@@ -304,7 +302,7 @@ public class SolGame {
                 }
             }
         } else {
-            hull = respawnHull;
+            hull = respawnState.getRespawnHull();
             money = respawnMoney;
             items = respawnState.getRespawnItems();
         }
@@ -585,7 +583,7 @@ public class SolGame {
 
     private void setRespawnState(float money, ItemContainer ic, HullConfig hullConfig) {
         respawnMoney = .75f * money;
-        respawnHull = hullConfig;
+        respawnState.setRespawnHull(hullConfig);
         respawnState.getRespawnItems().clear();
         respawnState.setPlayerRespawned(true);
         for (List<SolItem> group : ic) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -161,19 +161,19 @@ public class SolGame {
 
     // uh, this needs refactoring
     private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game) {
-        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), this) : ShipConfig.load(game.getHullConfigs(), shipName, itemManager, this);
+        ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, itemManager, game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;
 
         if (!isPlayerRespawned) {
-            game.getGalaxyFiller().fill(this, game.getHullConfigs(), game.getItemMan());
+            game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
         }
 
         // If we continue a game, we should spawn from the same position
         Vector2 position;
         if (isNewGame) {
-            position = game.getGalaxyFiller().getPlayerSpawnPos(this);
+            position = game.getGalaxyFiller().getPlayerSpawnPos(game);
         } else {
             position = shipConfig.spawnPos;
         }
@@ -181,7 +181,7 @@ public class SolGame {
 
         Pilot pilot;
         if (solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE) {
-            beaconHandler.init(this, position);
+            beaconHandler.init(game, position);
             pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
         } else {
             pilot = new UiControlledPilot(gameScreens.mainScreen);
@@ -194,7 +194,7 @@ public class SolGame {
         String itemsStr = !respawnItems.isEmpty() ? "" : shipConfig.items;
 
         boolean giveAmmo = shipName != null && respawnItems.isEmpty();
-        hero = new Hero(shipBuilder.buildNewFar(this, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(this));
+        hero = new Hero(shipBuilder.buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
 
         ItemContainer itemContainer = hero.getItemContainer();
         if (!respawnItems.isEmpty()) {
@@ -203,9 +203,9 @@ public class SolGame {
                 // Ensure that previously equipped items stay equipped
                 if (item.isEquipped() > 0) {
                     if (item instanceof Gun) {
-                        hero.maybeEquip(this, item, item.isEquipped() == 2, true);
+                        hero.maybeEquip(game, item, item.isEquipped() == 2, true);
                     } else {
-                        hero.maybeEquip(this, item, true);
+                        hero.maybeEquip(game, item, true);
                     }
                 }
             }
@@ -215,7 +215,7 @@ public class SolGame {
                     break;
                 }
                 SolItem it = game.getItemMan().random();
-                if (!(it instanceof Gun) && it.getIcon(this) != null && itemContainer.canAdd(it)) {
+                if (!(it instanceof Gun) && it.getIcon(game) != null && itemContainer.canAdd(it)) {
                     itemContainer.add(it.copy());
                 }
             }

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -108,7 +108,6 @@ public class SolGame {
     private float time;
     private boolean paused;
     private float timeFactor;
-    private float respawnMoney;
     private RespawnState respawnState;
 
     public SolGame(SolApplication cmp, String shipName, boolean tut, boolean isNewGame, CommonDrawer commonDrawer) {
@@ -163,8 +162,7 @@ public class SolGame {
                 isNewGame,
                 respawnState,
                 this,
-                solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE,
-                respawnMoney);
+                solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE);
     }
 
     private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, SolGame game) {
@@ -176,7 +174,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl, float respawnMoney) {
+    private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl) {
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
         assert shipConfig != null;
@@ -202,7 +200,7 @@ public class SolGame {
             pilot = new UiControlledPilot(game.getScreens().mainScreen);
         }
 
-        float money = respawnMoney != 0 ? respawnMoney : game.getTutMan() != null ? 200 : shipConfig.money;
+        float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.money;
 
         HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.hull;
 
@@ -303,7 +301,7 @@ public class SolGame {
             }
         } else {
             hull = respawnState.getRespawnHull();
-            money = respawnMoney;
+            money = respawnState.getRespawnMoney();
             items = respawnState.getRespawnItems();
         }
 
@@ -575,14 +573,14 @@ public class SolGame {
 
         setRespawnState(money, itemContainer, hero.getHull().config);
 
-        hero.setMoney(money - respawnMoney);
+        hero.setMoney(money - respawnState.getRespawnMoney());
         for (SolItem item : respawnState.getRespawnItems()) {
             itemContainer.remove(item);
         }
     }
 
     private void setRespawnState(float money, ItemContainer ic, HullConfig hullConfig) {
-        respawnMoney = .75f * money;
+        respawnState.setRespawnMoney(.75f * money);
         respawnState.setRespawnHull(hullConfig);
         respawnState.getRespawnItems().clear();
         respawnState.setPlayerRespawned(true);

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -177,7 +177,7 @@ public class SolGame {
         } else {
             position = shipConfig.spawnPos;
         }
-        camera.setPos(position);
+        game.getCam().setPos(position);
 
         Pilot pilot;
         if (solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -30,17 +30,11 @@ import org.destinationsol.game.chunk.ChunkManager;
 import org.destinationsol.game.drawables.DrawableDebugger;
 import org.destinationsol.game.drawables.DrawableManager;
 import org.destinationsol.game.farBg.FarBackgroundManagerOld;
-import org.destinationsol.game.input.AiPilot;
-import org.destinationsol.game.input.BeaconDestProvider;
-import org.destinationsol.game.input.Pilot;
-import org.destinationsol.game.input.UiControlledPilot;
-import org.destinationsol.game.item.Gun;
 import org.destinationsol.game.item.ItemContainer;
 import org.destinationsol.game.item.ItemManager;
 import org.destinationsol.game.item.LootBuilder;
 import org.destinationsol.game.item.MercItem;
 import org.destinationsol.game.item.SolItem;
-import org.destinationsol.game.item.TradeConfig;
 import org.destinationsol.game.particle.EffectTypes;
 import org.destinationsol.game.particle.PartMan;
 import org.destinationsol.game.particle.SpecialEffects;
@@ -166,7 +160,7 @@ public class SolGame {
         if (!respawnState.isPlayerRespawned()) {
             game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
         }
-        hero = createPlayer(shipConfig,
+        hero = new PlayerCreator().createPlayer(shipConfig,
                 shouldSpawnOnGalaxySpawnPosition,
                 respawnState,
                 this,
@@ -180,67 +174,6 @@ public class SolGame {
         } else {
             return SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game);
         }
-    }
-
-    // uh, this needs refactoring
-    private Hero createPlayer(ShipConfig shipConfig, boolean shouldSpawnOnGalaxySpawnPosition, RespawnState respawnState, SolGame game, boolean isMouseControl, boolean isNewShip) {
-        // If we continue a game, we should spawn from the same position
-        Vector2 position;
-        if (shouldSpawnOnGalaxySpawnPosition) {
-            position = game.getGalaxyFiller().getPlayerSpawnPos(game);
-        } else {
-            position = shipConfig.spawnPos;
-        }
-        game.getCam().setPos(position);
-
-        Pilot pilot;
-        if (isMouseControl) {
-            game.getBeaconHandler().init(game, position);
-            pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
-        } else {
-            pilot = new UiControlledPilot(game.getScreens().mainScreen);
-        }
-
-        float money = respawnState.getRespawnMoney() != 0 ? respawnState.getRespawnMoney() : game.getTutMan() != null ? 200 : shipConfig.money;
-
-        HullConfig hull = respawnState.getRespawnHull() != null ? respawnState.getRespawnHull() : shipConfig.hull;
-
-        String itemsStr = !respawnState.getRespawnItems().isEmpty() ? "" : shipConfig.items;
-
-        boolean giveAmmo = isNewShip && respawnState.getRespawnItems().isEmpty();
-        Hero hero = new Hero(game.getShipBuilder().buildNewFar(game, new Vector2(position), null, 0, 0, pilot, itemsStr, hull, null, true, money, new TradeConfig(), giveAmmo).toObject(game));
-        ItemContainer itemContainer = hero.getItemContainer();
-        if (!respawnState.getRespawnItems().isEmpty()) {
-            for (SolItem item : respawnState.getRespawnItems()) {
-                itemContainer.add(item);
-                // Ensure that previously equipped items stay equipped
-                if (item.isEquipped() > 0) {
-                    if (item instanceof Gun) {
-                        hero.maybeEquip(game, item, item.isEquipped() == 2, true);
-                    } else {
-                        hero.maybeEquip(game, item, true);
-                    }
-                }
-            }
-        } else if (game.getTutMan() != null) {
-            for (int i = 0; i < 50; i++) {
-                if (itemContainer.groupCount() > 1.5f * Const.ITEM_GROUPS_PER_PAGE) {
-                    break;
-                }
-                SolItem it = game.getItemMan().random();
-                if (!(it instanceof Gun) && it.getIcon(game) != null && itemContainer.canAdd(it)) {
-                    itemContainer.add(it.copy());
-                }
-            }
-        }
-        itemContainer.markAllAsSeen();
-
-        // Don't change equipped items across load/respawn
-        //AiPilot.reEquip(this, myHero);
-
-        game.getObjectManager().addObjDelayed(hero.getShip());
-        game.getObjectManager().resetDelays();
-        return hero;
     }
 
     private void createAndSpawnMercenariesFromSave() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -184,7 +184,7 @@ public class SolGame {
             game.getBeaconHandler().init(game, position);
             pilot = new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
         } else {
-            pilot = new UiControlledPilot(gameScreens.mainScreen);
+            pilot = new UiControlledPilot(game.getScreens().mainScreen);
         }
 
         float money = respawnMoney != 0 ? respawnMoney : tutorialManager != null ? 200 : shipConfig.money;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -198,7 +198,7 @@ public class SolGame {
             pilot = new UiControlledPilot(game.getScreens().mainScreen);
         }
 
-        float money = respawnMoney != 0 ? respawnMoney : tutorialManager != null ? 200 : shipConfig.money;
+        float money = respawnMoney != 0 ? respawnMoney : game.getTutMan() != null ? 200 : shipConfig.money;
 
         HullConfig hull = respawnHull != null ? respawnHull : shipConfig.hull;
 
@@ -220,7 +220,7 @@ public class SolGame {
                     }
                 }
             }
-        } else if (tutorialManager != null) {
+        } else if (game.getTutMan() != null) {
             for (int i = 0; i < 50; i++) {
                 if (itemContainer.groupCount() > 1.5f * Const.ITEM_GROUPS_PER_PAGE) {
                     break;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -176,9 +176,6 @@ public class SolGame {
     // uh, this needs refactoring
     private Hero createPlayer(ShipConfig shipConfig, boolean isNewGame, RespawnState respawnState, SolGame game, boolean isMouseControl) {
 
-        // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
-        assert shipConfig != null;
-
         if (!respawnState.isPlayerRespawned()) {
             game.getGalaxyFiller().fill(game, game.getHullConfigs(), game.getItemMan());
         }

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,7 +152,7 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull);
+        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull, respawnItems);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
         }
@@ -160,7 +160,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull) {
+    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney, HullConfig respawnHull, List<SolItem> respawnItems) {
         ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
@@ -430,7 +430,7 @@ public class SolGame {
             }
         }
         // TODO: Consider whether we want to treat respawn as a newGame or not.
-        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull);
+        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney, respawnHull, respawnItems);
     }
 
     public FactionManager getFactionMan() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -152,7 +152,7 @@ public class SolGame {
 
         // from this point we're ready!
         planetManager.fill(solNames);
-        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE);
+        createPlayer(shipName, isNewGame, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney);
         if (!isNewGame) {
             createAndSpawnMercenariesFromSave();
         }
@@ -160,7 +160,7 @@ public class SolGame {
     }
 
     // uh, this needs refactoring
-    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl) {
+    private void createPlayer(String shipName, boolean isNewGame, boolean isPlayerRespawned, SolGame game, boolean isMouseControl, float respawnMoney) {
         ShipConfig shipConfig = shipName == null ? SaveManager.readShip(game.getHullConfigs(), game.getItemMan(), game) : ShipConfig.load(game.getHullConfigs(), shipName, game.getItemMan(), game);
 
         // Added temporarily to remove warnings. Handle this more gracefully inside the SaveManager.readShip and the ShipConfig.load methods
@@ -430,7 +430,7 @@ public class SolGame {
             }
         }
         // TODO: Consider whether we want to treat respawn as a newGame or not.
-        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE);
+        createPlayer(null, true, isPlayerRespawned, this, solApplication.getOptions().controlType == GameOptions.CONTROL_MOUSE, respawnMoney);
     }
 
     public FactionManager getFactionMan() {

--- a/engine/src/main/java/org/destinationsol/game/ship/hulls/HullConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/hulls/HullConfig.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Immutable
-public final class HullConfig {
+public class HullConfig {
     private final Data data;
 
     public HullConfig(Data configData) {

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -256,6 +256,15 @@ public class PlayerCreatorTest {
         verify(solShip).maybeEquip(any(), eq(gun), eq(false),eq(true));
     }
 
+    @Test
+    public void testReEquipRespawnItemGunsSecondarySlot() {
+        Gun gun = mock(Gun.class);
+        when(gun.isEquipped()).thenReturn(2);
+        respawnState.getRespawnItems().add(gun);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solShip).maybeEquip(any(), eq(gun), eq(true),eq(true));
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 verification.position(),

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -130,10 +130,19 @@ public class PlayerCreatorTest {
     }
 
     @Test
-    public void testUseRespawnMoneyIfNotZero(){
+    public void testUseRespawnMoneyIfNotZero() {
         float respawnMoney = 42f;
         respawnState.setRespawnMoney(respawnMoney);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), eq(respawnMoney), any(), anyBoolean());
+    }
+
+    @Test
+    public void testUseShipConfigMoneyIfNoRespawnMoneyAndNoTutorial() {
+        int shipConfigMoney = 42;
+        when(shipConfig.getMoney()).thenReturn(shipConfigMoney);
+        respawnState.setRespawnMoney(0);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), eq((float) shipConfigMoney), any(), anyBoolean());
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -63,10 +63,10 @@ public class PlayerCreatorTest {
         when(solGame.getGalaxyFiller().getPlayerSpawnPos(any())).thenReturn(galaxySpawnPosition);
         when(shipConfig.getSpawnPos()).thenReturn(shipConfigSpawnPosition);
         mockShipBuilding();
+        when(solGame.getTutMan()).thenReturn(null);
     }
 
     private void mockShipBuilding() {
-        when(solGame.getTutMan()).thenReturn(null);
         when(solGame.getShipBuilder()).thenReturn(shipBuilder);
         when(shipBuilder.buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean())).thenReturn(farShip);
         when(farShip.toObject(any())).thenReturn(solShip);
@@ -81,28 +81,24 @@ public class PlayerCreatorTest {
 
     @Test
     public void testSpawnOnGalaxySpawnPositionSetsCameraPosition() {
-        when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
         verify(solGame.getCam()).setPos(eq(galaxySpawnPosition));
     }
 
     @Test
     public void testSpawnOnShipConfigSpawnPositionSetsShipPosition() {
-        when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), eq(shipConfigSpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
     }
 
     @Test
     public void testSpawnOnShipConfigSpawnPositionSetsCameraPosition() {
-        when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(solGame.getCam()).setPos(eq(shipConfigSpawnPosition));
     }
 
     @Test
     public void testBeaconHandlerNotInitializedIfNotMouseControl() {
-        when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(solGame.getBeaconHandler(),never()).init(any(),any());
     }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -237,6 +237,15 @@ public class PlayerCreatorTest {
         assertThat(shipItemContainer.getGroup(1)).containsExactly(item0);
     }
 
+    @Test
+    public void testReEquipRespawnItems() {
+        SolItem item = mock(SolItem.class);
+        when(item.isEquipped()).thenReturn(1);
+        respawnState.getRespawnItems().add(item);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solShip).maybeEquip(any(), eq(item), eq(true));
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 verification.position(),

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -265,6 +265,15 @@ public class PlayerCreatorTest {
         verify(solShip).maybeEquip(any(), eq(gun), eq(true),eq(true));
     }
 
+    @Test
+    public void testTutorialModeAddsItemsIfRespawnItemsAreEmpty() {
+        respawnState.getRespawnItems().clear();
+        when(solGame.getTutMan()).thenReturn(mock(TutorialManager.class));
+        int groupCountBefore = shipItemContainer.groupCount();
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        assertThat(shipItemContainer.groupCount()).isGreaterThan(groupCountBefore);
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 verification.position(),

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -22,6 +22,7 @@ import org.destinationsol.game.item.ItemContainer;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.ShipBuilder;
 import org.destinationsol.game.ship.SolShip;
+import org.destinationsol.ui.TutorialManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,6 +42,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class PlayerCreatorTest {
 
+    public static final float TUTORIAL_MONEY = 200f;
     private PlayerCreator playerCreator;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -144,5 +147,13 @@ public class PlayerCreatorTest {
         respawnState.setRespawnMoney(0);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), eq((float) shipConfigMoney), any(), anyBoolean());
+    }
+
+    @Test
+    public void testUseTutorialMoneyIfNoRespawnMoneyAndTutorialActive() {
+        when(solGame.getTutMan()).thenReturn(mock(TutorialManager.class));
+        respawnState.setRespawnMoney(0);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), eq(TUTORIAL_MONEY), any(), anyBoolean());
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -195,6 +195,26 @@ public class PlayerCreatorTest {
         verifyBuildNewFar(shipConfiguration().withItems(items));
     }
 
+    @Test
+    public void testGiveAmmoIfNewShipAndRespawnItemsIsEmpty() {
+        respawnState.getRespawnItems().clear();
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, true);
+        verifyBuildNewFar(shipConfiguration().withGiveAmmo(true));
+    }
+
+    @Test
+    public void testGiveNoAmmoIfNewShipAndRespawnItemsNotEmpty() {
+        respawnState.getRespawnItems().add(mock(SolItem.class));
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, true);
+        verifyBuildNewFar(shipConfiguration().withGiveAmmo(false));
+    }
+
+    @Test
+    public void testGiveNoAmmoIfNoNewShipAndRespawnItemsEmpty() {
+        respawnState.getRespawnItems().clear();
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verifyBuildNewFar(shipConfiguration().withGiveAmmo(false));
+    }
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
@@ -209,7 +229,7 @@ public class PlayerCreatorTest {
                 anyBoolean(),
                 verification.money(),
                 any(),
-                anyBoolean());
+                verification.giveAmmo());
     }
 
     private static class FarShipBuildConfiguration {
@@ -217,6 +237,7 @@ public class PlayerCreatorTest {
         Class<? extends Pilot> pilotClazz;
         HullConfig hullConfig;
         String items;
+        Boolean giveAmmo;
 
         FarShipBuildConfiguration withMoney(float money) {
             this.money = money;
@@ -238,6 +259,11 @@ public class PlayerCreatorTest {
             return this;
         }
 
+        FarShipBuildConfiguration withGiveAmmo(boolean giveAmmo) {
+            this.giveAmmo = giveAmmo;
+            return this;
+        }
+
         float money() {
             return money == null ? anyFloat() : eq(money.floatValue());
         }
@@ -252,6 +278,10 @@ public class PlayerCreatorTest {
 
         String items() {
             return items == null ? any() : eq(items);
+        }
+
+        boolean giveAmmo() {
+            return giveAmmo == null ? anyBoolean() : eq(giveAmmo.booleanValue());
         }
     }
 

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -239,12 +239,13 @@ public class PlayerCreatorTest {
     }
 
     @Test
-    public void testReEquipRespawnItems() {
+    public void testReEquipRespawnItemsSeen() {
         SolItem item = mock(SolItem.class);
         when(item.isEquipped()).thenReturn(1);
         respawnState.getRespawnItems().add(item);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(solShip).maybeEquip(any(), eq(item), eq(true));
+        assertThat(shipItemContainer.hasNew()).isFalse();
     }
 
     @Test
@@ -266,12 +267,13 @@ public class PlayerCreatorTest {
     }
 
     @Test
-    public void testTutorialModeAddsItemsIfRespawnItemsAreEmpty() {
+    public void testTutorialModeAddsSeenItemsIfRespawnItemsAreEmpty() {
         respawnState.getRespawnItems().clear();
         when(solGame.getTutMan()).thenReturn(mock(TutorialManager.class));
         int groupCountBefore = shipItemContainer.groupCount();
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         assertThat(shipItemContainer.groupCount()).isGreaterThan(groupCountBefore);
+        assertThat(shipItemContainer.hasNew()).isFalse();
     }
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -59,7 +59,7 @@ public class PlayerCreatorTest {
         playerCreator = new PlayerCreator();
         respawnState = new RespawnState();
         galaxySpawnPosition = new Vector2(42, 43);
-        shipConfigSpawnPosition = new Vector2(11,12);
+        shipConfigSpawnPosition = new Vector2(11, 12);
         when(solGame.getGalaxyFiller().getPlayerSpawnPos(any())).thenReturn(galaxySpawnPosition);
         when(shipConfig.getSpawnPos()).thenReturn(shipConfigSpawnPosition);
         mockShipBuilding();
@@ -100,6 +100,18 @@ public class PlayerCreatorTest {
     @Test
     public void testBeaconHandlerNotInitializedIfNotMouseControl() {
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
-        verify(solGame.getBeaconHandler(),never()).init(any(),any());
+        verify(solGame.getBeaconHandler(), never()).init(any(), any());
+    }
+
+    @Test
+    public void testSpawnOnGalaxySpawnPositionInitsBeaconHandlerOnMouseControl() {
+        playerCreator.createPlayer(shipConfig, true, respawnState, solGame, true, false);
+        verify(solGame.getBeaconHandler()).init(any(), eq(galaxySpawnPosition));
+    }
+
+    @Test
+    public void testSpawnOnShipConfigSpawnPositionInitsBeaconHandlerOnMouseControl() {
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, true, false);
+        verify(solGame.getBeaconHandler()).init(any(), eq(shipConfigSpawnPosition));
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.game.input.AiPilot;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.input.UiControlledPilot;
+import org.destinationsol.game.item.Gun;
 import org.destinationsol.game.item.ItemContainer;
 import org.destinationsol.game.item.SolItem;
 import org.destinationsol.game.ship.FarShip;
@@ -244,6 +245,15 @@ public class PlayerCreatorTest {
         respawnState.getRespawnItems().add(item);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(solShip).maybeEquip(any(), eq(item), eq(true));
+    }
+
+    @Test
+    public void testReEquipRespawnItemGunsPrimarySlot() {
+        Gun gun = mock(Gun.class);
+        when(gun.isEquipped()).thenReturn(1);
+        respawnState.getRespawnItems().add(gun);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solShip).maybeEquip(any(), eq(gun), eq(false),eq(true));
     }
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game;
+
+import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.game.item.ItemContainer;
+import org.destinationsol.game.ship.FarShip;
+import org.destinationsol.game.ship.ShipBuilder;
+import org.destinationsol.game.ship.SolShip;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerCreatorTest {
+
+    private PlayerCreator playerCreator;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private SolGame solGame;
+    @Mock
+    private ShipConfig shipConfig;
+    @Mock
+    private ShipBuilder shipBuilder;
+    private RespawnState respawnState;
+    private Vector2 galaxySpawnPosition;
+    @Mock
+    private FarShip farShip;
+    @Mock
+    private SolShip solShip;
+
+    @Before
+    public void setUp() {
+        playerCreator = new PlayerCreator();
+        respawnState = new RespawnState();
+        galaxySpawnPosition = new Vector2(42, 43);
+        when(solGame.getGalaxyFiller().getPlayerSpawnPos(any())).thenReturn(galaxySpawnPosition);
+        mockShipBuilding();
+    }
+
+    private void mockShipBuilding() {
+        when(solGame.getShipBuilder()).thenReturn(shipBuilder);
+        when(shipBuilder.buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean())).thenReturn(farShip);
+        when(farShip.toObject(any())).thenReturn(solShip);
+        when(solShip.getItemContainer()).thenReturn(new ItemContainer());
+    }
+
+    @Test
+    public void testSpawnOnGalaxySpawnPosition() {
+        when(solGame.getTutMan()).thenReturn(null);
+        playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
+        verify(shipBuilder).buildNewFar(any(), eq(galaxySpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
+    }
+}

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -20,6 +20,7 @@ import org.destinationsol.game.input.AiPilot;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.input.UiControlledPilot;
 import org.destinationsol.game.item.ItemContainer;
+import org.destinationsol.game.item.SolItem;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.ShipBuilder;
 import org.destinationsol.game.ship.SolShip;
@@ -36,6 +37,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.intThat;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -178,6 +180,13 @@ public class PlayerCreatorTest {
         verifyBuildNewFar(shipConfiguration().withHullConfig(hullConfig));
     }
 
+    @Test
+    public void testUseEmptyItemsIfRespawnItemsNotEmpty() throws Exception {
+        respawnState.getRespawnItems().add(mock(SolItem.class));
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verifyBuildNewFar(shipConfiguration().withItems(""));
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 any(),
@@ -185,7 +194,7 @@ public class PlayerCreatorTest {
                 anyFloat(),
                 anyFloat(),
                 verification.pilot(),
-                any(),
+                verification.items(),
                 verification.hullConfig(),
                 any(),
                 anyBoolean(),
@@ -198,6 +207,7 @@ public class PlayerCreatorTest {
         Float money;
         Class<? extends Pilot> pilotClazz;
         HullConfig hullConfig;
+        String items;
 
         FarShipBuildConfiguration withMoney(float money) {
             this.money = money;
@@ -214,6 +224,11 @@ public class PlayerCreatorTest {
             return this;
         }
 
+        FarShipBuildConfiguration withItems(String items){
+            this.items = items;
+            return this;
+        }
+
         float money() {
             return money == null ? anyFloat() : eq(money.floatValue());
         }
@@ -224,6 +239,10 @@ public class PlayerCreatorTest {
 
         HullConfig hullConfig() {
             return hullConfig == null ? any() : same(hullConfig);
+        }
+
+        String items(){
+            return items == null ? any() : eq(items);
         }
     }
 

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -20,7 +20,6 @@ import org.destinationsol.game.input.AiPilot;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.input.UiControlledPilot;
 import org.destinationsol.game.item.ItemContainer;
-import org.destinationsol.game.item.TradeConfig;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.ShipBuilder;
 import org.destinationsol.game.ship.SolShip;
@@ -36,8 +35,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -162,6 +161,14 @@ public class PlayerCreatorTest {
         verifyBuildNewFar(shipConfiguration().withMoney(TUTORIAL_MONEY));
     }
 
+    @Test
+    public void testUseRespawnHullIfNotNull() {
+        HullConfig hullConfig = mock(HullConfig.class);
+        respawnState.setRespawnHull(hullConfig);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verifyBuildNewFar(shipConfiguration().withHullConfig(hullConfig));
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 any(),
@@ -170,7 +177,7 @@ public class PlayerCreatorTest {
                 anyFloat(),
                 verification.pilot(),
                 any(),
-                any(),
+                verification.hullConfig(),
                 any(),
                 anyBoolean(),
                 verification.money(),
@@ -181,23 +188,33 @@ public class PlayerCreatorTest {
     private static class FarShipBuildConfiguration {
         Float money;
         Class<? extends Pilot> pilotClazz;
+        HullConfig hullConfig;
 
         FarShipBuildConfiguration withMoney(float money) {
             this.money = money;
             return this;
         }
 
-        FarShipBuildConfiguration withPilot(Class<? extends Pilot> pilotClazz){
+        FarShipBuildConfiguration withPilot(Class<? extends Pilot> pilotClazz) {
             this.pilotClazz = pilotClazz;
             return this;
         }
 
-        float money(){
+        FarShipBuildConfiguration withHullConfig(HullConfig hullConfig) {
+            this.hullConfig = hullConfig;
+            return this;
+        }
+
+        float money() {
             return money == null ? anyFloat() : eq(money.floatValue());
         }
 
-        Pilot pilot(){
+        Pilot pilot() {
             return pilotClazz == null ? any() : any(pilotClazz);
+        }
+
+        HullConfig hullConfig() {
+            return hullConfig == null ? any() : same(hullConfig);
         }
     }
 

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -37,7 +37,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.intThat;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -181,11 +180,21 @@ public class PlayerCreatorTest {
     }
 
     @Test
-    public void testUseEmptyItemsIfRespawnItemsNotEmpty() throws Exception {
+    public void testUseEmptyItemsIfRespawnItemsNotEmpty() {
         respawnState.getRespawnItems().add(mock(SolItem.class));
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verifyBuildNewFar(shipConfiguration().withItems(""));
     }
+
+    @Test
+    public void testUseShipConfigItemsIfRespawnItemsIsEmpty() {
+        respawnState.getRespawnItems().clear();
+        String items = "core:plasmaGun+core:blaster 0.36|core:smallShield";
+        when(shipConfig.getItems()).thenReturn(items);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verifyBuildNewFar(shipConfiguration().withItems(items));
+    }
+
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
@@ -224,7 +233,7 @@ public class PlayerCreatorTest {
             return this;
         }
 
-        FarShipBuildConfiguration withItems(String items){
+        FarShipBuildConfiguration withItems(String items) {
             this.items = items;
             return this;
         }
@@ -241,7 +250,7 @@ public class PlayerCreatorTest {
             return hullConfig == null ? any() : same(hullConfig);
         }
 
-        String items(){
+        String items() {
             return items == null ? any() : eq(items);
         }
     }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -276,6 +276,12 @@ public class PlayerCreatorTest {
         assertThat(shipItemContainer.hasNew()).isFalse();
     }
 
+    @Test
+    public void testAddShipDelayed() {
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solGame.getObjectManager()).addObjDelayed(solShip);
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 verification.position(),

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -47,6 +47,7 @@ public class PlayerCreatorTest {
     private ShipBuilder shipBuilder;
     private RespawnState respawnState;
     private Vector2 galaxySpawnPosition;
+    private Vector2 shipConfigSpawnPosition;
     @Mock
     private FarShip farShip;
     @Mock
@@ -57,7 +58,9 @@ public class PlayerCreatorTest {
         playerCreator = new PlayerCreator();
         respawnState = new RespawnState();
         galaxySpawnPosition = new Vector2(42, 43);
+        shipConfigSpawnPosition = new Vector2(11,12);
         when(solGame.getGalaxyFiller().getPlayerSpawnPos(any())).thenReturn(galaxySpawnPosition);
+        when(shipConfig.getSpawnPos()).thenReturn(shipConfigSpawnPosition);
         mockShipBuilding();
     }
 
@@ -73,5 +76,12 @@ public class PlayerCreatorTest {
         when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), eq(galaxySpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
+    }
+
+    @Test
+    public void testSpawnOnShipConfigSpawnPosition() {
+        when(solGame.getTutMan()).thenReturn(null);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(shipBuilder).buildNewFar(any(), eq(shipConfigSpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -63,6 +63,7 @@ public class PlayerCreatorTest {
     private FarShip farShip;
     @Mock
     private SolShip solShip;
+    private ItemContainer shipItemContainer;
 
     @Before
     public void setUp() {
@@ -81,7 +82,8 @@ public class PlayerCreatorTest {
         when(solGame.getShipBuilder()).thenReturn(shipBuilder);
         when(shipBuilder.buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean())).thenReturn(farShip);
         when(farShip.toObject(any())).thenReturn(solShip);
-        when(solShip.getItemContainer()).thenReturn(new ItemContainer());
+        shipItemContainer = new ItemContainer();
+        when(solShip.getItemContainer()).thenReturn(shipItemContainer);
     }
 
     @Test
@@ -221,6 +223,18 @@ public class PlayerCreatorTest {
     public void testShipIsUsedToCreateHero() {
         Hero hero = playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         assertThat(hero.getShip()).isSameAs(solShip);
+    }
+
+    @Test
+    public void testAddRespawnItems() {
+        SolItem item0 = mock(SolItem.class);
+        respawnState.getRespawnItems().add(item0);
+        SolItem item1 = mock(SolItem.class);
+        respawnState.getRespawnItems().add(item1);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        //new item groups are created at the start of the container, therefore item1 ends in group 0
+        assertThat(shipItemContainer.getGroup(0)).containsExactly(item1);
+        assertThat(shipItemContainer.getGroup(1)).containsExactly(item0);
     }
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -16,6 +16,8 @@
 package org.destinationsol.game;
 
 import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.game.input.AiPilot;
+import org.destinationsol.game.input.UiControlledPilot;
 import org.destinationsol.game.item.ItemContainer;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.ShipBuilder;
@@ -113,5 +115,17 @@ public class PlayerCreatorTest {
     public void testSpawnOnShipConfigSpawnPositionInitsBeaconHandlerOnMouseControl() {
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, true, false);
         verify(solGame.getBeaconHandler()).init(any(), eq(shipConfigSpawnPosition));
+    }
+
+    @Test
+    public void testMouseControlCreatesAiPilot() {
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, true, false);
+        verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(AiPilot.class), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
+    }
+
+    @Test
+    public void testNoMouseControlCreatesUiControlledPilot() {
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(UiControlledPilot.class), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -169,6 +169,15 @@ public class PlayerCreatorTest {
         verifyBuildNewFar(shipConfiguration().withHullConfig(hullConfig));
     }
 
+    @Test
+    public void testUseShipConfigHullIfRespawnHullIsNull() {
+        HullConfig hullConfig = mock(HullConfig.class);
+        respawnState.setRespawnHull(null);
+        when(shipConfig.getHull()).thenReturn(hullConfig);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verifyBuildNewFar(shipConfiguration().withHullConfig(hullConfig));
+    }
+
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
                 any(),

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -72,16 +72,30 @@ public class PlayerCreatorTest {
     }
 
     @Test
-    public void testSpawnOnGalaxySpawnPosition() {
+    public void testSpawnOnGalaxySpawnPositionSetsShipPosition() {
         when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), eq(galaxySpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
     }
 
     @Test
-    public void testSpawnOnShipConfigSpawnPosition() {
+    public void testSpawnOnGalaxySpawnPositionSetsCameraPosition() {
+        when(solGame.getTutMan()).thenReturn(null);
+        playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
+        verify(solGame.getCam()).setPos(eq(galaxySpawnPosition));
+    }
+
+    @Test
+    public void testSpawnOnShipConfigSpawnPositionSetsShipPosition() {
         when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), eq(shipConfigSpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
+    }
+
+    @Test
+    public void testSpawnOnShipConfigSpawnPositionSetsCameraPosition() {
+        when(solGame.getTutMan()).thenReturn(null);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solGame.getCam()).setPos(eq(shipConfigSpawnPosition));
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -128,4 +128,12 @@ public class PlayerCreatorTest {
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(UiControlledPilot.class), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
     }
+
+    @Test
+    public void testUseRespawnMoneyIfNotZero(){
+        float respawnMoney = 42f;
+        respawnState.setRespawnMoney(respawnMoney);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(shipBuilder).buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), eq(respawnMoney), any(), anyBoolean());
+    }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -87,7 +87,7 @@ public class PlayerCreatorTest {
     @Test
     public void testSpawnOnGalaxySpawnPositionSetsShipPosition() {
         playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
-        verify(shipBuilder).buildNewFar(any(), eq(galaxySpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
+        verifyBuildNewFar(shipConfiguration().withPosition(galaxySpawnPosition));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class PlayerCreatorTest {
     @Test
     public void testSpawnOnShipConfigSpawnPositionSetsShipPosition() {
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
-        verify(shipBuilder).buildNewFar(any(), eq(shipConfigSpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
+        verifyBuildNewFar(shipConfiguration().withPosition(shipConfigSpawnPosition));
     }
 
     @Test
@@ -225,7 +225,7 @@ public class PlayerCreatorTest {
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {
         verify(shipBuilder).buildNewFar(any(),
-                any(),
+                verification.position(),
                 any(),
                 anyFloat(),
                 anyFloat(),
@@ -240,11 +240,17 @@ public class PlayerCreatorTest {
     }
 
     private static class FarShipBuildConfiguration {
+        Vector2 position;
         Float money;
         Class<? extends Pilot> pilotClazz;
         HullConfig hullConfig;
         String items;
         Boolean giveAmmo;
+
+        FarShipBuildConfiguration withPosition(Vector2 position) {
+            this.position = position;
+            return this;
+        }
 
         FarShipBuildConfiguration withMoney(float money) {
             this.money = money;
@@ -269,6 +275,10 @@ public class PlayerCreatorTest {
         FarShipBuildConfiguration withGiveAmmo(boolean giveAmmo) {
             this.giveAmmo = giveAmmo;
             return this;
+        }
+
+        Vector2 position() {
+            return position == null ? any() : eq(position);
         }
 
         float money() {

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -33,6 +33,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
@@ -214,6 +215,12 @@ public class PlayerCreatorTest {
         respawnState.getRespawnItems().clear();
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verifyBuildNewFar(shipConfiguration().withGiveAmmo(false));
+    }
+
+    @Test
+    public void testShipIsUsedToCreateHero() {
+        Hero hero = playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        assertThat(hero.getShip()).isSameAs(solShip);
     }
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,6 +66,7 @@ public class PlayerCreatorTest {
     }
 
     private void mockShipBuilding() {
+        when(solGame.getTutMan()).thenReturn(null);
         when(solGame.getShipBuilder()).thenReturn(shipBuilder);
         when(shipBuilder.buildNewFar(any(), any(), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean())).thenReturn(farShip);
         when(farShip.toObject(any())).thenReturn(solShip);
@@ -73,7 +75,6 @@ public class PlayerCreatorTest {
 
     @Test
     public void testSpawnOnGalaxySpawnPositionSetsShipPosition() {
-        when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, true, respawnState, solGame, false, false);
         verify(shipBuilder).buildNewFar(any(), eq(galaxySpawnPosition), any(), anyFloat(), anyFloat(), any(), any(), any(), any(), anyBoolean(), anyFloat(), any(), anyBoolean());
     }
@@ -97,5 +98,12 @@ public class PlayerCreatorTest {
         when(solGame.getTutMan()).thenReturn(null);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(solGame.getCam()).setPos(eq(shipConfigSpawnPosition));
+    }
+
+    @Test
+    public void testBeaconHandlerNotInitializedIfNotMouseControl() {
+        when(solGame.getTutMan()).thenReturn(null);
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solGame.getBeaconHandler(),never()).init(any(),any());
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
+++ b/engine/src/test/java/org/destinationsol/game/PlayerCreatorTest.java
@@ -254,7 +254,7 @@ public class PlayerCreatorTest {
         when(gun.isEquipped()).thenReturn(1);
         respawnState.getRespawnItems().add(gun);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
-        verify(solShip).maybeEquip(any(), eq(gun), eq(false),eq(true));
+        verify(solShip).maybeEquip(any(), eq(gun), eq(false), eq(true));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class PlayerCreatorTest {
         when(gun.isEquipped()).thenReturn(2);
         respawnState.getRespawnItems().add(gun);
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
-        verify(solShip).maybeEquip(any(), eq(gun), eq(true),eq(true));
+        verify(solShip).maybeEquip(any(), eq(gun), eq(true), eq(true));
     }
 
     @Test
@@ -280,6 +280,12 @@ public class PlayerCreatorTest {
     public void testAddShipDelayed() {
         playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
         verify(solGame.getObjectManager()).addObjDelayed(solShip);
+    }
+
+    @Test
+    public void testResetObjectDelays() {
+        playerCreator.createPlayer(shipConfig, false, respawnState, solGame, false, false);
+        verify(solGame.getObjectManager()).resetDelays();
     }
 
     private void verifyBuildNewFar(FarShipBuildConfiguration verification) {


### PR DESCRIPTION
This PR moves player creation out of SolGame. The current class does still do a bit too much but at least it is tested and easier to understand.

Sidenotes for review:

- I added assertj for assertions, if we don't want to add this dependency I can replace the fluent assertions with old assertEquals.
- I had to remove final from HullConfig as the class alone is not instanciable and with final not able to mock. The cleaner solution would be to replace the class access with an interface and keep the backing up class final. This would involve chaning all calling places (~130) to the new interface which is something I did not want to include in this PR. The class as-is is still immutable however it could be extended and then break but that may be a bit esotheric depending how often we extend in destsol :)
- Can be reviewed commit-wise. I prepared the method for extraction first without changing the controlflow, then put it under test and refactored everything after the tests were in place without touching the tests again. Also did a short manual test session with respawn, reload and hiring a mercenary then reloading with him.