### PR TITLE
Added wildcard support to groovyw <item> get

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -353,15 +353,15 @@ class common {
      * @param regex the regex that the retrieved items should match
      */
     String[] retrieveAvailableItemsWithRegexMatch(String regex) {
-        ArrayList<String> selectedModules = new ArrayList<String>()
-        String[] moduleList = retrieveAvailableItems()
-        for (String module : moduleList) {
-            if (module.matches(regex)) {
-                selectedModules.add(module)
+        ArrayList<String> selectedItems = new ArrayList<String>()
+        String[] itemList = retrieveAvailableItems()
+        for (String item : itemList) {
+            if (item.matches(regex)) {
+                selectedItems.add(item)
             }
         }
 
-        return ((String[]) selectedModules.toArray());
+        return ((String[]) selectedItems.toArray());
     }
 
     /**

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -31,6 +31,12 @@ class common {
     /** The default name of a git remote we might want to work on or keep handy */
     String defaultRemote = "origin"
 
+    /** Should we cache the list of remote items */
+    boolean itemListCached = false
+
+    /** For keeping a list of remote items that can be retrieved */
+    String[] cachedItemList
+
     /**
      * Initialize defaults to match the target item type
      * @param type the type to be initialized
@@ -330,6 +336,46 @@ class common {
     }
 
     /**
+     * Retrieves all the available items for the target type in the form of a list that match the specified regex.
+     *
+     * Forming the regex:
+     * "\Q" starts an explicit quote (which includes all reserved characters as well)
+     * "\E" ends an explicit quote
+     * "\w*" is equivalent to "*" - it selects anything that has the same characters
+     * (in the range of a-z, A-Z or 1-9) as before and after the asterisk
+     * "." is equivalent to "?" - it selects anything that has the rest of the pattern but any
+     * character in the "?" symbol's position
+     * So, "\Q<INPUT_PART1>\E\w*\Q\<INPUT_PART1>E", selects anything that starts with INPUT_PART1
+     * and ends with INPUT_PART2 - This regex expression is equivalent to the input argument
+     * "INPUT_PART1*INPUT_PART2"
+     *
+     * @return a String[] containing the names of items available for download.
+     * @param regex the regex that the retrieved items should match
+     */
+    String[] retrieveAvailableItemsWithRegexMatch(String regex) {
+        ArrayList<String> selectedModules = new ArrayList<String>()
+        String[] moduleList = retrieveAvailableItems()
+        for (String module : moduleList) {
+            if (module.matches(regex)) {
+                selectedModules.add(module)
+            }
+        }
+
+        return ((String[]) selectedModules.toArray());
+    }
+
+    /**
+     * Retrieves all the available items for the target type in the form of a list that match the specified regex.
+     *
+     * @param wildcardPattern the wildcard pattern that the retrieved items should match
+     * @return a String[] containing the names of items available for download.
+     */
+    String[] retrieveAvalibleItemsWithWildcardMatch(String wildcardPattern) {
+        String regex = ("\\Q" + wildcardPattern.replace("*", "\\E\\w*\\Q").replace("?", "\\E.\\Q") + "\\E")
+        return retrieveAvailableItemsWithRegexMatch(regex);
+    }
+
+    /**
      * Retrieves link from HTTP headers (RFC 5988).
      * @param connection connection to retrieve link from
      * @param relation relation type of requested link
@@ -355,5 +401,14 @@ class common {
             }
         }
         return localItems
+    }
+
+    void cacheItemList() {
+        cachedItemList = retrieveAvailableItems()
+        itemListCached = true
+    }
+
+    void unCacheItemList() {
+        itemListCached = false
     }
 }

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -54,6 +54,10 @@ switch(cleanerArgs[0]) {
         } else {
             // Note: processCustomRemote also drops one of the array elements from cleanerArgs
             cleanerArgs = common.processCustomRemote(cleanerArgs)
+            if (cleanerArgs[0] == "*") {
+                cleanerArgs = common.retrieveAvailableItems()
+            }
+
             common.retrieve cleanerArgs, recurse
         }
         break
@@ -215,6 +219,7 @@ def printUsage() {
     println ""
     println "Example: 'groovyw module create MySpaceShips' - would create that module"
     println "Example: 'groovyw module get caution - remote vampcat - would retrieve caution module from vampcat's account on github.'"
+    println "Example: 'groovyw module get *' - would retrieve all the modules in the DestinationSol organisation on GitHub."
     println ""
     println "*NOTE*: Item names are case sensitive. If you add items then `gradlew idea` or similar may be needed to refresh your IDE"
     println ""

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -55,32 +55,16 @@ switch(cleanerArgs[0]) {
             // Note: processCustomRemote also drops one of the array elements from cleanerArgs
             cleanerArgs = common.processCustomRemote(cleanerArgs)
             ArrayList<String> selectedModules = new ArrayList<String>()
-            String[] moduleList = common.retrieveAvailableItems()
 
+            common.cacheItemList()
             for (String arg : cleanerArgs) {
                 if (!arg.contains('*') && !arg.contains('?')) {
                     selectedModules.add(arg)
                 } else {
-                    for (String module : moduleList) {
-                        /**
-                         * Forming the regex:
-                         * "\Q" starts an explicit quote (which includes all reserved characters as well)
-                         * "\E" ends an explicit quote
-                         * "\w*" is equivalent to "*" - it selects anything that has the same characters
-                         * (in the range of a-z, A-Z or 1-9) as before or after the asterisk
-                         * "." is equivalent to "?" - it selects anything that has the rest of the pattern but any
-                         * character in the "?" symbol's position
-                         * So, "\Q<INPUT_PART1>\E\w*\Q\<INPUT_PART1>E", selects anything that starts with INPUT_PART1
-                         * and ends with INPUT_PART2 - This regex expression is equivalent to the input argument
-                         * "INPUT_PART1*INPUT_PART2"
-                         */
-                        String regex = ("\\Q" + arg.replace("*", "\\E\\w*\\Q").replace("?", "\\E.\\Q") + "\\E")
-                        if (module.matches(regex)) {
-                            selectedModules.add(module)
-                        }
-                    }
+                    selectedModules.addAll(common.retrieveAvalibleItemsWithWildcardMatch(arg));
                 }
             }
