### PR TITLE
Schema fixes for display names and schemaGun.json

### DIFF
--- a/engine/src/main/resources/assets/schemas/schemaAbilityCharges.json
+++ b/engine/src/main/resources/assets/schemas/schemaAbilityCharges.json
@@ -16,7 +16,8 @@
     "displayName": {
       "type": "string",
       "minLength": 1,
-      "description": "Name of the ability charge"
+      "description": "Name of the ability charge",
+      "pattern": "^[ -~]+$"
     },
     "desc": {
       "type": "string",

--- a/engine/src/main/resources/assets/schemas/schemaArmor.json
+++ b/engine/src/main/resources/assets/schemas/schemaArmor.json
@@ -12,7 +12,8 @@
   "properties": {
     "displayName": {
       "type": "string",
-      "description": "Name of the armor"
+      "description": "Name of the armor",
+      "pattern": "^[ -~]+$"
     },
     "price":{
       "type": "integer",

--- a/engine/src/main/resources/assets/schemas/schemaGun.json
+++ b/engine/src/main/resources/assets/schemas/schemaGun.json
@@ -17,17 +17,22 @@
   ],
   "properties": {
     "maxAngleVar": {
-      "type": "integer",
+      "type": "number",
       "minimum": 0,
       "description": "Maximum angle variation for a shot from the center of the gun"
     },
+    "minAngleVar": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Minimum angle variation for a shot from the center of a gun"
+    },
     "angleVarDamp": {
-      "type": "integer",
+      "type": "number",
       "minimum": 0,
       "description": "Puts a damper or delay on the angle variation"
     },
     "angleVarPerShot": {
-      "type": "integer",
+      "type": "number",
       "minimum": 0,
       "description": "Controls how much the angle of the bullet can vary from shot to shot"
     },
@@ -59,7 +64,8 @@
     "displayName": {
       "type": "string",
       "minLength": 1,
-      "description": "Name to be displayed in inventories and trading stations"
+      "description": "Name to be displayed in inventories and trading stations",
+      "pattern": "^[ -~]+$"
     },
     "shootSounds": {
       "type": "array",

--- a/engine/src/main/resources/assets/schemas/schemaHullConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaHullConfig.json
@@ -61,7 +61,8 @@
     },
     "displayName": {
       "type": "string",
-      "description": "Human friendly name of the ship"
+      "description": "Human friendly name of the ship",
+      "pattern": "^[ -~]+$"
     },
     "price": {
       "type": "number",

--- a/engine/src/main/resources/assets/schemas/schemaPlayerSpawnConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaPlayerSpawnConfig.json
@@ -3,8 +3,8 @@
   "description": "Settings for different ships, classifying the hull and items/money given to the player on spawn.",
   "propertyNames": {
     "type": "string",
-    "pattern": "^\\w+( \\w+)*$",
-    "description": "Ship names can be any non-blank string of basic alphanumeric characters with or without single spaces. Spaces cannot be at the beginning or end of the ship name."
+    "pattern": "^[ -~]+$",
+    "description": "Ship names can be any non-blank string of ascii characters."
   },
   "additionalProperties": {
     "type": "object",

--- a/engine/src/main/resources/assets/schemas/schemaSolNames.json
+++ b/engine/src/main/resources/assets/schemas/schemaSolNames.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Names for in-game systems/planets, selected randomly in world generation",
   "propertyNames": {
-    "pattern": "^\\w+( \\w+)*$",
-    "description": "System/Planet names can be any non-blank string of basic alphanumeric characters with or without single spaces. Spaces cannot be at the beginning or end of the name."
+    "pattern": "^[ -~]+$",
+    "description": "System/Planet names can be any non-blank string of ascii characters."
   }
 }


### PR DESCRIPTION
# Description
This PR fixes two things in the JSON schemas:
1. All display names have been expanded/limited to allow all ascii characters from 32-126. (space-tilde)
2. `schemaGun.json` now allows decimal values for angle variations, and `minAngleVar` is now validated.

# Testing
- Change a display name field to include ascii punctuation (like `Gooey's Old Ship!`) and the schema should pass.
- Change a display name field to include an unprintable character (like `é è ç à`) and the schema should fail.
- Angle variation values in `schemaGun.json` should pass schema validation with decimal values.