### PR TITLE
UI 3 warning sign placements; enhancements

### DIFF
--- a/engine/src/main/java/org/destinationsol/common/SolColor.java
+++ b/engine/src/main/java/org/destinationsol/common/SolColor.java
@@ -35,6 +35,7 @@ public class SolColor {
     public static final Color UI_LIGHT = new Color(0, .75f, 1, .5f);
     public static final Color UI_OPAQUE = new Color(0, .56f, .75f, 1f);
     public static final Color UI_WARN = new Color(1, .5f, 0, .5f);
+    public static final Color UI_DANGER = new Color(1, 0, 0, .5f);
 
     public static Color col(float b, float t) {
         return new Color(b, b, b, t);

--- a/engine/src/main/java/org/destinationsol/game/screens/DmgWarnDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/DmgWarnDrawer.java
@@ -15,12 +15,13 @@
  */
 package org.destinationsol.game.screens;
 
+import org.destinationsol.common.SolColor;
 import org.destinationsol.game.Hero;
 import org.destinationsol.game.SolGame;
 
 public class DmgWarnDrawer extends WarnDrawer {
     DmgWarnDrawer() {
-        super("Heavily Damaged");
+        super("Heavily Damaged", SolColor.UI_DANGER);
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/screens/DmgWarnDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/DmgWarnDrawer.java
@@ -29,8 +29,14 @@ public class DmgWarnDrawer extends WarnDrawer {
         if (hero.isTranscendent()) {
             return false;
         }
-        float l = hero.getLife();
-        int ml = hero.getHull().config.getMaxLife();
-        return l < ml * .3f;
+        float currentLife = hero.getLife();
+
+        // already dead
+        if(currentLife <= 0.0) {
+            return false;
+        }
+
+        int maxLife = hero.getHull().config.getMaxLife();
+        return currentLife < maxLife * .3f;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -151,12 +151,13 @@ public class MainGameScreen extends SolUiBaseScreen {
         controls.add(consoleControlGrave);
         controls.add(consoleControlF1);
 
-        warnDrawers.add(new CollisionWarnDrawer());
+        // possible warning messages in order of importance, so earlier one will be drawn on the center
         warnDrawers.add(new SunWarnDrawer());
-        warnDrawers.add(new EnemyWarn());
         warnDrawers.add(new DmgWarnDrawer());
+        warnDrawers.add(new CollisionWarnDrawer());
         warnDrawers.add(new NoShieldWarn());
         warnDrawers.add(new NoArmorWarn());
+        warnDrawers.add(new EnemyWarn());
 
         zoneNameAnnouncer = new ZoneNameAnnouncer();
         borderDrawer = new BorderDrawer();
@@ -466,10 +467,10 @@ public class MainGameScreen extends SolUiBaseScreen {
             //updateTextPlace(col1, row, (int) hero.getMoney() + "", myMoneyExcessTp);
         }
 
+        int drawPlace = 0;
         for (WarnDrawer wd : warnDrawers) {
             if (wd.drawPercentage > 0) {
-                wd.draw(uiDrawer);
-                break;
+                wd.draw(uiDrawer, drawPlace++);
             }
         }
     }
@@ -486,10 +487,10 @@ public class MainGameScreen extends SolUiBaseScreen {
         myChargesExcessTp.draw(uiDrawer);
         myMoneyExcessTp.draw(uiDrawer, UiDrawer.TextAlignment.LEFT);
 
+        int drawPlace = 0;
         for (WarnDrawer warnDrawer : warnDrawers) {
             if (warnDrawer.drawPercentage > 0) {
-                warnDrawer.drawText(uiDrawer);
-                break;
+                warnDrawer.drawText(uiDrawer, drawPlace++);
             }
         }
 

--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -18,6 +18,7 @@ package org.destinationsol.game.screens;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.Const;
@@ -427,12 +428,12 @@ public class MainGameScreen extends SolUiBaseScreen {
             Shield shield = hero.getShield();
             if (shield != null) {
                 uiDrawer.draw(shield.getIcon(game), ICON_SZ, ICON_SZ, 0, 0, col0, row, 0, SolColor.WHITE);
-                drawBar(uiDrawer, col1, row, shield.getLife(), shield.getMaxLife(), myShieldLifeTp);
+                drawBar(uiDrawer, col1, row, MathUtils.floor(shield.getLife()), shield.getMaxLife(), myShieldLifeTp);
                 row += ICON_SZ + V_PAD;
             }
 
             uiDrawer.draw(lifeTexture, ICON_SZ, ICON_SZ, 0, 0, col0, row, 0, SolColor.WHITE);
-            drawBar(uiDrawer, col1, row, hero.getLife(), hero.getHull().config.getMaxLife(), myLifeTp);
+            drawBar(uiDrawer, col1, row, MathUtils.floor(hero.getLife()), hero.getHull().config.getMaxLife(), myLifeTp);
             int repairKitCount = hero.getItemContainer().count(game.getItemMan().getRepairExample());
             ItemManager itemManager = game.getItemMan();
             drawIcons(uiDrawer, col2, row, repairKitCount, itemManager.repairIcon, myRepairsExcessTp);

--- a/engine/src/main/java/org/destinationsol/game/screens/WarnDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/WarnDrawer.java
@@ -26,28 +26,35 @@ import org.destinationsol.ui.DisplayDimensions;
 import org.destinationsol.ui.FontSize;
 import org.destinationsol.ui.UiDrawer;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class WarnDrawer {
     private static final float FADE_TIME = 1f;
-    private final Rectangle warningRectangle;
     private final Color backgroundColor;
     private final Color textColor;
     private final float backgroundOriginA;
     private final String text;
+    private final DisplayDimensions displayDimensions;
+    private final List<Rectangle> rectangles = new ArrayList<>();
 
     float drawPercentage;
 
     WarnDrawer(String text) {
-        DisplayDimensions displayDimensions = SolApplication.displayDimensions;
-
-        warningRectangle = rect(displayDimensions.getRatio());
-        this.text = text;
-        backgroundColor = new Color(SolColor.UI_WARN);
-        backgroundOriginA = backgroundColor.a;
-        textColor = new Color(SolColor.WHITE);
+        this(text, SolColor.UI_WARN);
     }
 
-    private static Rectangle rect(float aspectRatio) {
-        return new Rectangle(.4f * aspectRatio, 0, .2f * aspectRatio, .1f);
+    WarnDrawer(String text, Color backgroundColor) {
+        displayDimensions = SolApplication.displayDimensions;
+
+        this.text = text;
+        this.backgroundColor = new Color(backgroundColor);
+        backgroundOriginA = backgroundColor.a;
+        textColor = new Color(SolColor.WHITE);
+        // create the 3 rectangles where notifications can appear
+        for(int i=0; i<3; i++) {
+            rectangles.add(createRectangle(i));
+        }
     }
 
     public void update(SolGame game) {
@@ -62,11 +69,35 @@ public abstract class WarnDrawer {
 
     protected abstract boolean shouldWarn(SolGame game);
 
-    public void draw(UiDrawer uiDrawer) {
-        uiDrawer.draw(warningRectangle, backgroundColor);
+    public void draw(UiDrawer uiDrawer, int drawIndex) {
+        if(drawIndex >= rectangles.size()) return;
+        uiDrawer.draw(rectangles.get(drawIndex), backgroundColor);
     }
 
-    public void drawText(UiDrawer uiDrawer) {
-        uiDrawer.drawString(text, warningRectangle.x + warningRectangle.width / 2, warningRectangle.y + warningRectangle.height / 2, FontSize.MENU, true, textColor);
+    public void drawText(UiDrawer uiDrawer, int drawIndex) {
+        if(drawIndex >= rectangles.size()) return;
+        Rectangle warningRectangle = rectangles.get(drawIndex);
+        uiDrawer.drawString(text, warningRectangle.x + warningRectangle.width / 2.f, warningRectangle.y + warningRectangle.height / 2.f, FontSize.MENU, true, textColor);
+    }
+
+    /**
+     * Create background rectangle by calculating bounds
+     * @param drawIndex where the rectangle starts on the screen
+     */
+    private Rectangle createRectangle(int drawIndex) {
+        float x;
+        float y = 0.05f;
+        switch(drawIndex) {
+            case 1: // left of center
+                x = 0.18f * displayDimensions.getRatio();
+                break;
+            case 2: // right of center
+                x = 0.62f * displayDimensions.getRatio();
+                break;
+            case 0: // fallthrough to default intended
+            default:
+                x = 0.4f * displayDimensions.getRatio();
+        }
+        return new Rectangle(x, y, .2f * displayDimensions.getRatio(), .1f);
     }
 }


### PR DESCRIPTION
This PR adds two more slots where warnings can appear like 'No Armor' or 'Heavily Damaged'. Also includes:
* Can set background color for warning displays
* 'Heavily Damaged' message has red background, and disappears after you die
* reordered warnings based on priority, first 3 will be shown
* You will no longer see 0 hp or shield on the UI when you still have fractional left, used floor to always round up

* How to test
Inside the game un-equip your armor and shield, and get on a collision course to an asteroid, and you will see 'No Armour', 'No Shield' and 'Collision' warnings.

preview:
![3warnings](https://user-images.githubusercontent.com/18668703/46577478-97224000-c9e8-11e8-939f-e937961d7e45.png)