### PR TITLE
Completing schemas for JSON validation

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/FactionInfo.java
+++ b/engine/src/main/java/org/destinationsol/game/FactionInfo.java
@@ -41,7 +41,7 @@ public class FactionInfo {
     private void createFactionList() {
         for (String modulePath : getModuleSet()) {
             Json factionJson = Assets.getJson(modulePath);
-            Validator.getValidatedJSON(modulePath, "engine:schemaAbilitiesConfig");
+            Validator.getValidatedJSON(modulePath, "engine:schemaFactions");
             JSONArray factionJsonArray = factionJson.getJsonValue().getJSONArray("factions");
             for (int n = 0; n < factionJsonArray.length(); n++) {
                 factionName.add(factionJsonArray.getJSONObject(n).getString("name").replace("\"", ""));
@@ -72,7 +72,7 @@ public class FactionInfo {
         String shipName = ship.getHull().getHullConfig().getInternalName();
         for(String modulePath: getModuleSet()) {
             Json factionJson = Assets.getJson(modulePath);
-            Validator.getValidatedJSON(modulePath, "engine:schemaAbilitiesConfig");
+            Validator.getValidatedJSON(modulePath, "engine:schemaFactions");
             JSONArray factionJsonArray = factionJson.getJsonValue().getJSONArray("factions");
             shipName = shipName.replaceAll(".*:", "");
             for(int n = 0; n < factionJsonArray.length(); n++) {

--- a/engine/src/main/resources/assets/schemas/schemaAbilitiesConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaAbilitiesConfig.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configuration for the effects/sounds linked to in-game special abilities.",
+  "propertyNames": {
+    "pattern": "^\\w+$",
+    "description": "Ability names must be a sequence of basic alphanumeric characters without a space."
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": [
+      "activatedSound"
+    ],
+    "properties": {
+      "activatedSound": {
+        "type": "string",
+        "description": "The gestalt id of the sound effect played upon ability activation.",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "effect": {
+        "type": "object",
+        "description": "The particle effect used upon ability activation.",
+        "properties": {
+          "effectFile": {
+            "type": "string",
+            "pattern": "^\\w+:\\w+$",
+            "description": "The gestalt id of the .emitter file for this particle effect."
+          },
+          "tex": {
+            "type": "string",
+            "pattern": "^\\w+:\\w+$",
+            "description": "The gestalt id of the particle texture for this effect."
+          },
+          "tint": {
+            "type": "string",
+            "description": "Colors can be defined as a keyword, or in the form `rrr ggg bbb`, `rrr ggg bbb aaa`, `hsb hhh sss bbb` or `hsb hhh sss bbb aaa`",
+            "pattern": "^(\\w+|(hsb (((360)|(3[0-5]\\d)|([012]?\\d?\\d))( ((100)|\\d?\\d)){2})|(((([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])) ){2}(([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5]))))( (([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])))?)$"
+          },
+          "floatsUp": {
+            "type": "boolean",
+            "description": "True if particles will float opposing the gravity of the nearest planet, default false."
+          },
+          "size": {
+            "type": "number",
+            "description": "The default unit size of each individual particle. Almost always overwritten for special effects."
+          }
+        }
+      }
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaAbilitiesConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaAbilitiesConfig.json
@@ -43,7 +43,12 @@
             "type": "number",
             "description": "The default unit size of each individual particle. Almost always overwritten for special effects."
           }
-        }
+        },
+        "required": [
+          "effectFile",
+          "tex",
+          "tint"
+        ]
       }
     }
   }

--- a/engine/src/main/resources/assets/schemas/schemaFactions.json
+++ b/engine/src/main/resources/assets/schemas/schemaFactions.json
@@ -30,7 +30,13 @@
               "pattern": "^\\w+$"
             }
           }
-        }
+        },
+        "required": [
+          "name",
+          "color",
+          "disposition",
+          "ships"
+        ]
       }
     }
   }