+            common.unCacheItemList()
 
             common.retrieve(((String[])selectedModules.toArray()), recurse)
         }

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -228,8 +228,11 @@ def printUsage() {
     println "Example: 'groovyw module create MySpaceShips' - would create that module"
     println "Example: 'groovyw module get caution - remote vampcat - would retrieve caution module from vampcat's account on github.'"
     println "Example: 'groovyw module get *' - would retrieve all the modules in the DestinationSol organisation on GitHub."
-    println "Example: 'groovyw module get *de*' - would retrieve all the modules in the DestinationSol organisation on GitHub" +
-            " that have the letter-pair \"de\" next somewhere within them."
+    println "Example: 'groovyw module get ?r*' - would retrieve all the modules in the DestinationSol organisation on GitHub" +
+            " that start with any single character, then an \"r\" and then end with anything else." +
+            " This should retrieve the draconic, organic and tribe repositories from the DestinationSol organisation on GitHub."
+    println ""
+    println "*NOTE*: On UNIX platforms (MacOS and Linux), the wildcard arguments must be escaped with single quotes e.g. groovyw module get '*'."
     println ""
     println "*NOTE*: Item names are case sensitive. If you add items then `gradlew idea` or similar may be needed to refresh your IDE"
     println ""

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -66,15 +66,15 @@ switch(cleanerArgs[0]) {
                          * Forming the regex:
                          * "\Q" starts an explicit quote (which includes all reserved characters as well)
                          * "\E" ends an explicit quote
-                         * "\w*" is equivalent to "*" - it selects anything that has the same characters as before or
-                         * after the asterisk
-                         * "\w*" is equivalent to "?" - it selects anything that has the rest of the pattern but any
+                         * "\w*" is equivalent to "*" - it selects anything that has the same characters
+                         * (in the range of a-z, A-Z or 1-9) as before or after the asterisk
+                         * "." is equivalent to "?" - it selects anything that has the rest of the pattern but any
                          * character in the "?" symbol's position
                          * So, "\Q<INPUT_PART1>\E\w*\Q\<INPUT_PART1>E", selects anything that starts with INPUT_PART1
                          * and ends with INPUT_PART2 - This regex expression is equivalent to the input argument
                          * "INPUT_PART1*INPUT_PART2"
                          */
-                        String regex = ("\\Q" + arg.replace("*", "\\E\\w*\\Q").replace("?", "\\E\\w+\\Q") + "\\E")
+                        String regex = ("\\Q" + arg.replace("*", "\\E\\w*\\Q").replace("?", "\\E.\\Q") + "\\E")
                         if (module.matches(regex)) {
                             selectedModules.add(module)
                         }

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -54,19 +54,19 @@ switch(cleanerArgs[0]) {
         } else {
             // Note: processCustomRemote also drops one of the array elements from cleanerArgs
             cleanerArgs = common.processCustomRemote(cleanerArgs)
-            ArrayList<String> selectedModules = new ArrayList<String>()
+            ArrayList<String> selectedItems = new ArrayList<String>()
 
             common.cacheItemList()
             for (String arg : cleanerArgs) {
                 if (!arg.contains('*') && !arg.contains('?')) {
-                    selectedModules.add(arg)
+                    selectedItems.add(arg)
                 } else {
-                    selectedModules.addAll(common.retrieveAvalibleItemsWithWildcardMatch(arg));
+                    selectedItems.addAll(common.retrieveAvalibleItemsWithWildcardMatch(arg));
                 }
             }
             common.unCacheItemList()
 
-            common.retrieve(((String[])selectedModules.toArray()), recurse)
+            common.retrieve(((String[])selectedItems.toArray()), recurse)
         }
         break
 

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -61,7 +61,11 @@ if "x%~1" == "x" goto execute
 @REM set CMD_LINE_ARGS=%*
 :process_args
 IF "%1"=="" GOTO end
-IF "%1" == "*" (SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1") ELSE SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+echo "%1" | findstr /C:"\*" 1>nul && (
+    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1"
+) || (
+    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+)
 SHIFT
 GOTO process_args
 

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -61,10 +61,15 @@ if "x%~1" == "x" goto execute
 @REM set CMD_LINE_ARGS=%*
 :process_args
 IF "%1"=="" GOTO end
-echo "%1" | findstr /C:"\*" 1>nul && (
-    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1"
+SET ARG=%~1
+echo "%ARG%" | findstr /C:"\*" 1>nul && (
+    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%ARG%"
 ) || (
-    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+    echo "%ARG%" | findstr /C:"\?" 1>nul && (
+        SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%ARG%"
+    ) || (
+        SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %ARG%
+    )
 )
 SHIFT
 GOTO process_args

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -58,7 +58,15 @@ set _SKIP=2
 :win9xME_args_slurp
 if "x%~1" == "x" goto execute
 
-set CMD_LINE_ARGS=%*
+@REM set CMD_LINE_ARGS=%*
+:process_args
+IF "%1"=="" GOTO end
+IF "%1" == "*" (SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1") ELSE SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+SHIFT
+GOTO process_args
+
+:end
+SET CMD_LINE_ARGS=%CMD_LINE_ARGS:~1%
 
 :execute
 @rem Setup the command line


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This PR adds wildcard support to the `groovyw <item> get <object>` e.g. `groovyw <item> get *`.

# Testing
Testing this PR could take some considerable time and effort to check all of the use-cases are correct, so these changes should only apply if wildcards (`*` or `?`) are detected in the input argument (see [Line 61 of util.groovy](https://github.com/BenjaminAmos/DestinationSol/blob/6a9376b3216067f14163f930dc873fc713865f9c/config/groovy/util.groovy#L61)). As such, I will list the series of tests that I have tried so far:
## Single argument tests:
- [X] Command: `groovyw module get *`
    - Expected result: All the available modules under the @DestinationSol organisation should be obtained.
- [X] Command: `groovyw module get d??p*`
    - Expected result: This should obtain the [deepspace](https://github.com/DestinationSol/deepspace) module.
- [X] Command: `groovyw module get s??????`
    - Expected result: This should obtain the [salvage](https://github.com/DestinationSol/salvage) module.
- [X] Command: `groovyw module get f?rm?c`
    - Expected result: This should obtain the [formic](https://github.com/DestinationSol/formic) module.
- [X] Command: `groovyw module get t*`
    - Expected result: This should obtain the [tribe](https://github.com/DestinationSol/tribe) module.
- [X] Command: `groovyw module get *de*`
    - Expected result: This should obtain both the [deepspace](https://github.com/DestinationSol/deepspace) and the [federal](https://github.com/DestinationSol/federal) modules.
## Multiple argument tests:
- [X] Command: `groovyw module get *de* fo*`
    - Expected result: This should obtain both the [deepspace](https://github.com/DestinationSol/deepspace), [federal](https://github.com/DestinationSol/federal) modules, as well as the [deepspace](https://github.com/DestinationSol/deepspace) and the [formic](https://github.com/DestinationSol/formic) module.
- [X] Command: `groovyw module get f* d???*`
    - Expected result: This should obtain the [deepspace](https://github.com/DestinationSol/deepspace), [draconic](https://github.com/DestinationSol/draconic), [federal](https://github.com/DestinationSol/federal) and [formic](https://github.com/DestinationSol/formic) modules.
## Testing regex characters:
- [X] Command `groovyw module get .`
    - Expected result: This should attempt to obtain the "." module, which does not exist.
- [X] Command `groovyw module get (`
    - Expected result: This should attempt to obtain the "(" module, which does not exist.
- [X] Command `groovyw module get )`
    - Expected result: This should attempt to obtain the ")" module, which does not exist.
- [X] Command `groovyw module get []`
    - Expected result: This should attempt to obtain the "[]" module, which does not exist.
- [X] Command `groovyw module get *`
    - Expected result: This character is specially handled, so all the available modules under the @DestinationSol organisation should be obtained.
## Testing multiple wildcards in succession:
- [X] Command `groovyw module get ??????`
    - Expected result: This should attempt to obtain the [formic](https://github.com/DestinationSol/formic), [slimey](https://github.com/DestinationSol/slimey) and [vulcan](https://github.com/DestinationSol/vulcan) modules.
- [X] Command `groovyw module get ******`
    - Expected result: All the available modules under the @DestinationSol organisation should be obtained.

# Outstanding Work
- [X] Such a large change needs significant testing. This change needs to be tested extensively to be proven useable, although I think that it should work most of the time. I still need to finish doing this, as I have not fully tested it yet.
    - Further tests to perform:
        - [X] Test that the regex characters (``[``, ``]``, ``(``, ``)``, ``*``, ``.``, ``\``) are not injected into the code as regexes
        - [X] Test if multiple wildcard selectors can be used to obtain completely different modules, e.g. using the command `groovyw module get *de* fo*`, which should obtain both the [deepspace](https://github.com/DestinationSol/deepspace), [federal](https://github.com/DestinationSol/federal) modules, as well as the [deepspace](https://github.com/DestinationSol/deepspace) and the [formic](https://github.com/DestinationSol/formic) module.

# Notes
This should not break any existing functionality, as the new wildcard handling code is only used when the `*` or `?` symbols are found.

The wildcard strings will have to be escaped using single quotes (e.g. `./groovyw module get '*'` rather than `./groovyw module get *`) on POSIX platforms (Linux and MacOS), as otherwise the terminal appears to automatically expand them (replacing the arguments with the names all the files in the current directory matching that descriptor) before passing them to the program. I have modified the Windows script to automatically escape the arguments, although I am not sure if it is possible with POSIX platforms to do so.

<!--
### Pre Pull Request Checklist:
 When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] Methods have been annotated with @ Nullable and @ Nonnull ([Read more](https://github.com/MovingBlocks/DestinationSol/wiki/@Nullable-&-@Nonnull-Quickstart))
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
-->