### PR TITLE
Modified validation messages to not show stack trace

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/json/Validator.java
+++ b/engine/src/main/java/org/destinationsol/assets/json/Validator.java
@@ -17,6 +17,7 @@ package org.destinationsol.assets.json;
 
 import org.destinationsol.assets.Assets;
 import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -26,18 +27,24 @@ public class Validator {
 
     static Logger logger = LoggerFactory.getLogger(Validator.class);
 
-    public static void validate(JSONObject json, String schemaPath) {
+    public static void validate(String jsonPath, String schemaPath) {
+        JSONObject json = Assets.getJson(jsonPath).getJsonValue();
         JSONObject schema;
 
         try {
             schema = Assets.getJson(schemaPath).getJsonValue();
         } catch (RuntimeException e) {
-            logger.warn("Json Schema " + schemaPath + " not found!", e);
+            logger.warn("Json Schema " + schemaPath + " not found!");
             return;
         }
 
         Schema schemaValidator = SchemaLoader.load(schema);
-        schemaValidator.validate(json);
+        try {
+            schemaValidator.validate(json);
+        }
+        catch(ValidationException e) {
+            logger.warn("JSON \"" + jsonPath + "\" could not be validated against schema \"" + schemaPath + "\"." + e.getErrorMessage());
+        }
     }
 
 }

--- a/engine/src/main/java/org/destinationsol/files/HullConfigManager.java
+++ b/engine/src/main/java/org/destinationsol/files/HullConfigManager.java
@@ -106,7 +106,7 @@ public final class HullConfigManager {
         Json json = Assets.getJson(shipName);
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaHullConfig");
+        Validator.validate(shipName, "engine:schemaHullConfig");
 
         readProperties(rootNode, configData);
 

--- a/engine/src/main/java/org/destinationsol/game/AbilityCommonConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/AbilityCommonConfigs.java
@@ -33,7 +33,7 @@ public class AbilityCommonConfigs {
         Json json = Assets.getJson("core:abilitiesConfig");
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaAbilitiesConfig");
+        Validator.validate("core:abilitiesConfig", "engine:schemaAbilitiesConfig");
 
         teleport = AbilityCommonConfig.load(rootNode.getJSONObject("teleport"), effectTypes, cols, soundManager);
         emWave = AbilityCommonConfig.load(rootNode.getJSONObject("emWave"), effectTypes, cols, soundManager);

--- a/engine/src/main/java/org/destinationsol/game/CollisionMeshLoader.java
+++ b/engine/src/main/java/org/destinationsol/game/CollisionMeshLoader.java
@@ -63,7 +63,7 @@ public class CollisionMeshLoader {
         Json json = Assets.getJson(fileName);
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaCollisionMesh");
+        Validator.validate(fileName, "engine:schemaCollisionMesh");
 
         readModel(rootNode);
 

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -144,7 +144,7 @@ public class GalaxyFiller {
         Json json = Assets.getJson(moduleName + ":startingStation");
         JSONObject rootNode = getRootNode(json);
 
-        Validator.validate(rootNode, "engine:schemaStartingStation");
+        Validator.validate(moduleName + ":startingStation", "engine:schemaStartingStation");
 
         ShipConfig mainStationCfg = ShipConfig.load(hullConfigManager, rootNode, itemManager);
 

--- a/engine/src/main/java/org/destinationsol/game/GameColors.java
+++ b/engine/src/main/java/org/destinationsol/game/GameColors.java
@@ -37,7 +37,7 @@ public class GameColors {
         Json json = Assets.getJson("core:colorsConfig");
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaColorsConfig");
+        Validator.validate("core:colorsConfig", "engine:schemaColorsConfig");
 
         for (String key : rootNode.keySet()) {
             Color c = load(rootNode.getString(key));

--- a/engine/src/main/java/org/destinationsol/game/PlayerSpawnConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerSpawnConfig.java
@@ -37,7 +37,7 @@ public class PlayerSpawnConfig {
         Json json = Assets.getJson("engine:playerSpawnConfig");
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaPlayerSpawnConfig");
+        Validator.validate("engine:playerSpawnConfig", "engine:schemaPlayerSpawnConfig");
 
         JSONObject playerNode = rootNode.getJSONObject("player");
         ShipConfig shipConfig = ShipConfig.load(hullConfigs, playerNode.has("ship") ? playerNode.getJSONObject("ship") : null, itemManager);

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -91,7 +91,7 @@ public class ShipConfig {
             Json json = Assets.getJson(configUrn.toString());
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaPlayerSpawnConfig");
+            Validator.validate(configUrn.toString(), "engine:schemaPlayerSpawnConfig");
 
             if (rootNode.keySet().contains(shipName) && rootNode.get(shipName) instanceof JSONObject) {
                 shipConfig = load(hullConfigs, rootNode.has(shipName) ? rootNode.getJSONObject(shipName) : null, itemManager);

--- a/engine/src/main/java/org/destinationsol/game/SolNames.java
+++ b/engine/src/main/java/org/destinationsol/game/SolNames.java
@@ -48,7 +48,7 @@ public class SolNames {
         Json json = Assets.getJson(fileName);
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaSolNames");
+        Validator.validate(fileName, "engine:schemaSolNames");
 
         ArrayList<String> list = new ArrayList<>();
         for (String s : rootNode.keySet()) {

--- a/engine/src/main/java/org/destinationsol/game/item/AbilityCharge.java
+++ b/engine/src/main/java/org/destinationsol/game/item/AbilityCharge.java
@@ -101,7 +101,7 @@ public class AbilityCharge implements SolItem {
             Json json = Assets.getJson(abilityName);
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaAbilityCharges");
+            Validator.validate(abilityName, "engine:schemaAbilityCharges");
 
             float price = (float) rootNode.getDouble("price");
             String displayName = rootNode.getString("displayName");

--- a/engine/src/main/java/org/destinationsol/game/item/Armor.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Armor.java
@@ -134,7 +134,7 @@ public class Armor implements SolItem {
             Json json = Assets.getJson(armorName);
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaArmor");
+            Validator.validate(armorName, "engine:schemaArmor");
 
             String displayName = rootNode.getString("displayName");
             int price = rootNode.getInt("price");

--- a/engine/src/main/java/org/destinationsol/game/item/Clip.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Clip.java
@@ -116,7 +116,7 @@ public class Clip implements SolItem {
             Json json = Assets.getJson(clipName);
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaClip");
+            Validator.validate(clipName, "engine:schemaClip");
 
             String projectileName = rootNode.getString("projectile");
             ProjectileConfig projectileConfig = itemManager.projConfigs.find(projectileName);

--- a/engine/src/main/java/org/destinationsol/game/item/Engine.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Engine.java
@@ -125,7 +125,7 @@ public class Engine implements SolItem {
             Json json = Assets.getJson(engineName);
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaEngine");
+            Validator.validate(engineName, "engine:schemaEngine");
 
             boolean isBig = rootNode.getBoolean("big");
             float rotationAcceleration = isBig ? 100f : 515f;

--- a/engine/src/main/java/org/destinationsol/game/item/Gun.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Gun.java
@@ -165,7 +165,7 @@ public class Gun implements SolItem {
             Json json = Assets.getJson(gunName);
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaGun");
+            Validator.validate(gunName, "engine:schemaGun");
 
             float minAngleVar = (float) rootNode.optDouble("minAngleVar", 0);
             float maxAngleVar = (float) rootNode.getDouble("maxAngleVar");

--- a/engine/src/main/java/org/destinationsol/game/item/Shield.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Shield.java
@@ -186,7 +186,7 @@ public class Shield implements SolItem {
             Json json = Assets.getJson(shieldName);
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaShield");
+            Validator.validate(shieldName, "engine:schemaShield");
 
             int maxLife = rootNode.getInt("maxLife");
             float idleTime = (float) rootNode.getDouble("idleTime");

--- a/engine/src/main/java/org/destinationsol/game/item/SolItemTypes.java
+++ b/engine/src/main/java/org/destinationsol/game/item/SolItemTypes.java
@@ -40,7 +40,7 @@ public class SolItemTypes {
         Json json = Assets.getJson("core:types");
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaTypes");
+        Validator.validate("core:types", "engine:schemaTypes");
 
         clip = load(rootNode.getJSONObject("clip"), soundManager, cols);
         shield = load(rootNode.getJSONObject("shield"), soundManager, cols);

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeConfigs.java
@@ -37,7 +37,7 @@ public class MazeConfigs {
             Json json = Assets.getJson(configUrn.toString());
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaMazesConfig");
+            Validator.validate(configUrn.toString(), "engine:schemaMazesConfig");
 
             for (String s : rootNode.keySet()) {
                 if (!(rootNode.get(s) instanceof JSONObject))

--- a/engine/src/main/java/org/destinationsol/game/particle/SpecialEffects.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/SpecialEffects.java
@@ -43,7 +43,7 @@ public class SpecialEffects {
         Json json = Assets.getJson("core:specialEffectsConfig");
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaSpecialEffectsConfig");
+        Validator.validate("core:specialEffectsConfig", "engine:schemaSpecialEffectsConfig");
 
         smoke = EffectConfig.load(rootNode.getJSONObject("smoke"), effectTypes, colours);
         fire = EffectConfig.load(rootNode.getJSONObject("fire"), effectTypes, colours);

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetConfigs.java
@@ -51,7 +51,7 @@ public class PlanetConfigs {
             Json json = Assets.getJson(planetConfigJson.toString());
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaPlanetsConfig");
+            Validator.validate(planetConfigJson.toString(), "engine:schemaPlanetsConfig");
 
             for (String s : rootNode.keySet()) {
                 JSONObject node = rootNode.getJSONObject(s);

--- a/engine/src/main/java/org/destinationsol/game/planet/SysConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/SysConfigs.java
@@ -52,7 +52,7 @@ public class SysConfigs {
         Json json = Assets.getJson("engine:" + configName);
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaSystemsConfig");
+        Validator.validate("engine:" + configName, "engine:schemaSystemsConfig");
 
         for (String s : rootNode.keySet()) {
             if (!(rootNode.get(s) instanceof JSONObject))
@@ -77,7 +77,7 @@ public class SysConfigs {
             json = Assets.getJson(configUrn.toString());
             rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaSystemsConfig");
+            Validator.validate(configUrn.toString(), "engine:schemaSystemsConfig");
 
             for (String s : rootNode.keySet()) {
                 if (!(rootNode.get(s) instanceof JSONObject))

--- a/engine/src/main/java/org/destinationsol/game/projectile/ProjectileConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/ProjectileConfigs.java
@@ -47,7 +47,7 @@ public class ProjectileConfigs {
             Json json = Assets.getJson(configUrn.toString());
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaProjectileConfig");
+            Validator.validate(configUrn.toString(), "engine:schemaProjectileConfig");
 
             for (String s : rootNode.keySet()) {
                 if (!(rootNode.get(s) instanceof JSONObject))

--- a/engine/src/main/java/org/destinationsol/game/ship/ShipBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/ShipBuilder.java
@@ -266,7 +266,7 @@ public class ShipBuilder {
         Json json = Assets.getJson(shipName);
         JSONObject rootNode = json.getJsonValue();
 
-        Validator.validate(rootNode, "engine:schemaHullConfig");
+        Validator.validate(shipName, "engine:schemaHullConfig");
 
         JSONObject rigidBodyNode = rootNode.getJSONObject("rigidBody");
         myCollisionMeshLoader.readRigidBody(rigidBodyNode, hullConfig);

--- a/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/NewShipScreen.java
@@ -120,7 +120,7 @@ public class NewShipScreen extends SolUiBaseScreen {
             Json json = Assets.getJson(configUrn.toString());
             JSONObject rootNode = json.getJsonValue();
 
-            Validator.validate(rootNode, "engine:schemaPlayerSpawnConfig");
+            Validator.validate(configUrn.toString(), "engine:schemaPlayerSpawnConfig");
 
             for (String s : rootNode.keySet()) {
                 playerSpawnConfigNames.add(s);


### PR DESCRIPTION
# Description
This PR modifies the log messages for schema validations so that they don't show the stack trace.

# Testing
Run the game and check the log messages for schema not found/validation exception. They should now be shorter and without the stack trace.
