### PR TITLE
Add module.json to templates directory

### DIFF
--- a/templates/module.json
+++ b/templates/module.json
@@ -1,0 +1,11 @@
+{
+    "id" : "MODULENAME",
+    "version" : "0.1.0",
+    "displayName" : "MODULENAME Faction",
+    "description" : "Content related to MODULENAME Faction.",
+    "dependencies" :  [
+        {
+            "id" : "core"
+        }
+    ]
+}


### PR DESCRIPTION
# Description
This PR adds the file `module.json` to the `templates` directory. This file is used for module creation via `groovyw` and will cause an error if no present.

# Testing
Try to run `./groovyw module create test`. See the error? Now checkout my changes. No error. Look at the module.json in the new module and you'll see it has your module name where appropriate.