--- a/engine/src/main/resources/assets/schemas/schemaFactions.json
+++ b/engine/src/main/resources/assets/schemas/schemaFactions.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configuration for in-game factions and the members of the factions.",
+  "properties": {
+    "factions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Faction names can be any non-blank string of ascii characters.",
+            "pattern": "^[ -~]+$"
+          },
+          "color": {
+            "type": "string",
+            "description": "Faction colors are hexidecimal, in the form RRGGBB(AA).",
+            "pattern": "^([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6})$"
+          },
+          "disposition": {
+            "type": "integer",
+            "description": "The opinion of the faction towards the player. Positive is friendly, negative is hostile. Faction will attack player when disposition < 0."
+          },
+          "ships": {
+            "type": "array",
+            "description": "The list of ships in this faction.",
+            "items": {
+              "type": "string",
+              "description": "The string Id of this ship. Can be any sequence of basic alphanumeric characters without a space.",
+              "pattern": "^\\w+$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaMazesConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaMazesConfig.json
@@ -39,9 +39,19 @@
         "farJunkDensity": {
           "type": "number",
           "description": "The density of placement of far space junk."
-        }
+        },
+        "required": [
+          "junkTexs",
+          "junkDensity",
+          "farJunkTexs",
+          "farJunkDensity"
+        ]
       }
