### PR TITLE
Fixed mercenary loyalty issue

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/ship/FarShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/FarShip.java
@@ -21,7 +21,13 @@ import org.destinationsol.game.FarObject;
 import org.destinationsol.game.RemoveController;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.input.Pilot;
-import org.destinationsol.game.item.*;
+import org.destinationsol.game.item.Armor;
+import org.destinationsol.game.item.Engine;
+import org.destinationsol.game.item.Gun;
+import org.destinationsol.game.item.ItemContainer;
+import org.destinationsol.game.item.MercItem;
+import org.destinationsol.game.item.Shield;
+import org.destinationsol.game.item.TradeContainer;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
 public class FarShip implements FarObject {
@@ -92,7 +98,7 @@ public class FarShip implements FarObject {
     public SolShip toObject(SolGame game) {
         SolShip ship = game.getShipBuilder().build(game, position, velocity, angle, rotationSpeed, pilot, container, hullConfig, life, gun1,
                 gun2, removeController, engine, repairer, money, tradeContainer, shield, armor);
-        if(isMerc){
+        if (isMerc) {
             ship.setMerc(mercItem);
         }
         return ship;
@@ -192,20 +198,15 @@ public class FarShip implements FarObject {
     }
 
     /**
-     * Each FarShip could be a mercenary. Each mercenary is definitely a FarShip .
-     * This method sets the associated MercItem.
-     * @param mercItem The {@link MercItem} that this FarShip is associated with. Can be null.
+     * Sets the mercItem and declares the ship to be a mercenary.
+     *
+     * Optional @param mercItem The {@link MercItem} of the FarShip.
      */
     public void setMerc(MercItem mercItem) {
         this.mercItem = mercItem;
         isMerc = true;
     }
 
-    /**
-     * Each FarShip could be a mercenary. Each mercenary is definitely a FarShip .
-     * This method gets the associated MercItem.
-     * @return The {@link MercItem} that this FarShip is associated with. Can be null.
-     */
     public MercItem getMerc() {
         return this.mercItem;
     }

--- a/engine/src/main/java/org/destinationsol/game/ship/FarShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/FarShip.java
@@ -21,12 +21,7 @@ import org.destinationsol.game.FarObject;
 import org.destinationsol.game.RemoveController;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.input.Pilot;
-import org.destinationsol.game.item.Armor;
-import org.destinationsol.game.item.Engine;
-import org.destinationsol.game.item.Gun;
-import org.destinationsol.game.item.ItemContainer;
-import org.destinationsol.game.item.Shield;
-import org.destinationsol.game.item.TradeContainer;
+import org.destinationsol.game.item.*;
 import org.destinationsol.game.ship.hulls.HullConfig;
 
 public class FarShip implements FarObject {
@@ -47,6 +42,8 @@ public class FarShip implements FarObject {
     private float life;
     private ShipRepairer repairer;
     private float money;
+    private MercItem mercItem;
+    private boolean isMerc;
 
     public FarShip(Vector2 position, Vector2 velocity, float angle, float rotationSpeed, Pilot pilot, ItemContainer container,
                    HullConfig hullConfig, float life,
@@ -93,8 +90,12 @@ public class FarShip implements FarObject {
 
     @Override
     public SolShip toObject(SolGame game) {
-        return game.getShipBuilder().build(game, position, velocity, angle, rotationSpeed, pilot, container, hullConfig, life, gun1,
+        SolShip ship = game.getShipBuilder().build(game, position, velocity, angle, rotationSpeed, pilot, container, hullConfig, life, gun1,
                 gun2, removeController, engine, repairer, money, tradeContainer, shield, armor);
+        if(isMerc){
+            ship.setMerc(mercItem);
+        }
+        return ship;
     }
 
     @Override
@@ -189,4 +190,24 @@ public class FarShip implements FarObject {
     public ItemContainer getIc() {
         return container;
     }
+
+    /**
+     * Each FarShip could be a mercenary. Each mercenary is definitely a FarShip .
+     * This method sets the associated MercItem.
+     * @param mercItem The {@link MercItem} that this FarShip is associated with. Can be null.
+     */
+    public void setMerc(MercItem mercItem) {
+        this.mercItem = mercItem;
+        isMerc = true;
+    }
+
+    /**
+     * Each FarShip could be a mercenary. Each mercenary is definitely a FarShip .
+     * This method gets the associated MercItem.
+     * @return The {@link MercItem} that this FarShip is associated with. Can be null.
+     */
+    public MercItem getMerc() {
+        return this.mercItem;
+    }
+
 }

--- a/engine/src/main/java/org/destinationsol/game/ship/FarShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/FarShip.java
@@ -211,4 +211,6 @@ public class FarShip implements FarObject {
         return this.mercItem;
     }
 
+    public boolean isMerc() { return this.isMerc; }
+
 }

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -243,14 +243,14 @@ public class SolShip implements SolObject {
         updateIdleTime(game);
         updateShield(game);
 
-        if(mercItem == null){
-            if (FactionInfo.getDisposition().get(factionID) < -5) {
-                getPilot().stringToFaction("ehar");
-            }
-            else {
-                getPilot().stringToFaction("laani");
-            }
+
+        if (!isMerc && FactionInfo.getDisposition().get(factionID) < -5) {
+            getPilot().stringToFaction("ehar");
         }
+        else {
+            getPilot().stringToFaction("laani");
+        }
+
 
         if (myArmor != null && !myItemContainer.contains(myArmor)) {
             myArmor = null;

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -671,6 +671,8 @@ public class SolShip implements SolObject {
         return this.mercItem;
     }
 
+    public boolean isMerc() { return this.isMerc; }
+
     public String getFactionName() {
         return factionName;
     }

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -238,11 +238,13 @@ public class SolShip implements SolObject {
         updateIdleTime(game);
         updateShield(game);
 
-        if (FactionInfo.getDisposition().get(factionID) < -5) {
-            getPilot().stringToFaction("ehar");
-        }
-        else {
-            getPilot().stringToFaction("laani");
+        if(mercItem == null){
+            if (FactionInfo.getDisposition().get(factionID) < -5) {
+                getPilot().stringToFaction("ehar");
+            }
+            else {
+                getPilot().stringToFaction("laani");
+            }
         }
 
         if (myArmor != null && !myItemContainer.contains(myArmor)) {

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -125,7 +125,7 @@ public class SolShip implements SolObject {
         float rotationSpeed = myHull.getBody().getAngularVelocity() * MathUtils.radDeg;
         FarShip farShip = new FarShip(myHull.getPosition(), myHull.getVelocity(), myHull.getAngle(), rotationSpeed, myPilot, myItemContainer, myHull.config, myHull.life,
                 myHull.getGun(false), myHull.getGun(true), myRemoveController, myHull.getEngine(), myRepairer, myMoney, myTradeContainer, myShield, myArmor);
-        if(isMerc){
+        if (isMerc) {
             farShip.setMerc(mercItem);
         }
         return farShip;
@@ -243,14 +243,11 @@ public class SolShip implements SolObject {
         updateIdleTime(game);
         updateShield(game);
 
-
         if (!isMerc && FactionInfo.getDisposition().get(factionID) < -5) {
             getPilot().stringToFaction("ehar");
-        }
-        else {
+        } else {
             getPilot().stringToFaction("laani");
         }
-
 
         if (myArmor != null && !myItemContainer.contains(myArmor)) {
             myArmor = null;
@@ -455,6 +452,7 @@ public class SolShip implements SolObject {
     /**
      * Method to be called on the death of a SolShip
      * Note: Use {@link SolGame#setRespawnState()}} for the death of the player specifically
+     *
      * @param game The SolGame currently in progress.
      */
     private void onDeath(SolGame game) {
@@ -660,20 +658,15 @@ public class SolShip implements SolObject {
     }
 
     /**
-     * Each SolShip could be a mercenary. Each mercenary is definitely a SolShip.
-     * This method sets the associated MercItem.
-     * @param mercItem The {@link MercItem} that this SolShip is associated with. Can be null.
+     * Sets the mercItem and declares the ship to be a mercenary.
+     *
+     * Optional @param mercItem The {@link MercItem} of the SolShip.
      */
     public void setMerc(MercItem mercItem) {
         this.mercItem = mercItem;
         isMerc = true;
     }
 
-    /**
-     * Each SolShip could be a mercenary. Each mercenary is definitely a SolShip.
-     * This method gets the associated MercItem.
-     * @return The {@link MercItem} that this SolShip is associated with. Can be null.
-     */
     public MercItem getMerc() {
         return this.mercItem;
     }

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -83,6 +83,7 @@ public class SolShip implements SolObject {
     private float myAbilityAwait;
     private float myControlEnableAwait;
     private MercItem mercItem;
+    private boolean isMerc;
 
     public SolShip(SolGame game, Pilot pilot, Hull hull, RemoveController removeController, List<Drawable> drawables,
                    ItemContainer container, ShipRepairer repairer, float money, TradeContainer tradeContainer, Shield shield,
@@ -122,8 +123,12 @@ public class SolShip implements SolObject {
     @Override
     public FarShip toFarObject() {
         float rotationSpeed = myHull.getBody().getAngularVelocity() * MathUtils.radDeg;
-        return new FarShip(myHull.getPosition(), myHull.getVelocity(), myHull.getAngle(), rotationSpeed, myPilot, myItemContainer, myHull.config, myHull.life,
+        FarShip farShip = new FarShip(myHull.getPosition(), myHull.getVelocity(), myHull.getAngle(), rotationSpeed, myPilot, myItemContainer, myHull.config, myHull.life,
                 myHull.getGun(false), myHull.getGun(true), myRemoveController, myHull.getEngine(), myRepairer, myMoney, myTradeContainer, myShield, myArmor);
+        if(isMerc){
+            farShip.setMerc(mercItem);
+        }
+        return farShip;
     }
 
     @Override
@@ -661,6 +666,7 @@ public class SolShip implements SolObject {
      */
     public void setMerc(MercItem mercItem) {
         this.mercItem = mercItem;
+        isMerc = true;
     }
 
     /**


### PR DESCRIPTION
# Description
This fixes the issue where mercenaries are hostile to the player. It does so by maintaining the MercItem that the mercenary is tied to when it's converted to a FarShip and back. Now the mercenaries will remain loyal forever.

# Testing
Hire some mercenaries. They will stay loyal, even if they are far enough away that they are converted into FarShips.