### PR TITLE
Auto-Adjusting of UiTextButtons

### DIFF
--- a/engine/src/main/java/org/destinationsol/CommonDrawer.java
+++ b/engine/src/main/java/org/destinationsol/CommonDrawer.java
@@ -82,11 +82,7 @@ public class CommonDrawer implements ResizeSubscriber {
             return;
         }
 
-        font.setColor(col);
-        font.getData().setScale(fontSize / originalFontHeight);
-        // http://www.badlogicgames.com/wordpress/?p=3658
-        layout.reset();
-        layout.setText(font, s);
+        makeFontLayout(s, fontSize, col);
 
         switch (align) {
             case LEFT:
@@ -104,6 +100,35 @@ public class CommonDrawer implements ResizeSubscriber {
         }
 
         font.draw(spriteBatch, layout, x, y);
+    }
+
+    /**
+     * Creates a GlyphLayout for a provided string, using the engine font.
+     *
+     * @param s The provided string.
+     * @param fontSize The size of the font.
+     * @param col The color of the font.
+     * @return The final GlyphLayout.
+     */
+    public GlyphLayout makeFontLayout(String s, float fontSize, Color col){
+        font.setColor(col);
+        return makeFontLayout(s, fontSize);
+    }
+
+    /**
+     * Creates a GlyphLayout for a provided string, using the engine font.
+     *
+     * @param s The provided string.
+     * @param fontSize The size of the font.
+     * @return The final GlyphLayout.
+     */
+    public GlyphLayout makeFontLayout(String s, float fontSize){
+        font.getData().setScale(fontSize / originalFontHeight);
+        // http://www.badlogicgames.com/wordpress/?p=3658
+        layout.reset();
+        layout.setText(font, s);
+
+        return layout; // returns for width calculations
     }
 
     public void draw(TextureRegion tr, float width, float height, float origX, float origY, float x, float y,

--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -46,7 +46,6 @@ import org.destinationsol.ui.responsiveUi.UiRelativeLayout;
 import org.destinationsol.ui.responsiveUi.UiTextButton;
 import org.destinationsol.ui.responsiveUi.UiVerticalListLayout;
 import static org.destinationsol.ui.UiDrawer.UI_POSITION_RIGHT;
-import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_WIDTH;
 
 public class MainGameScreen extends SolUiBaseScreen {
     public ShipUiControl shipControl;
@@ -185,8 +184,7 @@ public class MainGameScreen extends SolUiBaseScreen {
         consoleButton = new UiHeadlessButton().setTriggerKey(Input.Keys.GRAVE)
                                               .setOnReleaseAction(() -> inputManager.changeScreen(solApplication.getGame().getScreens().console));
         buttonList.addElement(consoleButton);
-
-        relativeLayout.addElement(buttonList, UI_POSITION_RIGHT, -BUTTON_WIDTH/2, 0)
+        relativeLayout.addElement(buttonList, UI_POSITION_RIGHT, -buttonList.getWidth()/2, 0)
                       .finalizeChanges();
 
         rootUiElement = relativeLayout;

--- a/engine/src/main/java/org/destinationsol/menu/CreditsScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/CreditsScreen.java
@@ -35,7 +35,6 @@ import org.destinationsol.ui.responsiveUi.UiTextButton;
 import static org.destinationsol.ui.UiDrawer.UI_POSITION_BOTTOM_RIGHT;
 import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_HEIGHT;
 import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_PADDING;
-import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_WIDTH;
 
 public class CreditsScreen extends SolUiBaseScreen {
     private static final float MAX_AWAIT = 6f;
@@ -59,7 +58,7 @@ public class CreditsScreen extends SolUiBaseScreen {
                 .enableSound()
                 .setOnReleaseAction(() -> inputManager.changeScreen(menuScreens.mainScreen));
 
-        rootUiElement = new UiRelativeLayout().addElement(creditsButton, UI_POSITION_BOTTOM_RIGHT, -BUTTON_WIDTH / 2 - BUTTON_PADDING, -BUTTON_HEIGHT / 2 - BUTTON_PADDING)
+        rootUiElement = new UiRelativeLayout().addElement(creditsButton, UI_POSITION_BOTTOM_RIGHT, -creditsButton.getWidth() / 2 - BUTTON_PADDING, -BUTTON_HEIGHT / 2 - BUTTON_PADDING)
                 .finalizeChanges();
 
         myColor = SolColor.col(1, 1);

--- a/engine/src/main/java/org/destinationsol/menu/MainMenuScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/MainMenuScreen.java
@@ -36,7 +36,6 @@ import static org.destinationsol.ui.UiDrawer.UI_POSITION_BOTTOM;
 import static org.destinationsol.ui.UiDrawer.UI_POSITION_BOTTOM_RIGHT;
 import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_HEIGHT;
 import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_PADDING;
-import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_WIDTH;
 
 public class MainMenuScreen extends SolUiBaseScreen {
     private final TextureAtlas.AtlasRegion logoTexture;
@@ -87,7 +86,7 @@ public class MainMenuScreen extends SolUiBaseScreen {
                 .setOnReleaseAction(() -> SolApplication.changeScreen(SolApplication.getMenuScreens().creditsScreen));
 
         rootUiElement = new UiRelativeLayout().addElement(buttonList, UI_POSITION_BOTTOM, 0, -buttonList.getHeight() / 2 - BUTTON_PADDING)
-                .addElement(creditsButton, UI_POSITION_BOTTOM_RIGHT, -BUTTON_WIDTH / 2 - BUTTON_PADDING, -BUTTON_HEIGHT / 2 - BUTTON_PADDING)
+                .addElement(creditsButton, UI_POSITION_BOTTOM_RIGHT, -buttonList.getWidth() / 2 - BUTTON_PADDING, -BUTTON_HEIGHT / 2 - BUTTON_PADDING)
                 .finalizeChanges();
 
         backgroundTexture = Assets.getAtlasRegion("engine:mainMenuBg", Texture.TextureFilter.Linear);

--- a/engine/src/main/java/org/destinationsol/ui/UiDrawer.java
+++ b/engine/src/main/java/org/destinationsol/ui/UiDrawer.java
@@ -119,6 +119,20 @@ public class UiDrawer implements ResizeSubscriber {
         filler = new Rectangle(0, 0, displayDimensions.getRatio(), 1);
     }
 
+    /**
+     * Returns the screen display width of a provided string in pixels.
+     *
+     * Does not account for padding/spacing.
+     *
+     * @param s The provided string.
+     * @param scale The scale the text would be displayed in.
+     * @return
+     */
+    public int getStringDisplayWidth(String s, float scale){
+        // Kind of a nasty statement, but is needed to convert the float from GlyphLayout.width to a pixel value.
+        return (int) ((drawer.makeFontLayout(s, scale*fontSize).width*displayDimensions.getWidth())/displayDimensions.getRatio());
+    }
+
     private void recomputeStraightMtx() {
         straightMtx = new Matrix4().setToOrtho2D(0, 1, displayDimensions.getRatio(), -1);
     }

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiElement.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiElement.java
@@ -23,6 +23,9 @@ public interface UiElement {
     // Set position. Returns UiElement to support Builder Pattern.
     UiElement setPosition(int x, int y);
 
+    // Set dimensions. Returns UiElement to support Builder Pattern.
+    UiElement setDimensions(int width, int height);
+
     // Required to commit the changes made to the element. Present for optimization purposes.
     UiElement finalizeChanges();
 

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiHeadlessButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiHeadlessButton.java
@@ -39,6 +39,9 @@ public class UiHeadlessButton implements UiElement {
         return this;
     }
 
+    @Override
+    public UiHeadlessButton setDimensions(int width, int height) { return this; }
+
     public UiHeadlessButton setTriggerKey(int triggerKey) {
         this.triggerKey = triggerKey;
 

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiRelativeLayout.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiRelativeLayout.java
@@ -42,6 +42,9 @@ public class UiRelativeLayout implements UiElement {
     }
 
     @Override
+    public UiRelativeLayout setDimensions(int width, int height) { return this; }
+
+    @Override
     public UiRelativeLayout finalizeChanges() {
         for (UiElementWithProperties uiElementWithProperties : uiElementsWithProperties) {
             setPosition(uiElementWithProperties);

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiTextButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiTextButton.java
@@ -26,9 +26,10 @@ import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.UiDrawer;
 
 public class UiTextButton implements UiElement {
-    public static final int BUTTON_WIDTH = 300;
     public static final int BUTTON_HEIGHT = 75;
     public static final int BUTTON_PADDING = 10;
+
+    private UiDrawer uiDrawer = SolApplication.getUiDrawer();
 
     private Rectangle screenArea;
 
@@ -51,7 +52,7 @@ public class UiTextButton implements UiElement {
 
     private int x;
     private int y;
-    private int width = BUTTON_WIDTH;
+    private int width;
     private int height = BUTTON_HEIGHT;
 
     // TODO: Make these optional?
@@ -66,6 +67,7 @@ public class UiTextButton implements UiElement {
         return this;
     }
 
+    @Override
     public UiTextButton setDimensions(int width, int height) {
         this.width = width;
         this.height = height;
@@ -75,6 +77,7 @@ public class UiTextButton implements UiElement {
 
     public UiTextButton setDisplayName(String displayName) {
         this.displayName = displayName;
+        width = uiDrawer.getStringDisplayWidth(displayName, FontSize.MENU)+(BUTTON_PADDING*2);
 
         return this;
     }
@@ -265,8 +268,6 @@ public class UiTextButton implements UiElement {
                 tint = SolColor.UI_DARK;
             }
         }
-
-        UiDrawer uiDrawer = SolApplication.getUiDrawer();
 
         uiDrawer.draw(screenArea, tint);
         if (warnCount > 0) {

--- a/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiVerticalListLayout.java
+++ b/engine/src/main/java/org/destinationsol/ui/responsiveUi/UiVerticalListLayout.java
@@ -23,7 +23,6 @@ import org.destinationsol.ui.DisplayDimensions;
 import org.destinationsol.ui.SolInputManager;
 import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_HEIGHT;
 import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_PADDING;
-import static org.destinationsol.ui.responsiveUi.UiTextButton.BUTTON_WIDTH;
 
 // TODO: Only handles UiTextButtons perfectly for now, due to height calculations. Make it more generic.
 public class UiVerticalListLayout implements UiElement {
@@ -47,11 +46,16 @@ public class UiVerticalListLayout implements UiElement {
     }
 
     @Override
+    public UiVerticalListLayout setDimensions(int width, int height) { return this; }
+
+    @Override
     public UiVerticalListLayout finalizeChanges() {
         int currentY = y - getHeight()/2 + BUTTON_HEIGHT/2;
+        int width = getWidth();
 
         for (UiElement uiElement : uiElements) {
-            uiElement.setPosition(x, currentY).finalizeChanges();
+            uiElement.setPosition(x, currentY).setDimensions(width, uiElement.getHeight());
+            uiElement.finalizeChanges();
 
             currentY += (BUTTON_HEIGHT + BUTTON_PADDING);
         }
@@ -71,7 +75,14 @@ public class UiVerticalListLayout implements UiElement {
 
     @Override
     public int getWidth() {
-        return BUTTON_WIDTH;
+        int width = 0;
+        for (UiElement uiElement :uiElements) { // finds the biggest width out of all UI elements
+            if (uiElement.getWidth() > width) {
+                width = uiElement.getWidth();
+            }
+        }
+
+        return width; // the biggest width is the width of the list.
     }
 
     @Override


### PR DESCRIPTION
# Description
This pull request makes it so `UiTextButton`s now have dynamic width, adjusting to the text inside of them. `UiVerticalListLayout` also will adjust the width of the entire list to fit to the largest width of the elements inside.

# Testing
- Start Game
- Go into UI's with text buttons (Main Menu, Ship Select, Options, etc.)
- Vertical lists should have all buttons as the same size
- The button with the largest string should have a margin of 10px on the left&right

# Notes
- This does not take into account changing text within text buttons, if the text is switched to be larger than the original, the bounding box will be broken.
- `BUTTON_WIDTH` in UiTextButton has been removed entirely, with all references to it replaced with getWidth() of the button or vertical list accordingly.