-    }
+    },
+    "required": [
+      "isMetal",
+      "environment"
+    ]
   },
   "definitions": {
     "ship": {

--- a/engine/src/main/resources/assets/schemas/schemaMazesConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaMazesConfig.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "The configuration for various mazes that spawn in the world.",
+  "propertyNames": {
+    "description": "Maze names can be any non-blank string of basic alphanumeric characters without spaces.",
+    "pattern": "^\\w+$"
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "isMetal": {
+        "type": "boolean",
+        "description": "True if this surface is metal, false otherwise. Metal surfaces make special sounds on impact."
+      },
+      "outerEnemies": {
+        "$ref": "#/definitions/shipArray"
+      },
+      "innerEnemies": {
+        "$ref": "#/definitions/shipArray"
+      },
+      "bosses": {
+        "$ref": "#/definitions/shipArray"
+      },
+      "environment": {
+        "junkTexs": {
+          "type": "string",
+          "description": "The root gestalt ID for the near space junk textures that make up the maze.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "junkDensity": {
+          "type": "number",
+          "description": "The density of placement of near space junk."
+        },
+        "farJunkTexs": {
+          "type": "string",
+          "descriptions": "The root gestalt ID for the far space junk textures that make up the maze.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "farJunkDensity": {
+          "type": "number",
+          "description": "The density of placement of far space junk."
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ship": {
+      "type": "object",
+      "properties": {
+        "hull": {
+          "type": "string",
+          "description": "Id of the hull of this ship.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "items": {
+          "$ref": "#/definitions/items"
+        },
+        "money": {
+          "type": "integer",
+          "description": "Starting money for the player on spawn."
+        },
+        "density": {
+          "type": "number",
+          "description": "The density of these ships present on the planet. N/A for 'station'",
+          "exclusiveMinimum": 0
+        }
+      },
+      "required": [
+        "hull",
+        "items",
+        "money"
+      ]
+    },
+    "shipArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ship"
+      }
+    },
+    "items": {
+      "type": "string",
+      "description": "Space separated list of items the ship possesses on spawn. See /docs/items.txt for a more detailed explanation.",
+      "pattern": "^(((0(\\.\\d+)?|1\\.0)\\|)?(\\d+\\*)?(\\w+(:\\w+)?(-[12])?)(\\+(\\w+(:\\w+)?(-[12])?))*)( ((0(\\.\\d+)?|1\\.0)\\|)?(\\d+\\*)?(\\w+(:\\w+)?(-[12])?)(\\+(\\w+(:\\w+)?(-[12])?))*)* ?$"
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaPlanetsConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaPlanetsConfig.json
@@ -162,7 +162,11 @@
           "description": "The density of these ships present on the planet. N/A for 'station'",
           "exclusiveMinimum": 0
         }
-      }
+      },
+      "required": [
+        "hull",
+        "items"
+      ]
     },
     "items": {
       "type": "string",

--- a/engine/src/main/resources/assets/schemas/schemaPlanetsConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaPlanetsConfig.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configuration for planets that spawn in the world.",
+  "propertyNames": {
+    "pattern": "^\\w+$",
+    "description": "Planet config names must be a sequence of basic alphanumeric characters without a space."
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": [
+      "minGrav",
+      "maxGrav",
+      "cloudTexs",
+      "groundTexs",
+      "rowCount"
+    ],
+    "properties": {
+      "minGrav": {
+        "type": "number",
+        "description": "The minimum value of gravity for this planet.",
+        "minimum": 0
+      },
+      "maxGrav": {
+        "type": "number",
+        "description": "The maximum value of gravity for this planet.",
+        "minimum": 0
+      },
+      "decorations": {
+        "type": "object",
+        "propertyNames": {
+          "description": "Decoration config names must be the gestalt ID of the decoration texture.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "density": {
+              "type": "number",
+              "description": "The frequency of placement for this decoration on the planet.",
+              "exclusiveMinimum": 0
+            },
+            "szMin": {
+              "type": "number",
+              "description": "The minimum size of this decoration.",
+              "exclusiveMinimum": 0
+            },
+            "szMax": {
+              "type": "number",
+              "description": "The maximum size of this decoration.",
+              "exclusiveMinimum": 0
+            },
+            "orig": {
+              "$ref": "#/definitions/vec2"
+            },
+            "allowFlip": {
+              "type": "boolean",
+              "description": "True if the decoration could be drawn flipped, false otherwise."
+            }
+          },
+          "required": [
+            "density",
+            "szMin",
+            "szMax",
+            "orig",
+            "allowFlip"
+          ]
+        }
+      },
+      "highOrbitEnemies": {
+        "$ref": "#/definitions/shipArray"
+      },
+      "lowOrbitEnemies": {
+        "$ref": "#/definitions/shipArray"
+      },
+      "groundEnemies": {
+        "$ref": "#/definitions/shipArray"
+      },
+      "station": {
+        "$ref": "#/definitions/ship"
+      },
+      "cloudTexs": {
+        "type": "string",
+        "description": "The root gestalt ID of the textures for the planet's clouds.",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "groundTexs": {
+        "type": "string",
+        "description": "The root gestalt ID of the JSON config and textures for the planet ground.",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "sky": {
+        "type": "object",
+        "description": "The configuration for the colors in the planet's sky.",
+        "properties": {
+          "dawnColor": {
+            "$ref": "#/definitions/color"
+          },
+          "dayColor": {
+            "$ref": "#/definitions/color"
+          }
+        }
+      },
+      "rows": {
+        "type": "integer",
+        "description": "The number of iterations performed during planet generation.",
+        "exclusiveMinimum": 0
+      },
+      "smoothLandscape": {
+        "type": "boolean",
+        "description": "True if smoothing should be performed on the planet terrain, false otherwise."
+      },
+      "trading": {
+        "type": "object",
+        "description": "The configuration of the trading stations that spawn on the planet.",
+        "properties": {
+          "items": {
+            "$ref": "#/definitions/items"
+          },
+          "ships": {
+            "type": "string",
+            "description": "A list of ships that the player can change their ship to.",
+            "pattern": "^(\\w+:\\w+)( \\w+:\\w+)*$"
+          },
+          "mercenaries": {
+            "$ref": "#/definitions/shipArray"
+          }
+        }
+      },
+      "hardOnly": {
+        "type": "boolean",
+        "description": "True if the planet should only be spawned when the parent system is in hard mode. False by default."
+      },
+      "easyOnly": {
+        "type": "boolean",
+        "description": "True if the planet should only be spawned when the parent system is in easy mode, False by default."
+      }
+    }
+  },
+  "definitions": {
+    "vec2": {
+      "type": "string",
+      "pattern": "^(-?([0-9]*\\.)?[0-9]+ +(-?[0-9]*\\.)?[0-9]+)$",
+      "$comment": "2 float values separated by one or more spaces, ints also accepted"
+    },
+    "ship": {
+      "type": "object",
+      "properties": {
+        "hull": {
+          "type": "string",
+          "description": "Id of the hull of this ship.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "items": {
+          "$ref": "#/definitions/items"
+        },
+        "money": {
+          "type": "integer",
+          "description": "Starting money for the player on spawn."
+        },
+        "density": {
+          "type": "number",
+          "description": "The density of these ships present on the planet. N/A for 'station'",
+          "exclusiveMinimum": 0
+        }
+      }
+    },
+    "items": {
+      "type": "string",
+      "description": "Space separated list of items the ship possesses on spawn. See /docs/items.txt for a more detailed explanation.",
+      "pattern": "^(((0(\\.\\d+)?|1\\.0)\\|)?(\\d+\\*)?(\\w+(:\\w+)?(-[12])?)(\\+(\\w+(:\\w+)?(-[12])?))*)( ((0(\\.\\d+)?|1\\.0)\\|)?(\\d+\\*)?(\\w+(:\\w+)?(-[12])?)(\\+(\\w+(:\\w+)?(-[12])?))*)* ?$"
+    },
+    "shipArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ship"
+      }
+    },
+    "color": {
+      "type": "string",
+      "pattern": "^((hsb (((360)|(3[0-5]\\d)|([012]?\\d?\\d))( ((100)|\\d?\\d)){2})|(((([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])) ){2}(([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5]))))( (([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])))?)$",
+      "description": "Color can be defined in the form `rrr ggg bbb`, `rrr ggg bbb aaa`, `hsb hhh sss bbb` or `hsb hhh sss bbb aaa`"
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaProjectileConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaProjectileConfig.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configuration for various projectile shot by guns on ships.",
+  "propertyNames": {
+    "pattern": "^\\w+$",
+    "description": "Projectile names must be a sequence of basic alphanumeric characters without a space."
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": [
+      "tex",
+      "texSz",
+      "speed",
+      "dmgType",
+      "dmg"
+    ],
+    "properties": {
+      "tex": {
+        "type": "string",
+        "description": "The gestalt ID of the texture for this projectile. The file should have 'Projectile' as a prefix.",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "texSz": {
+        "type": "number",
+        "description": "The scale factor of the texture of this projectile.",
+        "minimum": 0
+      },
+      "speed": {
+        "type": "number",
+        "description": "The speed of this projectile when fired."
+      },
+      "physSize": {
+        "type": "number",
+        "description": "The diameter of the bounding circle of this projectile.",
+        "exclusiveMinimum": 0
+      },
+      "stretch": {
+        "type": "boolean",
+        "description": "True if the texture should stretch vertically to resize, false to scale the texture instead. Defaults to false."
+      },
+      "dmgType": {
+        "type": "string",
+        "description": "The type of damage dealt by this projectile on contact.",
+        "enum": [
+          "bullet",
+          "explosion",
+          "energy",
+          "crash",
+          "fire"
+        ]
+      },
+      "collisionSound": {
+        "type": "string",
+        "description": "The gestalt id of the sound effect played on projectile collision",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "lightSz": {
+        "type": "number",
+        "description": "The size of the light source on this projectile. Size of zero by default.",
+        "minimun": 0
+      },
+      "trailEffect": {
+        "$ref": "#/definitions/effect"
+      },
+      "bodyEffect": {
+        "$ref": "#/definitions/effect"
+      },
+      "collisionEffect": {
+        "$ref": "#/definitions/effect"
+      },
+      "collisionEffectBg": {
+        "$ref": "#/definitions/effect"
+      },
+      "guideRotationSpeed": {
+        "type": "number",
+        "description": "How fast the projectile will guide itself towards a target. 0 by default."
+      },
+      "zeroAbsSpd": {
+        "type": "boolean",
+        "description": "True if bullet velocity should not be relative to the gun's velocity. False by default."
+      },
+      "texOrig": {
+        "$ref": "#/definitions/vec2"
+      },
+      "acceleration": {
+        "type": "number",
+        "description": "The acceleration acting on this projectile. Zero by default."
+      },
+      "workSound": {
+        "type": "string",
+        "description": "The gestalt ID of the sound played every frame of the projectile's motion.",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "massless": {
+        "type": "boolean",
+        "description": "True if the projectile does not have mass. False by default."
+      },
+      "density": {
+        "type": "number",
+        "description": "The density of this projectile. Effects various collision behavior. -1 by default."
+      },
+      "dmg": {
+        "type": "number",
+        "description": "The base damage caused to an object when shot by this projectile",
+        "minimum": 0
+      },
+      "emTime": {
+        "type": "number",
+        "description": "The time that an enemy is disabled after collision. 0 by default.",
+        "minimum": 0
+      }
+    }
+  },
+  "definitions": {
+    "vec2": {
+      "type": "string",
+      "pattern": "^(-?([0-9]*\\.)?[0-9]+ +(-?[0-9]*\\.)?[0-9]+)$",
+      "$comment": "2 float values separated by one or more spaces, ints also accepted"
+    },
+    "effect": {
+      "type": "object",
+      "properties": {
+        "effectFile": {
+          "type": "string",
+          "pattern": "^\\w+:\\w+$",
+          "description": "The gestalt id of the .emitter file for this particle effect."
+        },
+        "tex": {
+          "type": "string",
+          "pattern": "^\\w+:\\w+$",
+          "description": "The gestalt id of the particle texture for this effect."
+        },
+        "tint": {
+          "type": "string",
+          "pattern": "^(\\w+|(hsb (((360)|(3[0-5]\\d)|([012]?\\d?\\d))( ((100)|\\d?\\d)){2})|(((([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])) ){2}(([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5]))))( (([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])))?)$",
+          "description": "A keyword of a color defined in colorsConfig or in GameColors.java. Must be any sequence of basic alphanumeric characters without a space."
+        },
+        "floatsUp": {
+          "type": "boolean",
+          "description": "True if particles will float opposing the gravity of the nearest planet, default false."
+        },
+        "size": {
+          "type": "number",
+          "description": "The default unit size of each individual particle. Almost always overwritten for special effects."
+        }
+      },
+      "required": [
+        "effectFile",
+        "tex",
+        "tint"
+      ]
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaShield.json
+++ b/engine/src/main/resources/assets/schemas/schemaShield.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "A shield is an item that protects ships from losing health when attacked.",
+  "required": [
+    "maxLife",
+    "idleTime",
+    "regenSpd",
+    "bulletDmgFactor",
+    "energyDmgFactor",
+    "explosionDmgFactor",
+    "displayName",
+    "price",
+    "absorbSound",
+    "regenSound"
+  ],
+  "properties": {
+    "maxLife": {
+      "type": "integer",
+      "description": "The maximum life that this shield can possess.",
+      "exclusiveMinimum": 0
+    },
+    "idleTime": {
+      "type": "number",
+      "description": "The amount of idle time needed before shield health regenerates.",
+      "minimum": 0
+    },
+    "regenSpd": {
+      "type": "number",
+      "description": "The speed of health regeneration, in health points per second.",
+      "minimum": 0
+    },
+    "bulletDmgFactor": {
+      "type": "number",
+      "description": "The damage multiplier when the damage is bullet typed."
+    },
+    "energyDmgFactor": {
+      "type": "number",
+      "description": "The damage multiplier when the damage is energy typed."
+    },
+    "explosionDmgFactor": {
+      "type": "number",
+      "description": "The damage multiplier when the damage is explosion typed."
+    },
+    "displayName": {
+      "type": "string",
+      "description": "The display name of this shield. Must be any non-blank string of printable ascii characters.",
+      "pattern": "^[ -~]+$"
+    },
+    "price": {
+      "type": "integer",
+      "description": "The cost to buy/sell this shield."
+    },
+    "absorbSound": {
+      "type": "string",
+      "description": "The gestalt ID of the sound effect played upon damage absorption",
+      "pattern": "^\\w+:\\w+$"
+    },
+    "absorbSoundPitch": {
+      "type": "number",
+      "description": "The multiplier to raise/lower the pitch of absorbSound by."
+    },
+    "regenSound": {
+      "type": "string",
+      "description": "The gestalt ID of the sound effect played upon shield regen",
+      "pattern": "^\\w+:\\w+$"
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaSpecialEffectsConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaSpecialEffectsConfig.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configuration for visual particle effects, such as smoke, fire, exhaust, etc.",
+  "propertyNames": {
+    "pattern": "^\\w+$",
+    "description": "Effect names must be a sequence of basic alphanumeric characters without a space."
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": [
+      "effectFile",
+      "tex",
+      "tint"
+    ],
+    "properties": {
+      "effectFile": {
+        "type": "string",
+        "pattern": "^\\w+:\\w+$",
+        "description": "The gestalt id of the .emitter file for this particle effect."
+      },
+      "tex": {
+        "type": "string",
+        "pattern": "^\\w+:\\w+$",
+        "description": "The gestalt id of the particle texture for this effect."
+      },
+      "tint": {
+        "type": "string",
+        "pattern": "^\\w+$",
+        "description": "A keyword of a color defined in colorsConfig or in GameColors.java. Must be any sequence of basic alphanumeric characters without a space."
+      },
+      "floatsUp": {
+        "type": "boolean",
+        "description": "True if particles will float opposing the gravity of the nearest planet, default false."
+      },
+      "size": {
+        "type": "number",
+        "description": "The default unit size of each individual particle. Almost always overwritten for special effects."
+      }
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaSystemsConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaSystemsConfig.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configurations for space systems created in world generation.",
+  "propertyNames": {
+    "description": "The system type that the configuration should be applied to.",
+    "enum": [
+      "standard",
+      "hard"
+    ]
+  },
+  "additionalItems": {
+    "type": "object",
+    "properties": {
+      "hard": {
+        "type": "boolean",
+        "description": "True if this is the 'hard' configuration, false by default."
+      },
+      "constantAllies": {
+        "$ref": "#/definitions/shipSpawnConfig"
+      },
+      "constantEnemies": {
+        "$ref": "#/definitions/shipSpawnConfig"
+      },
+      "temporaryEnemies": {
+        "$ref": "#/definitions/shipSpawnConfig"
+      },
+      "innerTemporaryEnemies": {
+        "$ref": "#/definitions/shipSpawnConfig"
+      },
+      "trading": {
+        "type": "object",
+        "description": "The trade configuration of friendly stations/large ships in this system.",
+        "properties": {
+          "items": {
+            "$ref": "#/definitions/items"
+          },
+          "ships": {
+            "type": "string",
+            "description": "A list of ships that are available to be changed into."
+          },
+          "mercenaries": {
+            "type": "array",
+            "description": "A list of mercenaries available for hire.",
+            "items": {
+              "$ref": "#/definitions/shipConfig"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "shipSpawnConfig": {
+      "type": "object",
+      "description": "The spawn configuration of a single ship.",
+      "properties": {
+        "hull": {
+          "type": "string",
+          "description": "Id of the hull of this ship.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "items": {
+          "$ref": "#/definitions/items"
+        },
+        "money": {
+          "type": "integer",
+          "description": "Starting money for the ship on spawn."
+        },
+        "density": {
+          "type": "number",
+          "description": "The density of these ships present in the system.",
+          "exclusiveMinimum": 0
+        },
+        "guard": {
+          "ref": "#/definitions/ship"
+        }
+      },
+      "required": [
+        "hull",
+        "items",
+        "money",
+        "density"
+      ]
+    },
+    "shipConfig": {
+      "type": "object",
+      "description": "The configuration of a single ship.",
+      "properties": {
+        "hull": {
+          "type": "string",
+          "description": "Id of the hull of this ship.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "items": {
+          "$ref": "#/definitions/items"
+        },
+        "money": {
+          "type": "integer",
+          "description": "Starting money for the ship on spawn."
+        },
+        "guard": {
+          "ref": "#/definitions/ship"
+        }
+      },
+      "required": [
+        "hull",
+        "items",
+        "money"
+      ]
+    },
+    "items": {
+      "type": "string",
+      "description": "Space separated list of items the ship possesses on spawn. See /docs/items.txt for a more detailed explanation.",
+      "pattern": "^(((0(\\.\\d+)?|1\\.0)\\|)?(\\d+\\*)?(\\w+(:\\w+)?(-[12])?)(\\+(\\w+(:\\w+)?(-[12])?))*)( ((0(\\.\\d+)?|1\\.0)\\|)?(\\d+\\*)?(\\w+(:\\w+)?(-[12])?)(\\+(\\w+(:\\w+)?(-[12])?))*)* ?$"
+    }
+  }
+}

--- a/engine/src/main/resources/assets/schemas/schemaSystemsConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaSystemsConfig.json
@@ -61,7 +61,13 @@
         "farJunkDensity": {
           "type": "number",
           "description": "The density of placement of far space junk."
-        }
+        },
+        "required": [
+          "junkTexs",
+          "junkDensity",
+          "farJunkTexs",
+          "farJunkDensity"
+        ]
       }
     }
   },

--- a/engine/src/main/resources/assets/schemas/schemaSystemsConfig.json
+++ b/engine/src/main/resources/assets/schemas/schemaSystemsConfig.json
@@ -8,7 +8,7 @@
       "hard"
     ]
   },
-  "additionalItems": {
+  "additionalProperties": {
     "type": "object",
     "properties": {
       "hard": {
@@ -16,16 +16,16 @@
         "description": "True if this is the 'hard' configuration, false by default."
       },
       "constantAllies": {
-        "$ref": "#/definitions/shipSpawnConfig"
+        "$ref": "#/definitions/shipArray"
       },
       "constantEnemies": {
-        "$ref": "#/definitions/shipSpawnConfig"
+        "$ref": "#/definitions/shipArray"
       },
       "temporaryEnemies": {
-        "$ref": "#/definitions/shipSpawnConfig"
+        "$ref": "#/definitions/shipArray"
       },
       "innerTemporaryEnemies": {
-        "$ref": "#/definitions/shipSpawnConfig"
+        "$ref": "#/definitions/shipArray"
       },
       "trading": {
         "type": "object",
@@ -39,20 +39,35 @@
             "description": "A list of ships that are available to be changed into."
           },
           "mercenaries": {
-            "type": "array",
-            "description": "A list of mercenaries available for hire.",
-            "items": {
-              "$ref": "#/definitions/shipConfig"
-            }
+            "$ref": "#/definitions/shipArray"
           }
+        }
+      },
+      "environment": {
+        "junkTexs": {
+          "type": "string",
+          "description": "The root gestalt ID for the near space junk textures that make up the maze.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "junkDensity": {
+          "type": "number",
+          "description": "The density of placement of near space junk."
+        },
+        "farJunkTexs": {
+          "type": "string",
+          "descriptions": "The root gestalt ID for the far space junk textures that make up the maze.",
+          "pattern": "^\\w+:\\w+$"
+        },
+        "farJunkDensity": {
+          "type": "number",
+          "description": "The density of placement of far space junk."
         }
       }
     }
   },
   "definitions": {
-    "shipSpawnConfig": {
+    "ship": {
       "type": "object",
-      "description": "The spawn configuration of a single ship.",
       "properties": {
         "hull": {
           "type": "string",
@@ -64,49 +79,27 @@
         },
         "money": {
           "type": "integer",
-          "description": "Starting money for the ship on spawn."
+          "description": "Starting money for the player on spawn."
         },
         "density": {
           "type": "number",
-          "description": "The density of these ships present in the system.",
+          "description": "The density of these ships present on the planet. N/A for 'station'",
           "exclusiveMinimum": 0
         },
         "guard": {
-          "ref": "#/definitions/ship"
+          "$ref": "#/definitions/ship"
         }
       },
       "required": [
         "hull",
-        "items",
-        "money",
-        "density"
+        "items"
       ]
     },
-    "shipConfig": {
-      "type": "object",
-      "description": "The configuration of a single ship.",
-      "properties": {
-        "hull": {
-          "type": "string",
-          "description": "Id of the hull of this ship.",
-          "pattern": "^\\w+:\\w+$"
-        },
-        "items": {
-          "$ref": "#/definitions/items"
-        },
-        "money": {
-          "type": "integer",
-          "description": "Starting money for the ship on spawn."
-        },
-        "guard": {
-          "ref": "#/definitions/ship"
-        }
-      },
-      "required": [
-        "hull",
-        "items",
-        "money"
-      ]
+    "shipArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ship"
+      }
     },
     "items": {
       "type": "string",

--- a/engine/src/main/resources/assets/schemas/schemaTypes.json
+++ b/engine/src/main/resources/assets/schemas/schemaTypes.json
@@ -23,6 +23,11 @@
         "description": "The scale factor of this type's item icon.",
         "exclusiveMinimum": 0
       }
-    }
+    },
+    "required": [
+      "color",
+      "pickUpSound",
+      "sz"
+    ]
   }
 }

--- a/engine/src/main/resources/assets/schemas/schemaTypes.json
+++ b/engine/src/main/resources/assets/schemas/schemaTypes.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Configuration for the types of items available to the player.",
+  "propertyNames": {
+    "pattern": "^\\w+$",
+    "description": "Type names must be a sequence of basic alphanumeric characters without a space."
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "color": {
+        "type": "string",
+        "pattern": "^((hsb (((360)|(3[0-5]\\d)|([012]?\\d?\\d))( ((100)|\\d?\\d)){2})|(((([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])) ){2}(([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5]))))( (([01]?\\d?\\d)|(2[0-4]\\d)|(25[0-5])))?)$",
+        "description": "Color can be defined in the form `rrr ggg bbb`, `rrr ggg bbb aaa`, `hsb hhh sss bbb` or `hsb hhh sss bbb aaa`"
+      },
+      "pickUpSound": {
+        "type": "string",
+        "description": "The gestalt id of the sound asset played when an item of this type is picked up.",
+        "pattern": "^\\w+:\\w+$"
+      },
+      "sz": {
+        "type": "number",
+        "description": "The scale factor of this type's item icon.",
+        "exclusiveMinimum": 0
+      }
+    }
+  }
+}

