### PR TITLE
Added Music changes

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -211,6 +211,7 @@ public class SolApplication implements ApplicationListener {
 
         inputManager.setScreen(this, menuScreens.loading);
         menuScreens.loading.setMode(tut, shipName, isNewGame);
+        musicManager.registerModuleMusic(shipName);
         musicManager.playMusic(OggMusicManager.GAME_MUSIC_SET, options);
     }
 
@@ -223,6 +224,7 @@ public class SolApplication implements ApplicationListener {
 
         solGame = new SolGame(shipName, tut, isNewGame, commonDrawer, context, worldConfig);
         inputManager.setScreen(this, solGame.getScreens().mainGameScreen);
+        musicManager.registerModuleMusic(shipName);
         musicManager.playMusic(OggMusicManager.GAME_MUSIC_SET, options);
     }
 

--- a/engine/src/main/java/org/destinationsol/assets/audio/MusicConfig.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/MusicConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.assets.audio;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MusicConfig {
+    public final String moduleName;
+    public final Map<String, List<String>> musicMap;
+
+    public MusicConfig(String moduleName, Map<String, List<String>> musicMap) {
+        this.moduleName = moduleName;
+        this.musicMap = musicMap;
+    }
+
+    static MusicConfig load(String moduleName, JSONObject config) {
+        List<String> menuMusicSet = new ArrayList<>();
+        List<String> gameMusicSet = new ArrayList<>();
+
+        JSONArray menuMusicArray = config.getJSONArray("menuMusic");
+        JSONArray gameMusicArray = config.getJSONArray("gameMusic");
+
+        for (Object o : menuMusicArray) {
+            if (o instanceof String) {
+                menuMusicSet.add(moduleName + ":" + o);
+            }
+        }
+
+        for (Object o : gameMusicArray) {
+            if (o instanceof String) {
+                gameMusicSet.add(moduleName + ":" + o);
+            }
+        }
+
+        Map<String, List<String>> musicMap = new HashMap<>();
+        musicMap.put(OggMusicManager.MENU_MUSIC_SET, menuMusicSet);
+        musicMap.put(OggMusicManager.GAME_MUSIC_SET, gameMusicSet);
+
+        return new MusicConfig(moduleName, musicMap);
+    }
+
+    public Map<String, List<String>> getMusicMap() {
+        return musicMap;
+    }
+}


### PR DESCRIPTION
# Description
This PR adds supports for Music in Modules. Modules can now have a musicConfig.json file which would define the music files to play, both in-game and in-menu

# musicConfig.json
The JSON must consist of 2 Json arrays - "menuMusic" and "gameMusic" which would contain the respective music files **without** their extension (.ogg).
For the menu, once you launch the game, all menu-music from all modules are loaded to be played.
Once you choose your ship and start/continue a game, the game-music files from the module of that ship would be loaded and played.
NOTE: Make sure to add the music files (.ogg) in module/music too.

# Testing
- Add musicConfig.json along with respective music files to the module. (This PR already contains some test music files, not the best music though :P)
- Run the Game
- Listen to your favorite music in game!
