### PR TITLE
Target velocity based engine with throttling

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/input/AiPilot.java
+++ b/engine/src/main/java/org/destinationsol/game/input/AiPilot.java
@@ -52,6 +52,9 @@ public class AiPilot implements Pilot {
     private PlanetBind myPlanetBind;
     private float myReEquipAwait;
 
+    private float orientation;
+    private float throttle;
+
     public AiPilot(MoveDestProvider destProvider, boolean collectsItems, Faction faction,
                    boolean shootAtObstacles, String mapHint, float detectionDist) {
         myDestProvider = destProvider;
@@ -121,7 +124,7 @@ public class AiPilot implements Pilot {
         Vector2 enemySpeed = nearestEnemy == null ? null : nearestEnemy.getSpeed();
         float enemyApproxRad = nearestEnemy == null ? 0 : nearestEnemy.getHull().config.getApproxRadius();
         myShooter.update(ship, enemyPos, moverActive, canShoot, enemySpeed, enemyApproxRad);
-        if (hasEngine && !moverActive && !isShooterRotated()) {
+        if (hasEngine && !moverActive && !myShooter.isRotatingTowardsTarget()) {
             myMover.rotateOnIdle(ship, np, dest, shouldStopNearDest, maxIdleDist);
         }
 
@@ -130,6 +133,27 @@ public class AiPilot implements Pilot {
         } else {
             myReEquipAwait -= game.getTimeStep();
         }
+
+        throttle = SolMath.clamp(myMover.getThrottle());
+
+        if (myShooter.isRotatingTowardsTarget()) {
+            orientation = myShooter.getDesiredOrientation();
+        }
+        else {
+            orientation = myMover.getDesiredOrientation();
+        }
+
+        orientation = SolMath.norm(orientation);
+    }
+
+    @Override
+    public float getThrottle() {
+        return throttle;
+    }
+
+    @Override
+    public float getOrientation() {
+        return orientation;
     }
 
     private float getMaxIdleDist(HullConfig hullConfig) {
@@ -150,25 +174,6 @@ public class AiPilot implements Pilot {
             return !g2.config.fixed ? null : true;
         }
         return false;
-    }
-
-    private boolean isShooterRotated() {
-        return myShooter.isLeft() || myShooter.isRight();
-    }
-
-    @Override
-    public boolean isUp() {
-        return myMover.isUp();
-    }
-
-    @Override
-    public boolean isLeft() {
-        return myMover.isLeft() || myShooter.isLeft();
-    }
-
-    @Override
-    public boolean isRight() {
-        return myMover.isRight() || myShooter.isRight();
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/input/Pilot.java
+++ b/engine/src/main/java/org/destinationsol/game/input/Pilot.java
@@ -16,6 +16,7 @@
 
 package org.destinationsol.game.input;
 
+import org.destinationsol.common.SolMath;
 import org.destinationsol.game.Faction;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.ship.FarShip;
@@ -24,11 +25,9 @@ import org.destinationsol.game.ship.SolShip;
 public interface Pilot {
     void update(SolGame game, SolShip ship, SolShip nearestEnemy);
 
-    boolean isUp();
+    float getThrottle();
 
-    boolean isLeft();
-
-    boolean isRight();
+    float getOrientation();
 
     boolean isShoot();
 
@@ -54,7 +53,7 @@ public interface Pilot {
 
     public static final class Utils {
         public static boolean isIdle(Pilot p) {
-            return !(p.isUp() || p.isShoot() || p.isShoot2() || p.isAbility());
+            return !(p.getThrottle() != 0 || p.isShoot() || p.isShoot2() || p.isAbility());
         }
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/input/Pilot.java
+++ b/engine/src/main/java/org/destinationsol/game/input/Pilot.java
@@ -25,8 +25,14 @@ import org.destinationsol.game.ship.SolShip;
 public interface Pilot {
     void update(SolGame game, SolShip ship, SolShip nearestEnemy);
 
+    /**
+     * Returns the throttle applied to the engine.
+     */
     float getThrottle();
 
+    /**
+     * Returns the angle at which to orient the ship.
+     */
     float getOrientation();
 
     boolean isShoot();

--- a/engine/src/main/java/org/destinationsol/game/input/Shooter.java
+++ b/engine/src/main/java/org/destinationsol/game/input/Shooter.java
@@ -29,8 +29,9 @@ public class Shooter {
     public static final float MIN_SHOOT_AAD = 2f;
     private boolean myShoot;
     private boolean myShoot2;
-    private boolean myRight;
-    private boolean myLeft;
+
+    private float desiredOrientation;
+    private boolean rotatingTowardsTarget;
 
     Shooter() {
     }
@@ -67,8 +68,7 @@ public class Shooter {
 
     public void update(SolShip ship, Vector2 enemyPos, boolean notRotate, boolean canShoot, Vector2 enemySpeed,
                        float enemyApproxRad) {
-        myLeft = false;
-        myRight = false;
+        rotatingTowardsTarget = false;
         myShoot = false;
         myShoot2 = false;
         Vector2 shipPos = ship.getPosition();
@@ -127,14 +127,10 @@ public class Shooter {
         if (notRotate) {
             return;
         }
-        Boolean needsToTurn = Mover.needsToTurn(shipAngle, shootAngle, ship.getRotationSpeed(), ship.getRotationAcceleration(), MIN_SHOOT_AAD);
-        if (needsToTurn != null) {
-            if (needsToTurn) {
-                myRight = true;
-            } else {
-                myLeft = true;
-            }
-        }
+
+        rotatingTowardsTarget = true;
+
+        desiredOrientation = shootAngle;
     }
 
     // returns gun if it's fixed & can shoot
@@ -179,11 +175,11 @@ public class Shooter {
         return myShoot2;
     }
 
-    public boolean isLeft() {
-        return myLeft;
+    public boolean isRotatingTowardsTarget() {
+        return rotatingTowardsTarget;
     }
 
-    public boolean isRight() {
-        return myRight;
+    public float getDesiredOrientation() {
+        return desiredOrientation;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/input/UiControlledPilot.java
+++ b/engine/src/main/java/org/destinationsol/game/input/UiControlledPilot.java
@@ -20,15 +20,15 @@ import org.destinationsol.Const;
 import org.destinationsol.game.Faction;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.screens.MainScreen;
+import org.destinationsol.game.screens.ShipUiControl;
 import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.SolShip;
 
 public class UiControlledPilot implements Pilot {
-
-    private final MainScreen myScreen;
+    private final ShipUiControl uiControl;
 
     public UiControlledPilot(MainScreen screen) {
-        myScreen = screen;
+        uiControl = screen.shipControl;
     }
 
     @Override
@@ -36,28 +36,23 @@ public class UiControlledPilot implements Pilot {
     }
 
     @Override
-    public boolean isUp() {
-        return myScreen.isUp();
+    public float getThrottle() {
+        return uiControl.getThrottle();
     }
 
     @Override
-    public boolean isLeft() {
-        return myScreen.isLeft();
-    }
-
-    @Override
-    public boolean isRight() {
-        return myScreen.isRight();
+    public float getOrientation() {
+        return uiControl.getOrientation();
     }
 
     @Override
     public boolean isShoot() {
-        return myScreen.isShoot();
+        return uiControl.isShoot();
     }
 
     @Override
     public boolean isShoot2() {
-        return myScreen.isShoot2();
+        return uiControl.isShoot2();
     }
 
     @Override
@@ -67,7 +62,7 @@ public class UiControlledPilot implements Pilot {
 
     @Override
     public boolean isAbility() {
-        return myScreen.isAbility();
+        return uiControl.isAbility();
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/item/Engine.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Engine.java
@@ -126,7 +126,7 @@ public class Engine implements SolItem {
 
             boolean isBig = rootNode.getBoolean("big");
             float rotationAcceleration = isBig ? 100f : 515f;
-            float acceleration = 2f;
+            float acceleration = 7.5f;
             float maxRotationSpeed = isBig ? 40f : 230f;
 
             json.dispose();

--- a/engine/src/main/java/org/destinationsol/game/screens/MainScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainScreen.java
@@ -492,18 +492,6 @@ public class MainScreen implements SolUiScreen {
         shipControl.blur();
     }
 
-    public boolean isLeft() {
-        return shipControl.isLeft();
-    }
-
-    public boolean isRight() {
-        return shipControl.isRight();
-    }
-
-    public boolean isUp() {
-        return shipControl.isUp();
-    }
-
     public boolean isDown() {
         return shipControl.isDown();
     }

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipControllerControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipControllerControl.java
@@ -180,6 +180,11 @@ public class ShipControllerControl implements ShipUiControl {
     public void update(SolApplication solApplication, boolean enabled) {
         retrieveMovementAxesInput(solApplication);
 
+        // Consider input in camera local space so that ship always moves on the screen in
+        // the same (or inverted) direction in which the joystick is moved
+        // Rotate input vector from camera local space to world space
+        SolMath.rotate(movementAxesInput,  solApplication.getGame().getCam().getAngle());
+
         float movementAxesInputLen;
 
         // Dead zone
@@ -215,6 +220,11 @@ public class ShipControllerControl implements ShipUiControl {
     }
 
     private void retrieveMovementAxesInput(SolApplication solApplication) {
+        if (Controllers.getControllers().size == 0) {
+            logger.warn("No controller found!");
+            return;
+        }
+
         final GameOptions gameOptions = solApplication.getOptions();
         Controller controller = Controllers.getControllers().first();
 

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipControllerControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipControllerControl.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector3;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.common.SolMath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,9 @@ import org.slf4j.LoggerFactory;
 public class ShipControllerControl implements ShipUiControl {
     private static Logger logger = LoggerFactory.getLogger(ShipControllerControl.class);
 
+    private static final float THROTTLE_INCREMENT = 0.1f;
+    private static final float ORIENTATION_INCREMENT = 0.2f * SolMath.radDeg;
+
     private boolean controllerShoot;
     private boolean controllerShoot2;
     private boolean controllerAbility;
@@ -60,6 +64,9 @@ public class ShipControllerControl implements ShipUiControl {
     private boolean controllerRight;
     private boolean controllerUp;
     private boolean controllerDown;
+
+    private float orientation;
+    private float throttle;
 
     ShipControllerControl(SolApplication solApplication) {
         final GameOptions gameOptions = solApplication.getOptions();
@@ -190,18 +197,35 @@ public class ShipControllerControl implements ShipUiControl {
     }
 
     @Override
-    public boolean isLeft() {
-        return controllerLeft;
+    public void update(SolApplication solApplication, boolean enabled) {
+        // TODO: Use joystick direction to calculate orientation and throttle
+        if (controllerUp) {
+            throttle += THROTTLE_INCREMENT;
+        }
+        if (controllerDown) {
+            throttle -= THROTTLE_INCREMENT;
+        }
+
+        throttle = SolMath.clamp(throttle);
+
+        if (controllerLeft) {
+            orientation -= ORIENTATION_INCREMENT;
+        }
+        if (controllerRight) {
+            orientation += ORIENTATION_INCREMENT;
+        }
+
+        orientation = SolMath.norm(orientation);
     }
 
     @Override
-    public boolean isRight() {
-        return controllerRight;
+    public float getThrottle() {
+        return throttle;
     }
 
     @Override
-    public boolean isUp() {
-        return controllerUp;
+    public float getOrientation() {
+        return orientation;
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipKbControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipKbControl.java
@@ -17,6 +17,7 @@ package org.destinationsol.game.screens;
 
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.common.SolMath;
 import org.destinationsol.game.Hero;
 import org.destinationsol.game.item.Gun;
 import org.destinationsol.ui.SolUiControl;
@@ -24,6 +25,9 @@ import org.destinationsol.ui.SolUiControl;
 import java.util.List;
 
 public class ShipKbControl implements ShipUiControl {
+    private static final float THROTTLE_INCREMENT = 0.1f;
+    private static final float ORIENTATION_INCREMENT = 0.2f * SolMath.radDeg;
+
     public final SolUiControl leftCtrl;
     public final SolUiControl rightCtrl;
     public final SolUiControl upCtrl;
@@ -31,6 +35,9 @@ public class ShipKbControl implements ShipUiControl {
     public final SolUiControl shootCtrl;
     public final SolUiControl shoot2Ctrl;
     public final SolUiControl abilityCtrl;
+
+    private float throttle;
+    private float orientation;
 
     ShipKbControl(SolApplication solApplication, float resolutionRatio, List<SolUiControl> controls) {
         GameOptions gameOptions = solApplication.getOptions();
@@ -86,21 +93,34 @@ public class ShipKbControl implements ShipUiControl {
         Gun g2 = hero.isTranscendent() ? null : hero.getHull().getGun(true);
         shoot2Ctrl.setEnabled(g2 != null && g2.ammo > 0);
         abilityCtrl.setEnabled(hero.isNonTranscendent() && hero.canUseAbility());
+
+        if (upCtrl.isJustOff()) {
+            throttle += THROTTLE_INCREMENT;
+        }
+        if (myDownCtrl.isJustOff()) {
+            throttle -= THROTTLE_INCREMENT;
+        }
+
+        throttle = SolMath.clamp(throttle);
+
+        if (leftCtrl.isJustOff()) {
+            orientation -= ORIENTATION_INCREMENT;
+        }
+        if (rightCtrl.isJustOff()) {
+            orientation += ORIENTATION_INCREMENT;
+        }
+
+        orientation = SolMath.norm(orientation);
     }
 
     @Override
-    public boolean isLeft() {
-        return leftCtrl.isOn();
+    public float getThrottle() {
+        return throttle;
     }
 
     @Override
-    public boolean isRight() {
-        return rightCtrl.isOn();
-    }
-
-    @Override
-    public boolean isUp() {
-        return upCtrl.isOn();
+    public float getOrientation() {
+        return orientation;
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipMixedControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipMixedControl.java
@@ -33,6 +33,8 @@ import org.destinationsol.ui.SolUiControl;
 import java.util.List;
 
 public class ShipMixedControl implements ShipUiControl {
+    private static final float THROTTLE_INCREMENT = 0.1f;
+
     public final SolUiControl upCtrl;
     public final SolUiControl shootCtrl;
     public final SolUiControl shoot2Ctrl;
@@ -40,8 +42,9 @@ public class ShipMixedControl implements ShipUiControl {
     private final SolUiControl myDownCtrl;
     private final Vector2 myMouseWorldPos;
     private final TextureAtlas.AtlasRegion myCursor;
-    private boolean myRight;
-    private boolean myLeft;
+
+    private float orientation;
+    private float throttle;
 
     ShipMixedControl(SolApplication solApplication, List<SolUiControl> controls) {
         GameOptions gameOptions = solApplication.getOptions();
@@ -72,15 +75,8 @@ public class ShipMixedControl implements ShipUiControl {
         if (hero.isNonTranscendent()) {
             myMouseWorldPos.set(Gdx.input.getX(), Gdx.input.getY());
             game.getCam().screenToWorld(myMouseWorldPos);
-            float desiredAngle = SolMath.angle(hero.getPosition(), myMouseWorldPos);
-            Boolean ntt = Mover.needsToTurn(hero.getAngle(), desiredAngle, hero.getRotationSpeed(), hero.getRotationAcceleration(), Shooter.MIN_SHOOT_AAD);
-            if (ntt != null) {
-                if (ntt) {
-                    myRight = true;
-                } else {
-                    myLeft = true;
-                }
-            }
+            orientation = SolMath.angle(hero.getPosition(), myMouseWorldPos);
+
             if (!im.isMouseOnUi()) {
                 if (Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
                     shootCtrl.maybeFlashPressed(gameOptions.getKeyShoot());
@@ -93,21 +89,26 @@ public class ShipMixedControl implements ShipUiControl {
                 }
             }
         }
+
+        // TODO: Probably make a throttle slider of some sort too
+        if (upCtrl.isJustOff()) {
+            throttle += THROTTLE_INCREMENT;
+        }
+        if (myDownCtrl.isJustOff()) {
+            throttle -= THROTTLE_INCREMENT;
+        }
+
+        throttle = SolMath.clamp(throttle);
     }
 
     @Override
-    public boolean isLeft() {
-        return myLeft;
+    public float getThrottle() {
+        return throttle;
     }
 
     @Override
-    public boolean isRight() {
-        return myRight;
-    }
-
-    @Override
-    public boolean isUp() {
-        return upCtrl.isOn();
+    public float getOrientation() {
+        return orientation;
     }
 
     @Override
@@ -133,11 +134,5 @@ public class ShipMixedControl implements ShipUiControl {
     @Override
     public TextureAtlas.AtlasRegion getInGameTex() {
         return myCursor;
-    }
-
-    @Override
-    public void blur() {
-        myLeft = false;
-        myRight = false;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipMouseControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipMouseControl.java
@@ -63,18 +63,13 @@ public class ShipMouseControl implements ShipUiControl {
     }
 
     @Override
-    public boolean isLeft() {
-        return false;
+    public float getThrottle() {
+        return 0;
     }
 
     @Override
-    public boolean isRight() {
-        return false;
-    }
-
-    @Override
-    public boolean isUp() {
-        return false;
+    public float getOrientation() {
+        return 0;
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipUiControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipUiControl.java
@@ -23,11 +23,9 @@ public interface ShipUiControl {
         // Intentionally left blank
     }
 
-    boolean isLeft();
+    float getThrottle();
 
-    boolean isRight();
-
-    boolean isUp();
+    float getOrientation();
 
     boolean isDown();
 

--- a/engine/src/main/java/org/destinationsol/game/ship/Door.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/Door.java
@@ -79,7 +79,7 @@ public class Door {
             }
             SolShip ship2 = (SolShip) o;
             Pilot pilot2 = ship2.getPilot();
-            if (!pilot2.isUp()) {
+            if (pilot2.getThrottle() == 0) {
                 continue;
             }
             if (factionManager.areEnemies(pilot2.getFaction(), faction)) {

--- a/engine/src/main/java/org/destinationsol/game/ship/ForceBeacon.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/ForceBeacon.java
@@ -55,7 +55,7 @@ public class ForceBeacon {
             }
             SolShip ship = (SolShip) o;
             Pilot pilot = ship.getPilot();
-            if (pilot.isUp() || pilot.isLeft() || pilot.isRight()) {
+            if (pilot.getThrottle() != 0) {
                 continue;
             }
             if (game.getFactionMan().areEnemies(faction, pilot.getFaction())) {

--- a/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
@@ -18,9 +18,11 @@ package org.destinationsol.game.ship;
 
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
+import com.badlogic.gdx.physics.box2d.Transform;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.input.Pilot;
+import org.destinationsol.game.input.Shooter;
 import org.destinationsol.game.item.Engine;
 import org.destinationsol.game.ship.hulls.Hull;
 
@@ -36,47 +38,56 @@ public class ShipEngine {
         myItem = engine;
     }
 
-    public void update(float angle, SolGame game, Pilot provider, Body body, Vector2 speed, boolean controlsEnabled,
+    public void update(float angle, SolGame game, Pilot pilot, Body body, Vector2 speed, boolean controlsEnabled,
                        float mass, Hull hull) {
-
-        boolean working = applyInput(game, angle, provider, body, speed, controlsEnabled, mass);
-        game.getPartMan().updateAllHullEmittersOfType(hull, "engine", working);
+        boolean engineRunning = applyInput(game, angle, pilot, body, speed, controlsEnabled, mass);
+        game.getPartMan().updateAllHullEmittersOfType(hull, "engine", engineRunning);
     }
 
-    private boolean applyInput(SolGame cmp, float shipAngle, Pilot provider, Body body, Vector2 speed,
+    private boolean applyInput(SolGame game, float shipAngle, Pilot pilot, Body body, Vector2 speed,
                                boolean controlsEnabled, float mass) {
         boolean speedOk = SolMath.canAccelerate(shipAngle, speed);
-        boolean working = controlsEnabled && provider.isUp() && speedOk;
+        boolean engineRunning = controlsEnabled && pilot.getThrottle() != 0 && speedOk;
 
         Engine e = myItem;
-        if (working) {
-            Vector2 v = SolMath.fromAl(shipAngle, mass * e.getAcceleration());
+        if (engineRunning) {
+            Vector2 v = SolMath.fromAl(shipAngle, pilot.getThrottle() * mass * e.getAcceleration());
             body.applyForceToCenter(v, true);
             SolMath.free(v);
         }
 
-        float ts = cmp.getTimeStep();
-        float rotationSpeed = body.getAngularVelocity() * SolMath.radDeg;
-        float desiredRotationSpeed = 0;
-        float rotAcc = e.getRotationAcceleration();
-        boolean l = controlsEnabled && provider.isLeft();
-        boolean r = controlsEnabled && provider.isRight();
-        float absRotationSpeed = SolMath.abs(rotationSpeed);
-        if (absRotationSpeed < e.getMaxRotationSpeed() && l != r) {
-            desiredRotationSpeed = SolMath.toInt(r) * e.getMaxRotationSpeed();
-            if (absRotationSpeed < MAX_RECOVER_ROT_SPD) {
-                if (myRecoverAwait > 0) {
-                    myRecoverAwait -= ts;
-                }
-                if (myRecoverAwait <= 0) {
-                    rotAcc *= RECOVER_MUL;
-                }
-            }
-        } else {
-            myRecoverAwait = RECOVER_AWAIT;
+        float orientation = body.getAngle() * SolMath.radDeg;
+        float angularVelocity = body.getAngularVelocity() * SolMath.radDeg;
+
+        float targetOrientation = pilot.getOrientation();
+
+        float angularDisplacement = SolMath.norm(targetOrientation - orientation);
+
+        float absAngularAcceleration = e.getRotationAcceleration();
+
+        float maxStoppingDistance = 0.5f * angularVelocity * angularVelocity / absAngularAcceleration;
+
+        float angularAcceleration;
+
+        // If we are close to where we want to aim, stop rotating
+        if (Math.abs(angularDisplacement) <= Shooter.MIN_SHOOT_AAD) {
+            angularAcceleration = -angularVelocity / game.getTimeStep();
         }
-        body.setAngularVelocity(SolMath.degRad * SolMath.approach(rotationSpeed, desiredRotationSpeed, rotAcc * ts));
-        return working;
+        // If angular speed is greater than maximum angular speed OR
+        // if angular displacement is just enough to stop the body in time,
+        // accelerate in the opposite direction of angular velocity to slow down
+        else if (Math.abs(angularVelocity) > e.getMaxRotationSpeed()) {
+            angularAcceleration = -Math.signum(angularVelocity) * absAngularAcceleration;
+        } else if (Math.abs(angularDisplacement) <= maxStoppingDistance) {
+            angularAcceleration = -Math.signum(angularVelocity) * absAngularAcceleration;
+        } else {
+            // Otherwise, accelerate in direction of angular displacement
+            angularAcceleration = Math.signum(angularDisplacement) * absAngularAcceleration;
+        }
+
+        body.applyTorque(body.getInertia() * angularAcceleration * SolMath.degRad, true);
+
+        return engineRunning;
     }
 
     public Engine getItem() {


### PR DESCRIPTION
# Motivation
Inspired by the controls of the game Galaxy on Fire 2, this PR introduces a target velocity based `ShipEngine`, which constrains the ship speed instead of accelerating indefinitely (till the max velocity cap, rather) like the current approach. The ship speed constraint is determined by scaling the maximum possible speed with the throttle, making slowing down and fine maneuvering _much_ easier. With this system, stopping the ship is as simple as setting the throttle to zero.

This PR is based on the continuous input system introduced in #286, and should be merged after it. This PR is pretty small and changes `ShipEngine` and `Engine` only. The extraneous changes in this PR which have already introduced in #286 should disappear after #286 is merged.

# Changes
- The engine now accelerates only to maintain constant speed
- The acceleration property in `Engine` has been increased to make the controls feel more responsive, in line with the intentions of this PR.

# Usage
Increase or decrease the throttle to see a corresponding increase or decrease in ship speed.