### PR TITLE
Fixed bug where mercs are removed by star ports

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/Hero.java
+++ b/engine/src/main/java/org/destinationsol/game/Hero.java
@@ -66,7 +66,7 @@ public class Hero {
 
     public void setSolShip(SolShip hero, SolGame solGame) {
         isDead = false;
-        if (hero != shipHero) {
+        if (hero != shipHero && !isTranscendent) {
             mercs = new ItemContainer();
         }
         this.shipHero = hero;


### PR DESCRIPTION
# Description
Bug #354 was causing the player to lose their mercenaries when they went through a star port. This was because the setSolShip method didn't check for transcendence before creating a new mercenary list. This PR adds a check to ensure that the hero can transcend space and time with impunity :)

# Testing
Hire some mercenaries, go through a star port, then check the mercenaries tab. The mercenaries that were hired should still be there.

fixes #354 