### PR TITLE
Fixed autosave crash when using star ports

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/Hero.java
+++ b/engine/src/main/java/org/destinationsol/game/Hero.java
@@ -172,7 +172,6 @@ public class Hero {
     }
 
     public ItemContainer getMercs() {
-        assertNonTranscendent();
         return mercs;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This fixes a bug where the game crashes if it tries to autosave whilst the hero is in a transcendent state, such as when travelling between star ports.

# Testing
- Un-comment line 156 in [SolGame.java](https://github.com/MovingBlocks/DestinationSol/blob/develop/engine/src/main/java/org/destinationsol/game/SolGame.java#L156)
- Create a new game with 2 systems.
- Visit the nearest star port and enter it.
- Open the console window.
- If the game attempts to autosave, the "game saved" message should be shown. If this message is shown whilst the hero is in transit between two star ports, the game should not crash, Previously, it crashed just before the message was shown. It should not crash when the hero is in a normal state either.

## Notes
This pull request removes the transcendent check on the getMercs method, as it is not actually dependant on the hero ship.  Another approach could be to not autosave when the hero is in a transcendent state, although this could further delay saving for another 30 seconds.

<!-- ### Pre Pull Request Checklist:
When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] Methods have been annotated with @ Nullable and @ Nonnull ([Read more](https://github.com/MovingBlocks/DestinationSol/wiki/@Nullable-&-@Nonnull-Quickstart))
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))-->