--- a/modules/core/assets/configs/factions.json
+++ b/modules/core/assets/configs/factions.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Techie",
-      "color": "169E1",
+      "color": "169E10",
       "disposition": -50,
       "ships": [
         "techieOrbiter",

--- a/modules/core/assets/configs/systemsConfig.json
+++ b/modules/core/assets/configs/systemsConfig.json
@@ -10,7 +10,6 @@
             {
                 "hull": "core:imperialCapital",
                 "items": "core:gun+core:blaster core:gun+core:blaster core:advancedArmor core:advancedShield",
-                "repairer": true,
                 "density": 1,
 
                 "guard": {
@@ -29,7 +28,6 @@
             {
                 "hull": "core:station",
                 "items": "core:cannon core:gun",
-                "repairer": true,
                 "density": 1,
 
                 "guard": {
@@ -109,7 +107,6 @@
             {
                 "hull": "core:station",
                 "items": "core:gun core:cannon",
-                "repairer": true,
                 "density": 2,
 
                 "guard": {

--- a/modules/core/assets/items/types.json
+++ b/modules/core/assets/items/types.json
@@ -2,60 +2,60 @@
     "clip": {
         "color": "hsb 0 100 50",
         "pickUpSound": "core:otherPickUp",
-        "sz": 0.12,
+        "sz": 0.12
     },
 
     "shield": {
         "color": "hsb 260 100 100",
         "pickUpSound": "core:otherPickUp",
-        "sz": 0.16,
+        "sz": 0.16
     },
 
     "armor": {
         "color": "hsb 60 100 100",
         "pickUpSound": "core:otherPickUp",
-        "sz": 0.16,
+        "sz": 0.16
     },
 
     "abilityCharge": {
         "color": "hsb 300 100 100",
         "pickUpSound": "core:otherPickUp",
-        "sz": 0.12,
+        "sz": 0.12
     },
 
     "gun": {
         "color": "hsb 0 100 100",
         "pickUpSound": "core:gunPickUp",
-        "sz": 0.16,
+        "sz": 0.16
     },
 
     "fixedGun": {
         "color": "hsb 0 100 100",
         "pickUpSound": "core:gunPickUp",
-        "sz": 0.2,
+        "sz": 0.2
     },
 
     "money": {
         "color": "hsb 40 100 50",
         "pickUpSound": "core:money",
-        "sz": 0.12,
+        "sz": 0.12
     },
 
     "medMoney": {
         "color": "hsb 40 100 100",
         "pickUpSound": "core:money",
-        "sz": 0.16,
+        "sz": 0.16
     },
 
     "bigMoney": {
         "color": "hsb 40 100 100",
         "pickUpSound": "core:money",
-        "sz": 0.2,
+        "sz": 0.2
     },
 
     "repair": {
         "color": "hsb 200 100 100",
         "pickUpSound": "core:otherPickUp",
-        "sz": 0.12,
-    },
+        "sz": 0.12
+    }
 }


### PR DESCRIPTION
# Description
> Completes the schemas required for JSON validation.
> Adds 9 schemas in total, including one for the factions revamp in #386.
> Along with `schemaClip.json` in #371, all currently required schemas should be accounted for.
> Some minor JSON fixes where applicable as well.

# Testing
> The only schema warning in the console currently should be for `schemaClip.json`.
> All schemas should validate with all downloadable modules.

# Notes
> These PRs will conflict and will need to change the schemas that are applicable: #352, #366, 
> Additional schemas will be needed for these PRs: #355, #380