### PR TITLE
Fixed work sounds crash

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/gun/GunMount.java
+++ b/engine/src/main/java/org/destinationsol/game/gun/GunMount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class GunMount {
         }
 
         float gunAngle = shipAngle + myRelGunAngle;
-        myGun.update(ic, game, gunAngle, creator, shouldShoot, faction, creator.getHull());
+        myGun.update(ic, game, gunAngle, creator, shouldShoot, faction, creator);
     }
 
     public Gun getGun() {

--- a/engine/src/main/java/org/destinationsol/game/gun/SolGun.java
+++ b/engine/src/main/java/org/destinationsol/game/gun/SolGun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.destinationsol.game.particle.LightSource;
 import org.destinationsol.game.planet.Planet;
 import org.destinationsol.game.projectile.Projectile;
 import org.destinationsol.game.projectile.ProjectileConfig;
-import org.destinationsol.game.ship.hulls.Hull;
+import org.destinationsol.game.ship.SolShip;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +77,7 @@ public class SolGun {
         return myDrawables;
     }
 
-    private void shoot(Vector2 gunSpeed, SolGame game, float gunAngle, Vector2 muzzlePos, Faction faction, SolObject creator, Hull hull) {
+    private void shoot(Vector2 gunSpeed, SolGame game, float gunAngle, Vector2 muzzlePos, Faction faction, SolObject creator) {
         Vector2 baseSpeed = gunSpeed;
         Clip.Config cc = myItem.config.clipConf;
         if (cc.projConfig.zeroAbsSpeed) {
@@ -104,7 +104,7 @@ public class SolGun {
         game.getSoundManager().play(game, myItem.config.shootSound, muzzlePos, creator);
     }
 
-    public void update(ItemContainer itemContainer, SolGame game, float gunAngle, SolObject creator, boolean shouldShoot, Faction faction, Hull hull) {
+    public void update(ItemContainer itemContainer, SolGame game, float gunAngle, SolObject creator, boolean shouldShoot, Faction faction, SolShip ship) {
         float baseAngle = creator.getAngle();
         Vector2 basePos = creator.getPosition();
         float gunRelAngle = gunAngle - baseAngle;
@@ -135,10 +135,10 @@ public class SolGun {
         }
 
         boolean shot = shouldShoot && myCoolDown <= 0 && myItem.ammo > 0;
-        game.getPartMan().updateAllHullEmittersOfType(hull, "shoot", shot);
+        game.getPartMan().updateAllHullEmittersOfType(ship, "shoot", shot);
         if (shot) {
             Vector2 gunSpeed = creator.getSpeed();
-            shoot(gunSpeed, game, gunAngle, muzzlePos, faction, creator,  hull);
+            shoot(gunSpeed, game, gunAngle, muzzlePos, faction, creator);
         } else {
             myCurrAngleVar = SolMath.approach(myCurrAngleVar, myItem.config.minAngleVar, myItem.config.angleVarDamp * ts);
         }

--- a/engine/src/main/java/org/destinationsol/game/particle/DSParticleEmitter.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/DSParticleEmitter.java
@@ -233,8 +233,12 @@ public class DSParticleEmitter {
     }
 
     public void setWorking(boolean working) {
+        setWorking(working, null);
+    }
+
+    public void setWorking(boolean working, SolShip ship) {
         if (working && workSoundSet != null) {
-            game.getSoundManager().play(game, workSoundSet, position, null);
+            game.getSoundManager().play(game, workSoundSet, position, ship);
         }
         light.update(working, relativeAngle, game);
 

--- a/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
@@ -95,7 +95,7 @@ public class PartMan {
     /**
      * This method updates all of the particle emitters on a Hull with the specified trigger
      *
-     * @param hull Hull containing the particle emitters
+     * @param ship Ship with the {@code Hull} containing the particle emitters
      * @param triggerType trigger type of the particle emitters
      * @param on boolean where true turns the particle emitters on and false turns it off
      */

--- a/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/PartMan.java
@@ -26,6 +26,7 @@ import org.destinationsol.game.drawables.DrawableLevel;
 import org.destinationsol.game.drawables.DrawableObject;
 import org.destinationsol.game.drawables.RectSprite;
 import org.destinationsol.game.item.Shield;
+import org.destinationsol.game.ship.SolShip;
 import org.destinationsol.game.ship.hulls.Hull;
 
 import java.util.ArrayList;
@@ -98,10 +99,10 @@ public class PartMan {
      * @param triggerType trigger type of the particle emitters
      * @param on boolean where true turns the particle emitters on and false turns it off
      */
-    public void updateAllHullEmittersOfType(Hull hull, String triggerType, boolean on) {
-        for (DSParticleEmitter particleEmitter : hull.getParticleEmitters()) {
+    public void updateAllHullEmittersOfType(SolShip ship, String triggerType, boolean on) {
+        for (DSParticleEmitter particleEmitter : ship.getHull().getParticleEmitters()) {
             if (triggerType.equals(particleEmitter.getTrigger())) {
-                particleEmitter.setWorking(on);
+                particleEmitter.setWorking(on, ship);
             }
         }
     }

--- a/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/ShipEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.destinationsol.common.SolMath;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.item.Engine;
-import org.destinationsol.game.ship.hulls.Hull;
 
 public class ShipEngine {
     public static final float MAX_RECOVER_ROT_SPD = 5f;
@@ -37,10 +36,10 @@ public class ShipEngine {
     }
 
     public void update(float angle, SolGame game, Pilot provider, Body body, Vector2 speed, boolean controlsEnabled,
-                       float mass, Hull hull) {
+                       float mass, SolShip ship) {
 
         boolean working = applyInput(game, angle, provider, body, speed, controlsEnabled, mass);
-        game.getPartMan().updateAllHullEmittersOfType(hull, "engine", working);
+        game.getPartMan().updateAllHullEmittersOfType(ship, "engine", working);
     }
 
     private boolean applyInput(SolGame cmp, float shipAngle, Pilot provider, Body body, Vector2 speed,

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,7 +226,7 @@ public class SolShip implements SolObject {
         SolShip nearestEnemy = game.getFactionMan().getNearestEnemy(game, this);
         myPilot.update(game, this, nearestEnemy);
         myHull.update(game, myItemContainer, myPilot, this, nearestEnemy);
-        game.getPartMan().updateAllHullEmittersOfType(myHull, "collision", colliding);
+        game.getPartMan().updateAllHullEmittersOfType(this, "collision", colliding);
 
         updateAbility(game);
         updateIdleTime(game);

--- a/engine/src/main/java/org/destinationsol/game/ship/hulls/Hull.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/hulls/Hull.java
@@ -110,7 +110,7 @@ public class Hull {
         boolean controlsEnabled = ship.isControlsEnabled() && !SolCam.DIRECT_CAM_CONTROL;
 
         if (engine != null) {
-            engine.update(angle, game, provider, body, speed, controlsEnabled, mass, this);
+            engine.update(angle, game, provider, body, speed, controlsEnabled, mass, ship);
         }
 
         Faction faction = ship.getPilot().getFaction();
@@ -142,7 +142,7 @@ public class Hull {
             body.setAngularVelocity(angleDiff * SolMath.degRad * fps);
         }
 
-        game.getPartMan().updateAllHullEmittersOfType(this, "none", true);
+        game.getPartMan().updateAllHullEmittersOfType(ship, "none", true);
     }
 
     private void setParamsFromBody() {


### PR DESCRIPTION
Fixed the nasty work sounds crash that slipped into develop by hiding behind the traitor IntelliJ
A `SolObject` source had to be passed into `OggSoundManager` so some method parameters were switched from `Hull` to `SolShip` 