### PR TITLE
Fixes groovyw not fetching dependencies on recurse and implements fail over to official modules repo

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -108,20 +108,34 @@ class common {
         } else if (itemsRetrieved.contains(itemName)) {
             println "We already retrieved $itemName - skipping"
         } else {
-            itemsRetrieved << itemName
             def targetUrl = "https://github.com/${githubTargetHome}/${itemName}"
+            def failUrl = "https://github.com/${githubDefaultHome}/${itemName}"
+            def failed = false;
+
             if (!isUrlValid(targetUrl)) {
                 println "Can't retrieve $itemType from $targetUrl - URL appears invalid. Typo? Not created yet?"
-                return
-            }
-            println "Retrieving $itemType $itemName from $targetUrl"
-            if (githubTargetHome != githubDefaultHome) {
+
+                if (isUrlValid(failUrl)) {
+                    println "Failed to retrieve $itemType $itemName, failing over to default modules repository."
+                    Grgit.clone dir: targetDir, uri: failUrl
+                    itemsRetrieved << itemName
+                    failed = true
+                } else {
+                    println "$itemType $itemName does not exist in $githubDefaultHome. Failed to retrieve $itemName."
+                    return
+                }  
+            } 
+
+            if (githubTargetHome != githubDefaultHome && !failed) {
+                println "Retrieving $itemType $itemName from $targetUrl"
                 println "Doing a retrieve from a custom remote: $githubTargetHome - will name it as such plus add the $githubDefaultHome remote as '$defaultRemote'"
                 Grgit.clone dir: targetDir, uri: targetUrl, remote: githubTargetHome
                 println "Primary clone operation complete, about to add the '$defaultRemote' remote for the $githubDefaultHome org address"
                 addRemote(itemName, defaultRemote, "https://github.com/${githubDefaultHome}/${itemName}")
-            } else {
+                itemsRetrieved << itemName
+            } else if (!failed) {
                 Grgit.clone dir: targetDir, uri: targetUrl
+                itemsRetrieved << itemName
             }
 
             // This step allows the item type to check the newly cloned item and add in extra template stuff

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -124,7 +124,7 @@ class common {
                     println "$itemType $itemName does not exist in $githubDefaultHome. Failed to retrieve $itemName."
                     return
                 }  
-            } 
+            }
 
             if (githubTargetHome != githubDefaultHome && !failed) {
                 println "Retrieving $itemType $itemName from $targetUrl"
@@ -154,7 +154,7 @@ class common {
                         retrieve(uniqueDependencies, true)
                     }
                 }
-            }    
+            }
         }
     }
 

--- a/config/groovy/module.groovy
+++ b/config/groovy/module.groovy
@@ -12,7 +12,7 @@ class module {
     def itemType = "module"
 
     String[] findDependencies(File targetDir) {
-        def foundDependencies = readModuleDependencies(new File(targetDir, "module.txt"))
+        def foundDependencies = readModuleDependencies(new File(targetDir, "module.json"))
         println "Looked for dependencies, found: " + foundDependencies
         return foundDependencies
     }


### PR DESCRIPTION
# Description
This PR fixes a bug in `groovyw`'s remote flag where it wouldn't attempt to fetch a module from the official Destination Sol modules repo if the remote in the flag failed. It also fixes a bug where `groovyw` attempted to read `modules/<module>/module.txt` as the config file, when `modules/<module>/module.json` is the read config file.

# Testing
Without my changes, run `./groovyw module recurse formic -remote Steampunkery`. You'll see the formic module download from my person repo. If you check the dependencies in the module you just downloaded, you'll see the dependencies weren't downloaded even though you passed the recurse flag. Now checkout my changes and run the same command. You'll see that all the deps have downloaded and the game runs correctly

# Notes
> Include any extra notes here

### Pre Pull Request Checklist:
<!-- When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones -->
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [x] Methods have been annotated with @ Nullable and @ Nonnull ([Read more](https://github.com/MovingBlocks/DestinationSol/wiki/@Nullable-&-@Nonnull-Quickstart))
- [x] There are no errors present in the project
- [x] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))