### PR TITLE
Asteroid moduled

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -123,7 +123,7 @@ public class SolGame {
         gridDrawer = new GridDrawer();
         chunkManager = new ChunkManager();
         partMan = new PartMan();
-        asteroidBuilder = new AsteroidBuilder();
+        asteroidBuilder = new AsteroidBuilder(shipName);
         lootBuilder = new LootBuilder();
         mapDrawer = new MapDrawer();
         shardBuilder = new ShardBuilder();

--- a/engine/src/main/java/org/destinationsol/game/asteroid/Asteroid.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/Asteroid.java
@@ -38,12 +38,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Asteroid implements SolObject {
-    private static final float MIN_SPLIT_SZ = .25f;
-    private static final float MIN_BURN_SZ = .3f;
-    private static final float SZ_TO_LIFE = 20f;
-    private static final float SPD_TO_ATM_DMG = SZ_TO_LIFE * .11f;
-    private static final float MAX_SPLIT_SPD = 1f;
-    private static final float DUR = .5f;
+    private final float MIN_SPLIT_SZ;
+    private final float MIN_BURN_SZ;
+    private final float SZ_TO_LIFE;
+    private final float SPD_TO_ATM_DMG;
+    private final float MAX_SPLIT_SPD;
+    private final float DUR;
 
     private final Body body;
     private final Vector2 position;
@@ -59,7 +59,15 @@ public class Asteroid implements SolObject {
     private float life;
     private float size;
 
-    Asteroid(SolGame game, TextureAtlas.AtlasRegion tex, Body body, float size, RemoveController removeController, ArrayList<Drawable> drawables) {
+    Asteroid(SolGame game, TextureAtlas.AtlasRegion tex, Body body, float size, RemoveController removeController, ArrayList<Drawable> drawables, String moduleName) {
+        AsteroidConfig asteroidConfig = AsteroidConfig.load(moduleName);
+        this.MIN_SPLIT_SZ = asteroidConfig.MIN_SPLIT_SZ;
+        this.MIN_BURN_SZ = asteroidConfig.MIN_BURN_SZ;
+        this.SZ_TO_LIFE = asteroidConfig.SZ_TO_LIFE;
+        this.SPD_TO_ATM_DMG = asteroidConfig.SPD_TO_ATM_DMG;
+        this.MAX_SPLIT_SPD = asteroidConfig.MAX_SPLIT_SPD;
+        this.DUR = asteroidConfig.DUR;
+
         texture = tex;
         this.removeController = removeController;
         this.drawables = drawables;

--- a/engine/src/main/java/org/destinationsol/game/asteroid/Asteroid.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/Asteroid.java
@@ -61,12 +61,12 @@ public class Asteroid implements SolObject {
 
     Asteroid(SolGame game, TextureAtlas.AtlasRegion tex, Body body, float size, RemoveController removeController, ArrayList<Drawable> drawables, String moduleName) {
         AsteroidConfig asteroidConfig = AsteroidConfig.load(moduleName);
-        this.MIN_SPLIT_SZ = asteroidConfig.MIN_SPLIT_SZ;
-        this.MIN_BURN_SZ = asteroidConfig.MIN_BURN_SZ;
-        this.SZ_TO_LIFE = asteroidConfig.SZ_TO_LIFE;
-        this.SPD_TO_ATM_DMG = asteroidConfig.SPD_TO_ATM_DMG;
-        this.MAX_SPLIT_SPD = asteroidConfig.MAX_SPLIT_SPD;
-        this.DUR = asteroidConfig.DUR;
+        this.MIN_SPLIT_SZ = asteroidConfig.minSplitSize;
+        this.MIN_BURN_SZ = asteroidConfig.minBurnSize;
+        this.SZ_TO_LIFE = asteroidConfig.sizeToLife;
+        this.SPD_TO_ATM_DMG = asteroidConfig.speedToAtmDamage;
+        this.MAX_SPLIT_SPD = asteroidConfig.maxSplitSpeed;
+        this.DUR = asteroidConfig.dur;
 
         texture = tex;
         this.removeController = removeController;

--- a/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidBuilder.java
@@ -52,26 +52,25 @@ public class AsteroidBuilder {
         moduleName = getModule(shipName);
         CollisionMeshLoader tempCML;
         List<TextureAtlas.AtlasRegion> tempTextures;
-        try{
-            tempCML = new CollisionMeshLoader(moduleName+":asteroids");// THIS WORKS
-            tempTextures = Assets.listTexturesMatching(moduleName+":asteroid_.*"); //THIS WORKS
-        }catch(RuntimeException e){
-            tempCML = new CollisionMeshLoader("engine:asteroids");// THIS WORKS
-            tempTextures = Assets.listTexturesMatching("engine:asteroid_.*"); //THIS WORKS
+        try {
+            tempCML = new CollisionMeshLoader(moduleName +":asteroids");
+            tempTextures = Assets.listTexturesMatching(moduleName +":asteroid_.*");
+        } catch (RuntimeException e) {
+            tempCML = new CollisionMeshLoader("engine:asteroids");
+            tempTextures = Assets.listTexturesMatching("engine:asteroid_.*");
         }
         collisionMeshLoader = tempCML;
         textures = tempTextures;
     }
 
-    private String getModule(String shipName){
+    private String getModule(String shipName) {
         Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-zA-Z]*:playerSpawnConfig");
 
         for (ResourceUrn configUrn : configUrnList) {Json json = Assets.getJson(configUrn.toString());
             JSONObject rootNode = json.getJsonValue();
 
             if (rootNode.keySet().contains(shipName) && rootNode.get(shipName) instanceof JSONObject) {
-                String moduleName = configUrn.toString().split(":")[0];
-                return moduleName;
+                return configUrn.toString().split(":")[0];
             }
         }
         return "engine";

--- a/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidBuilder.java
@@ -46,17 +46,27 @@ public class AsteroidBuilder {
     private static final float MAX_BALL_SZ = .2f;
     private final CollisionMeshLoader collisionMeshLoader;
     private final List<TextureAtlas.AtlasRegion> textures;
+    private final String moduleName;
 
     public AsteroidBuilder(String shipName) {
-        collisionMeshLoader = new CollisionMeshLoader(getModule(shipName)+":asteroids");// THIS WORKS
-        textures = Assets.listTexturesMatching(getModule(shipName)+":asteroid_.*"); //THIS WORKS*/
+        moduleName = getModule(shipName);
+        CollisionMeshLoader tempCML;
+        List<TextureAtlas.AtlasRegion> tempTextures;
+        try{
+            tempCML = new CollisionMeshLoader(moduleName+":asteroids");// THIS WORKS
+            tempTextures = Assets.listTexturesMatching(moduleName+":asteroid_.*"); //THIS WORKS
+        }catch(RuntimeException e){
+            tempCML = new CollisionMeshLoader("engine:asteroids");// THIS WORKS
+            tempTextures = Assets.listTexturesMatching("engine:asteroid_.*"); //THIS WORKS
+        }
+        collisionMeshLoader = tempCML;
+        textures = tempTextures;
     }
 
     private String getModule(String shipName){
         Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-zA-Z]*:playerSpawnConfig");
 
-        for (ResourceUrn configUrn : configUrnList) {
-            Json json = Assets.getJson(configUrn.toString());
+        for (ResourceUrn configUrn : configUrnList) {Json json = Assets.getJson(configUrn.toString());
             JSONObject rootNode = json.getJsonValue();
 
             if (rootNode.keySet().contains(shipName) && rootNode.get(shipName) instanceof JSONObject) {
@@ -95,9 +105,6 @@ public class AsteroidBuilder {
     // doesn't consume position
     public FarAsteroid buildNewFar(Vector2 position, Vector2 speed, float size, RemoveController removeController) {
         float rotationSpeed = SolRandom.randomFloat(MAX_A_ROT_SPD);
-        /*if(textures.size() < 1){
-            throw new IllegalArgumentException("Could not find any textures");
-        }*/
         return new FarAsteroid(SolRandom.randomElement(textures), new Vector2(position), SolRandom.randomFloat(180), removeController, size, new Vector2(speed), rotationSpeed);
     }
 
@@ -116,7 +123,7 @@ public class AsteroidBuilder {
         body.setAngularVelocity(rotationSpeed);
         body.setLinearVelocity(speed);
 
-        Asteroid asteroid = new Asteroid(game, texture, body, size, removeController, drawables);
+        Asteroid asteroid = new Asteroid(game, texture, body, size, removeController, drawables, moduleName);
         body.setUserData(asteroid);
         return asteroid;
     }

--- a/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidBuilder.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.physics.box2d.CircleShape;
 import com.badlogic.gdx.physics.box2d.FixtureDef;
 import org.destinationsol.Const;
 import org.destinationsol.assets.Assets;
+import org.destinationsol.assets.json.Json;
 import org.destinationsol.common.SolColor;
 import org.destinationsol.common.SolRandom;
 import org.destinationsol.game.CollisionMeshLoader;
@@ -32,9 +33,12 @@ import org.destinationsol.game.SolGame;
 import org.destinationsol.game.drawables.Drawable;
 import org.destinationsol.game.drawables.DrawableLevel;
 import org.destinationsol.game.drawables.RectSprite;
+import org.json.JSONObject;
+import org.terasology.assets.ResourceUrn;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class AsteroidBuilder {
     private static final float DENSITY = 10f;
@@ -43,9 +47,24 @@ public class AsteroidBuilder {
     private final CollisionMeshLoader collisionMeshLoader;
     private final List<TextureAtlas.AtlasRegion> textures;
 
-    public AsteroidBuilder() {
-        collisionMeshLoader = new CollisionMeshLoader("engine:asteroids");
-        textures = Assets.listTexturesMatching("engine:asteroid_.*");
+    public AsteroidBuilder(String shipName) {
+        collisionMeshLoader = new CollisionMeshLoader(getModule(shipName)+":asteroids");// THIS WORKS
+        textures = Assets.listTexturesMatching(getModule(shipName)+":asteroid_.*"); //THIS WORKS*/
+    }
+
+    private String getModule(String shipName){
+        Set<ResourceUrn> configUrnList = Assets.getAssetHelper().list(Json.class, "[a-zA-Z]*:playerSpawnConfig");
+
+        for (ResourceUrn configUrn : configUrnList) {
+            Json json = Assets.getJson(configUrn.toString());
+            JSONObject rootNode = json.getJsonValue();
+
+            if (rootNode.keySet().contains(shipName) && rootNode.get(shipName) instanceof JSONObject) {
+                String moduleName = configUrn.toString().split(":")[0];
+                return moduleName;
+            }
+        }
+        return "engine";
     }
 
     public static Body buildBall(SolGame game, Vector2 position, float angle, float rad, float density, boolean sensor) {
@@ -76,6 +95,9 @@ public class AsteroidBuilder {
     // doesn't consume position
     public FarAsteroid buildNewFar(Vector2 position, Vector2 speed, float size, RemoveController removeController) {
         float rotationSpeed = SolRandom.randomFloat(MAX_A_ROT_SPD);
+        /*if(textures.size() < 1){
+            throw new IllegalArgumentException("Could not find any textures");
+        }*/
         return new FarAsteroid(SolRandom.randomElement(textures), new Vector2(position), SolRandom.randomFloat(180), removeController, size, new Vector2(speed), rotationSpeed);
     }
 

--- a/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.asteroid;
+
+import org.destinationsol.assets.Assets;
+import org.json.JSONObject;
+
+public class AsteroidConfig {
+    public final float MIN_SPLIT_SZ;
+    public final float MIN_BURN_SZ;
+    public final float SZ_TO_LIFE;
+    public final float SPD_TO_ATM_DMG;
+    public final float MAX_SPLIT_SPD;
+    public final float DUR;
+
+    public AsteroidConfig(float min_split_sz,float min_burn_sz,float sz_to_life,float max_split_spd,float dur) {
+        this.MIN_SPLIT_SZ = min_split_sz;
+        this.MIN_BURN_SZ = min_burn_sz;
+        this.SZ_TO_LIFE = sz_to_life;
+        this.SPD_TO_ATM_DMG = sz_to_life * .11f;
+        this.MAX_SPLIT_SPD = max_split_spd;
+        this.DUR = dur;
+    }
+
+    static AsteroidConfig load(String moduleName){
+        JSONObject asteroidConfigs;
+        try{
+            asteroidConfigs = Assets.getJson(moduleName + ":asteroidsConfig").getJsonValue();
+        }catch (RuntimeException e){
+            asteroidConfigs = Assets.getJson("engine:asteroidsConfig").getJsonValue();
+        }
+        float MIN_SPLIT_SZ = asteroidConfigs.getFloat("MIN_SPLIT_SZ");
+        float MIN_BURN_SZ = asteroidConfigs.getFloat("MIN_BURN_SZ");
+        float SZ_TO_LIFE = asteroidConfigs.getFloat("SZ_TO_LIFE");
+        float MAX_SPLIT_SPD = asteroidConfigs.getFloat("MAX_SPLIT_SPD");
+        float DUR = asteroidConfigs.getFloat("DUR");
+        return new AsteroidConfig(MIN_SPLIT_SZ, MIN_BURN_SZ, SZ_TO_LIFE, MAX_SPLIT_SPD, DUR);
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/AsteroidConfig.java
@@ -19,34 +19,34 @@ import org.destinationsol.assets.Assets;
 import org.json.JSONObject;
 
 public class AsteroidConfig {
-    public final float MIN_SPLIT_SZ;
-    public final float MIN_BURN_SZ;
-    public final float SZ_TO_LIFE;
-    public final float SPD_TO_ATM_DMG;
-    public final float MAX_SPLIT_SPD;
-    public final float DUR;
+    public final float minSplitSize;
+    public final float minBurnSize;
+    public final float sizeToLife;
+    public final float speedToAtmDamage;
+    public final float maxSplitSpeed;
+    public final float dur;
 
-    public AsteroidConfig(float min_split_sz,float min_burn_sz,float sz_to_life,float max_split_spd,float dur) {
-        this.MIN_SPLIT_SZ = min_split_sz;
-        this.MIN_BURN_SZ = min_burn_sz;
-        this.SZ_TO_LIFE = sz_to_life;
-        this.SPD_TO_ATM_DMG = sz_to_life * .11f;
-        this.MAX_SPLIT_SPD = max_split_spd;
-        this.DUR = dur;
+    public AsteroidConfig(float minSplitSize,float minBurnSize,float sizeToLife,float maxSplitSpeed,float dur) {
+        this.minSplitSize = minSplitSize;
+        this.minBurnSize = minBurnSize;
+        this.sizeToLife = sizeToLife;
+        this.speedToAtmDamage = sizeToLife * .11f;
+        this.maxSplitSpeed = maxSplitSpeed;
+        this.dur = dur;
     }
 
-    static AsteroidConfig load(String moduleName){
+    static AsteroidConfig load(String moduleName) {
         JSONObject asteroidConfigs;
         try{
             asteroidConfigs = Assets.getJson(moduleName + ":asteroidsConfig").getJsonValue();
         }catch (RuntimeException e){
             asteroidConfigs = Assets.getJson("engine:asteroidsConfig").getJsonValue();
         }
-        float MIN_SPLIT_SZ = asteroidConfigs.getFloat("MIN_SPLIT_SZ");
-        float MIN_BURN_SZ = asteroidConfigs.getFloat("MIN_BURN_SZ");
-        float SZ_TO_LIFE = asteroidConfigs.getFloat("SZ_TO_LIFE");
-        float MAX_SPLIT_SPD = asteroidConfigs.getFloat("MAX_SPLIT_SPD");
-        float DUR = asteroidConfigs.getFloat("DUR");
-        return new AsteroidConfig(MIN_SPLIT_SZ, MIN_BURN_SZ, SZ_TO_LIFE, MAX_SPLIT_SPD, DUR);
+        float minSplitSz = asteroidConfigs.getFloat("MIN_SPLIT_SZ");
+        float minBurnSz = asteroidConfigs.getFloat("MIN_BURN_SZ");
+        float szToLife = asteroidConfigs.getFloat("SZ_TO_LIFE");
+        float maxSplitSpd = asteroidConfigs.getFloat("MAX_SPLIT_SPD");
+        float dur = asteroidConfigs.getFloat("DUR");
+        return new AsteroidConfig(minSplitSz, minBurnSz, szToLife, maxSplitSpd, dur);
     }
 }

--- a/engine/src/main/resources/assets/configs/asteroidsConfig.json
+++ b/engine/src/main/resources/assets/configs/asteroidsConfig.json
@@ -1,0 +1,7 @@
+{
+  "MIN_SPLIT_SZ": ".25f",
+  "MIN_BURN_SZ": ".3f",
+  "SZ_TO_LIFE": "20f",
+  "MAX_SPLIT_SPD": "1f",
+  "DUR": ".5f"
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This PR allows the game to use asteroids (textures and rigidbodies) found in individual modules. New asteroids can be added to modules following the same conventions which are used in the engine. ie, add textures with name `asteroid_0` or 'asteroid_1' etc.
Asteroid parameters (which will be used for all asteroids) can be added in modules with a new `asteroidsConfig.json` file. An example of this file can be found in the engine.

# Testing
Add new textures for asteroids, named `asteroid_0` and incrementing, in the module.
Add the rigidBodies for the new textures by adding a `asteroids.json` file to the module.
Parameters can be added by adding a `asteroidsConfig.json` file to the module.
Examples can be found in this PR.
Run the game and select your module to see the new Asteroids!
