### PR TITLE
UiTextButtons now expand to fit their contents

### DIFF
--- a/engine/src/main/java/org/destinationsol/CommonDrawer.java
+++ b/engine/src/main/java/org/destinationsol/CommonDrawer.java
@@ -115,15 +115,11 @@ public class CommonDrawer implements ResizeSubscriber {
      * @return The visible length
      */
     public int getStringLength(String s, float fontSize) {
-        BitmapFont.BitmapFontData data = font.getData();
-        data.setScale(fontSize / originalFontHeight);
-        int stringLength = 0;
-        for (char character : s.toCharArray()) {
-            BitmapFont.Glyph charGlyph = data.getGlyph(character);
-            stringLength += charGlyph.width;
-        }
-
-        return stringLength;
+        float fontScale = (fontSize / originalFontHeight);
+        font.getData().setScale(fontScale);
+        layout.reset();
+        layout.setText(font, s);
+        return (int) (layout.width / (displayDimensions.getRatio() / displayDimensions.getWidth()));
     }
 
     public void draw(TextureRegion tr, float width, float height, float origX, float origY, float x, float y,

--- a/engine/src/main/java/org/destinationsol/CommonDrawer.java
+++ b/engine/src/main/java/org/destinationsol/CommonDrawer.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import org.destinationsol.assets.Assets;
+import org.destinationsol.assets.fonts.FontData;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.ui.DisplayDimensions;
 import org.destinationsol.ui.ResizeSubscriber;
@@ -104,6 +105,25 @@ public class CommonDrawer implements ResizeSubscriber {
         }
 
         font.draw(spriteBatch, layout, x, y);
+    }
+
+    /**
+     * Returns the visible length of a string when drawn.
+     *
+     * @param s The string to measure
+     * @param fontSize The size of the font, relative to the string
+     * @return The visible length
+     */
+    public int getStringLength(String s, float fontSize) {
+        BitmapFont.BitmapFontData data = font.getData();
+        data.setScale(fontSize / originalFontHeight);
+        int stringLength = 0;
+        for (char character : s.toCharArray()) {
+            BitmapFont.Glyph charGlyph = data.getGlyph(character);
+            stringLength += charGlyph.width;
+        }
+
+        return stringLength;
     }
 
     public void draw(TextureRegion tr, float width, float height, float origX, float origY, float x, float y,

--- a/engine/src/main/java/org/destinationsol/ui/UiDrawer.java
+++ b/engine/src/main/java/org/destinationsol/ui/UiDrawer.java
@@ -92,6 +92,17 @@ public class UiDrawer implements ResizeSubscriber {
         drawer.drawString(s, x, y, scale * fontSize, align, centered, tint);
     }
 
+    /**
+     * Returns the visible length of a string when drawn.
+     *
+     * @param s The string to measure
+     * @param scale The scale of the string
+     * @return The visible length
+     */
+    public int getStringLength(String s, float scale) {
+        return drawer.getStringLength(s, scale * fontSize);
+    }
+
     public void draw(TextureRegion tr, float width, float height, float origX, float origY, float x, float y, float rot, Color tint) {
         drawer.draw(tr, width, height, origX, origY, x, y, rot, tint);
     }

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiElement.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiElement.java
@@ -23,6 +23,8 @@ public interface UiElement {
     // Set position. Returns UiElement to support Builder Pattern.
     UiElement setPosition(int x, int y);
 
+    UiElement setDimensions(int width, int height);
+
     int getX();
 
     int getY();
@@ -32,6 +34,8 @@ public interface UiElement {
     int getHeight();
 
     void draw();
+
+    void resetRect();
 
     // TODO: Ugly, ugly, ugly. Remove.
     boolean maybeFlashPressed(int keyCode);

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiHeadlessButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiHeadlessButton.java
@@ -39,6 +39,11 @@ public class UiHeadlessButton implements UiElement {
         return this;
     }
 
+    @Override
+    public UiElement setDimensions(int width, int height) {
+        return this;
+    }
+
     public UiHeadlessButton setTriggerKey(int triggerKey) {
         this.triggerKey = triggerKey;
 
@@ -162,5 +167,9 @@ public class UiHeadlessButton implements UiElement {
     @Override
     public Rectangle getScreenArea() {
         return new Rectangle(-1, -1, 0, 0);
+    }
+
+    @Override
+    public void resetRect() {
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiRelativeLayout.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiRelativeLayout.java
@@ -76,6 +76,11 @@ public class UiRelativeLayout implements UiElement {
         uiElementWithProperties.uiElement.setPosition(uiElementX, uiElementY);
     }
 
+    @Override
+    public UiElement setDimensions(int width, int height) {
+        return this;
+    }
+
     public void draw() {
         for (UiElementWithProperties uiElementWithProperties : uiElementsWithProperties) {
             uiElementWithProperties.uiElement.draw();
@@ -141,5 +146,10 @@ public class UiRelativeLayout implements UiElement {
             this.xOffset = xOffset;
             this.yOffset = yOffset;
         }
+    }
+
+    @Override
+    public void resetRect() {
+        setPosition(0, 0);
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiTextButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiTextButton.java
@@ -53,6 +53,7 @@ public class UiTextButton implements UiElement {
     private int y;
     private int width = BUTTON_WIDTH;
     private int height = BUTTON_HEIGHT;
+    private float fontSize = FontSize.MENU;
 
     // TODO: Make these optional?
     private UiCallback onClickAction; // Called *while* button is pressed
@@ -81,7 +82,7 @@ public class UiTextButton implements UiElement {
     public UiTextButton setDisplayName(String displayName) {
         this.displayName = displayName;
         UiDrawer drawer = SolApplication.getUiDrawer();
-        int textWidth = drawer.getStringLength(displayName, 1);
+        int textWidth = drawer.getStringLength(displayName, fontSize);
         this.width = textWidth + (BUTTON_PADDING * 2);
 
         return this;
@@ -130,6 +131,10 @@ public class UiTextButton implements UiElement {
     public int getHeight() {
         return height;
     }
+
+    public float getFontSize() { return fontSize; }
+
+    public void setFontSize(float newSize) { fontSize = newSize; }
 
     @Override
     public boolean maybeFlashPressed(int keyCode) {
@@ -274,7 +279,7 @@ public class UiTextButton implements UiElement {
         }
 
         tint = isEnabled ? SolColor.WHITE : SolColor.G;
-        uiDrawer.drawString(displayName, screenArea.x + screenArea.width / 2, screenArea.y + screenArea.height / 2, FontSize.MENU, true, tint);
+        uiDrawer.drawString(displayName, screenArea.x + screenArea.width / 2, screenArea.y + screenArea.height / 2, fontSize, true, tint);
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiTextButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiTextButton.java
@@ -68,6 +68,7 @@ public class UiTextButton implements UiElement {
         return this;
     }
 
+    @Override
     public UiTextButton setDimensions(int width, int height) {
         this.width = width;
         this.height = height;
@@ -79,6 +80,9 @@ public class UiTextButton implements UiElement {
 
     public UiTextButton setDisplayName(String displayName) {
         this.displayName = displayName;
+        UiDrawer drawer = SolApplication.getUiDrawer();
+        int textWidth = drawer.getStringLength(displayName, 1);
+        this.width = textWidth + (BUTTON_PADDING * 2);
 
         return this;
     }
@@ -305,5 +309,11 @@ public class UiTextButton implements UiElement {
     private void calculateScreenArea() {
         DisplayDimensions displayDimensions = SolApplication.displayDimensions;
         screenArea = new Rectangle((x - width/2) * displayDimensions.getRatio() / displayDimensions.getWidth(), (y - height/2) / (float)displayDimensions.getHeight(), width * displayDimensions.getRatio() / displayDimensions.getWidth(), height / (float)displayDimensions.getHeight());
+    }
+
+    @Override
+    public void resetRect() {
+        setPosition(0, 0);
+        setDisplayName(displayName);
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiVerticalListLayout.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiVerticalListLayout.java
@@ -31,6 +31,7 @@ public class UiVerticalListLayout implements UiElement {
 
     private int x;
     private int y;
+    private int buttonWidth = 0;
 
     public UiVerticalListLayout addElement(UiElement uiElement) {
         uiElements.add(uiElement);
@@ -47,6 +48,12 @@ public class UiVerticalListLayout implements UiElement {
 
         calculateButtonPositions();
 
+        return this;
+    }
+
+    @Override
+    public UiElement setDimensions(int width, int height) {
+        //The dimensions of a UiVerticalListLayout are determined by its contents
         return this;
     }
 
@@ -76,6 +83,7 @@ public class UiVerticalListLayout implements UiElement {
 
     @Override
     public void draw() {
+        calculateButtonPositions();
         for (UiElement uiElement : uiElements) {
             uiElement.draw();
         }
@@ -132,11 +140,30 @@ public class UiVerticalListLayout implements UiElement {
 
     private void calculateButtonPositions() {
         int currentY = y - getHeight()/2 + BUTTON_HEIGHT/2;
+        calcuateButtonWidth();
 
         for (UiElement uiElement : uiElements) {
             uiElement.setPosition(x, currentY);
+            uiElement.setDimensions(buttonWidth, BUTTON_HEIGHT);
 
             currentY += (BUTTON_HEIGHT + BUTTON_PADDING);
         }
+    }
+
+    private void calcuateButtonWidth() {
+        buttonWidth = 0;
+        for (UiElement uiElement : uiElements) {
+            uiElement.resetRect();
+            if (uiElement.getWidth() > buttonWidth) {
+                buttonWidth = uiElement.getWidth();
+            }
+        }
+    }
+
+    @Override
+    public void resetRect() {
+        setPosition(0, 0);
+        calcuateButtonWidth();
+        calculateButtonPositions();
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request resizes buttons to fit their contents. This only occurs when assigning the text to a button, so it can be overrided afterwards. It also modifies the UiVerticalListLayout to resize its content width to match the largest width of its individual elements.

# Testing
- Start the game
- Open the Play Game -> New Game menu
- Click the "Starting Ship" button multiple times to cycle through the ships
- The size of the button should change as the ship name gets larger.

# Notes
If the size of any of the buttons changes, the UiVerticalListLayout will change the size of all of the buttons, if the new size is larger than the curent size of the buttons. As such, on the New Ship screen, all the buttons may expand when selecting a new ship.

<!-- ### Pre Pull Request Checklist:
When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] Methods have been annotated with @ Nullable and @ Nonnull ([Read more](https://github.com/MovingBlocks/DestinationSol/wiki/@Nullable-&-@Nonnull-Quickstart))
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html)) -->