### PR TITLE
Remove SolGame parameter from some functions

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -47,14 +47,14 @@ public class SaveManager {
 
     private static final String FILE_NAME = "prevShip.ini";
 
-    public static void writeShips(HullConfig hull, float money, List<SolItem> itemsList, SolGame game, HullConfigManager hullConfigManager) {
+    public static void writeShips(HullConfig hull, float money, List<SolItem> itemsList, Hero hero, HullConfigManager hullConfigManager) {
         String hullName = hullConfigManager.getName(hull);
 
-        writeMercs(game, hullConfigManager);
+        writeMercs(hero, hullConfigManager);
 
         String items = itemsToString(itemsList);
 
-        Vector2 pos = game.getHero().getPosition();
+        Vector2 pos = hero.getPosition();
 
         IniReader.write(FILE_NAME, "hull", hullName, "money", (int) money, "items", items, "x", pos.x, "y", pos.y);
     }
@@ -91,12 +91,12 @@ public class SaveManager {
      * Writes the player's mercenaries to their JSON file.
      * The file will be created if it doesn't exist.
      *
-     * @param game The instance of the game we're dealing with
+     * @param hero The hero we're dealing with
      */
-    private static void writeMercs(SolGame game, HullConfigManager hullConfigManager) {
+    private static void writeMercs(Hero hero, HullConfigManager hullConfigManager) {
         PrintWriter writer;
 
-        ItemContainer mercenaries = game.getHero().getShipUnchecked().getTradeContainer().getMercs();
+        ItemContainer mercenaries = hero.getShipUnchecked().getTradeContainer().getMercs();
 
         List<JsonObject> jsons = new ArrayList<JsonObject>();
 

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -169,7 +169,7 @@ public class SaveManager {
         return resourceExists(fileName);
     }
 
-    public static ShipConfig readShip(HullConfigManager hullConfigs, ItemManager itemManager, SolGame game) {
+    public static ShipConfig readShip(HullConfigManager hullConfigs, ItemManager itemManager) {
         IniReader ir = new IniReader(SAVE_FILE_NAME, null);
 
         String hullName = ir.getString("hull", null);

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -79,7 +79,7 @@ public class ShipConfig {
         return res;
     }
 
-    public static ShipConfig load(HullConfigManager hullConfigs, String shipName, ItemManager itemManager, SolGame game) {
+    public static ShipConfig load(HullConfigManager hullConfigs, String shipName, ItemManager itemManager) {
         Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-zA-Z]*:playerSpawnConfig");
 
         ShipConfig shipConfig = null;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -243,7 +243,7 @@ public class SolGame {
             items = respawnState.getRespawnItems();
         }
 
-        SaveManager.writeShips(hull, money, items, this, hullConfigManager);
+        SaveManager.writeShips(hull, money, items, hero, hullConfigManager);
     }
 
     public GameScreens getScreens() {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -156,7 +156,7 @@ public class SolGame {
          * If shipName is not null then a new ship has to be created.
          */
         boolean isNewShip = shipName != null;
-        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, this, isNewShip, hullConfigManager);
+        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, itemManager, isNewShip, hullConfigManager);
         if (!respawnState.isPlayerRespawned()) {
             this.getGalaxyFiller().fill(this, hullConfigManager, this.getItemMan(), shipConfig.hull.getInternalName().split(":")[0]);
         }
@@ -168,11 +168,11 @@ public class SolGame {
                 isNewShip);
     }
 
-    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, SolGame game, boolean isNewShip, HullConfigManager hullConfigManager) {
+    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, ItemManager itemManager, boolean isNewShip, HullConfigManager hullConfigManager) {
         if (isNewShip) {
-            return ShipConfig.load(hullConfigManager, shipName, game.getItemMan(), game);
+            return ShipConfig.load(hullConfigManager, shipName, itemManager);
         } else {
-            return SaveManager.readShip(hullConfigManager, game.getItemMan(), game);
+            return SaveManager.readShip(hullConfigManager, itemManager);
         }
     }
 

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -143,22 +143,22 @@ public class SolGame {
         // from this point we're ready!
         planetManager.fill(solNames);
         respawnState = new RespawnState();
-        createGame(shipName, isNewGame, hullConfigManager);
+        createGame(shipName, isNewGame);
         if (!isNewGame) {
-            createAndSpawnMercenariesFromSave(hullConfigManager);
+            createAndSpawnMercenariesFromSave();
         }
         SolMath.checkVectorsTaken(null);
     }
 
-    private void createGame(String shipName, boolean shouldSpawnOnGalaxySpawnPosition, HullConfigManager hullConfigManager) {
+    private void createGame(String shipName, boolean shouldSpawnOnGalaxySpawnPosition) {
         /*
          * shipName will be null on respawn and continue, meaning the old ship will be loaded.
          * If shipName is not null then a new ship has to be created.
          */
         boolean isNewShip = shipName != null;
-        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, itemManager, isNewShip, hullConfigManager);
+        ShipConfig shipConfig = readShipFromConfigOrLoadFromSaveIfNull(shipName, isNewShip);
         if (!respawnState.isPlayerRespawned()) {
-            this.getGalaxyFiller().fill(this, hullConfigManager, this.getItemMan(), shipConfig.hull.getInternalName().split(":")[0]);
+            galaxyFiller.fill(this, hullConfigManager, itemManager, shipConfig.hull.getInternalName().split(":")[0]);
         }
         hero = new PlayerCreator().createPlayer(shipConfig,
                 shouldSpawnOnGalaxySpawnPosition,
@@ -168,7 +168,7 @@ public class SolGame {
                 isNewShip);
     }
 
-    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, ItemManager itemManager, boolean isNewShip, HullConfigManager hullConfigManager) {
+    private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, boolean isNewShip) {
         if (isNewShip) {
             return ShipConfig.load(hullConfigManager, shipName, itemManager);
         } else {
@@ -176,7 +176,7 @@ public class SolGame {
         }
     }
 
-    private void createAndSpawnMercenariesFromSave(HullConfigManager hullConfigManager) {
+    private void createAndSpawnMercenariesFromSave() {
         List<MercItem> mercenaryItems = new MercenarySaveLoader()
                 .loadMercenariesFromSave(hullConfigManager, itemManager, MERC_SAVE_FILE);
         for (MercItem mercenaryItem : mercenaryItems) {
@@ -373,7 +373,7 @@ public class SolGame {
                 objectManager.removeObjDelayed(hero.getTranscendentHero());
             }
         }
-        createGame(null, true, hullConfigManager);
+        createGame(null, true);
     }
 
     public FactionManager getFactionMan() {


### PR DESCRIPTION
I've removed the unnecessary SolGame parameter from:

- `SaveManager.writeMercs(...)` in favour of Hero
- `SaveManager.writeShips(...)` in favour of Hero
- `SaveManager.readShip(...)` because it was unused
- `ShipConfig.load(...)` because it was unused
- `SolGame.readShipFromConfigOrLoadFromSaveIfNull(...)` in favour of ItemManager