### PR TITLE
Fix ammo saving while reloading

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -83,7 +83,7 @@ public class SaveManager {
             // Save gun's loaded ammo
             if (i instanceof Gun) {
                 Gun g = (Gun) i;
-                if (g.ammo > 0 && !g.config.clipConf.infinite) {
+                if ((g.ammo > 0 || g.reloadAwait > 0) && !g.config.clipConf.infinite) {
                     sb.append(g.config.clipConf.code).append(" ");
                 }
             }


### PR DESCRIPTION
Before, if the game was exited while the guns were being reloaded, player would lose the ammo being loaded in the gun. This hs been fixed in this PR. This is not the same issue as #267