### PR TITLE
Better logging when getting single module

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -89,8 +89,8 @@ class common {
         println "Now inside retrieve, user (recursively? $recurse) wants: $items"
         for (String itemName: items) {
             println "Starting retrieval for $itemType $itemName, are we recursing? $recurse"
-            println "Retrieved so far: $itemsRetrieved"
             retrieveItem(itemName, recurse)
+            println "Retrieved so far: $itemsRetrieved"
         }
     }
 


### PR DESCRIPTION
Prior behaviour: print empty array -> fetch module -> quit
New behaviour: fetch module -> print array containing said module -> quit

Has not been tested