### PR TITLE
Fixed the Android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/metrics
 android
 gwt
 gestalt
+gestalt-reflections
 modules/*
 modules/**/build.gradle
 !modules/core

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config/metrics
 ## Ignored sub-projects with nested Git roots. Core module is bundled with the main repo.
 android
 gwt
+gestalt
 modules/*
 modules/**/build.gradle
 !modules/core

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,73 @@ task(fetchGwt, type: GitClone) {
     }
 }
 
+task(fetchGestalt, type: GitClone) {
+    description = 'Git clones the gestalt Android source from GitHub'
+
+    def repo = 'gestalt'
+    def githubHome = 'MovingBlocks'
+    def destination = file('gestalt')
+
+    enabled = !destination.exists()
+
+    if (enabled) {
+        uri = "https://github.com/$githubHome/" + repo + ".git"
+        destinationPath = destination
+        bare = false
+        branch = 'android'
+    }
+}
+
+task(fetchReflections, type: GitClone) {
+    description = 'Git clones the org.reflections.reflections source from GitHub'
+
+    def repo = 'reflections'
+    def githubHome = 'ronmamo'
+    def destination = file('gestalt-reflections')
+
+    enabled = !destination.exists()
+
+    if (enabled) {
+        uri = "https://github.com/$githubHome/" + repo + ".git"
+        destinationPath = destination
+        bare = false
+    }
+}
+
+fetchGestalt.doLast {
+    new File("$rootDir/gestalt", "gradle.properties").text = "version=7.0.0-SNAPSHOT"
+    def localPropertiesFile = new File("$rootDir", "local.properties")
+    if (localPropertiesFile.exists()) {
+        new File("$rootDir/gestalt", "local.properties").text = localPropertiesFile.text
+    }
+
+    File fileToPatch = new File("$rootDir/gestalt/gestalt-android-testbed/src/main/java/org/terasology/gestalt/android/testbed", "GestaltTestActivity.java")
+    fileToPatch.text = fileToPatch.text.replace("new ReflectionComponentTypeFactory()", "new ComponentManager()")
+                       .replace("org.terasology.entitysystem.component.ReflectionComponentTypeFactory", "org.terasology.entitysystem.component.ComponentManager");
+
+
+    def gradleCommand = System.getProperty("os.name").toLowerCase().contains("windows") ? "gradlew.bat" : "gradlew"
+    exec {
+        workingDir "$rootDir/gestalt"
+        commandLine "$rootDir/gestalt/$gradleCommand", 'assemble', '-x', ':gestalt-android-testbed:assemble'
+    }
+}
+
+fetchReflections.doLast {
+    def gradleCommand = System.getProperty("os.name").toLowerCase().contains("windows") ? "gradlew.bat" : "gradlew"
+    exec {
+        workingDir "$rootDir/gestalt-reflections"
+        commandLine "$rootDir/$gradleCommand", 'init', '--type', 'pom'
+    }
+    exec {
+        workingDir "$rootDir/gestalt-reflections"
+        commandLine "$rootDir/$gradleCommand", 'jar', 'install'
+    }
+}
+
+fetchAndroid.dependsOn fetchGestalt
+fetchGestalt.dependsOn fetchReflections
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.10'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -120,14 +120,10 @@ task(fetchAndroid, type: GitClone) {
     //println "fetchAndroid requested for $repo from Github under $githubHome - exists already? " + !enabled
 
     // Do the actual clone if we don't have the directory already
-    if (enabled) {
-        uri = "https://github.com/$githubHome/" + repo + ".git"
-        //println "Fetching $repo from $uri"
-        destinationPath = destination
-        bare = false
-    } else {
-        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
-    }
+    uri = "https://github.com/$githubHome/" + repo + ".git"
+    //println "Fetching $repo from $uri"
+    destinationPath = destination
+    bare = false
 }
 
 task(fetchGwt, type: GitClone) {
@@ -146,14 +142,10 @@ task(fetchGwt, type: GitClone) {
     //println "fetchGwt requested for $repo from Github under $githubHome - exists already? " + !enabled
 
     // Do the actual clone if we don't have the directory already
-    if (enabled) {
-        uri = "https://github.com/$githubHome/" + repo + ".git"
-        //println "Fetching $repo from $uri"
-        destinationPath = destination
-        bare = false
-    } else {
-        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
-    }
+    uri = "https://github.com/$githubHome/" + repo + ".git"
+    //println "Fetching $repo from $uri"
+    destinationPath = destination
+    bare = false
 }
 
 task(fetchGestalt, type: GitClone) {
@@ -165,14 +157,10 @@ task(fetchGestalt, type: GitClone) {
 
     enabled = !destination.exists()
 
-    if (enabled) {
-        uri = "https://github.com/$githubHome/" + repo + ".git"
-        destinationPath = destination
-        bare = false
-        branch = 'android'
-    } else {
-        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
-    }
+    uri = "https://github.com/$githubHome/" + repo + ".git"
+    destinationPath = destination
+    bare = false
+    branch = 'android'
 }
 
 task(fetchReflections, type: GitClone) {
@@ -184,13 +172,9 @@ task(fetchReflections, type: GitClone) {
 
     enabled = !destination.exists()
 
-    if (enabled) {
-        uri = "https://github.com/$githubHome/" + repo + ".git"
-        destinationPath = destination
-        bare = false
-    } else {
-        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
-    }
+    uri = "https://github.com/$githubHome/" + repo + ".git"
+    destinationPath = destination
+    bare = false
 }
 
 fetchGestalt.doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ fetchGestalt.doLast {
     def gradleCommand = System.getProperty("os.name").toLowerCase().contains("windows") ? "gradlew.bat" : "gradlew"
     exec {
         workingDir "$rootDir/gestalt"
-        commandLine "$rootDir/gestalt/$gradleCommand", 'assemble', '-x', ':gestalt-android-testbed:assemble'
+        commandLine "$rootDir/gestalt/$gradleCommand", 'assemble', '-x', ':gestalt-android-testbed:assemble', '-x', ':gestalt-es-perf:assemble'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,8 @@ task(fetchAndroid, type: GitClone) {
         //println "Fetching $repo from $uri"
         destinationPath = destination
         bare = false
+    } else {
+        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
     }
 }
 
@@ -149,6 +151,8 @@ task(fetchGwt, type: GitClone) {
         //println "Fetching $repo from $uri"
         destinationPath = destination
         bare = false
+    } else {
+        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
     }
 }
 
@@ -166,6 +170,8 @@ task(fetchGestalt, type: GitClone) {
         destinationPath = destination
         bare = false
         branch = 'android'
+    } else {
+        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
     }
 }
 
@@ -182,6 +188,8 @@ task(fetchReflections, type: GitClone) {
         uri = "https://github.com/$githubHome/" + repo + ".git"
         destinationPath = destination
         bare = false
+    } else {
+        throw new StopActionException("The repository $repo already exists. To re-clone the repository, delete the ${destination.name} folder and try again.")
     }
 }
 

--- a/desktop/src/main/java/org/destinationsol/desktop/SolDesktop.java
+++ b/desktop/src/main/java/org/destinationsol/desktop/SolDesktop.java
@@ -124,6 +124,7 @@ public final class SolDesktop {
             public void run() {
                 try {
                     moduleManager = new ModuleManager();
+                    moduleManager.init();
                 } catch (Exception ignore) {
                 }
                 initFinished = true;

--- a/desktop/src/main/java/org/destinationsol/desktop/SolDesktop.java
+++ b/desktop/src/main/java/org/destinationsol/desktop/SolDesktop.java
@@ -192,7 +192,7 @@ public final class SolDesktop {
                 // Create a crash dump file
                 String fileName = "crash-" + new SimpleDateFormat("yyyy-dd-MM_HH-mm-ss").format(new Date()) + ".log";
                 List<String> lines = Collections.singletonList(exceptionString);
-                Path logPath = new MyReader().create(fileName, lines).toAbsolutePath().getParent();
+                Path logPath = Paths.get(new MyReader().create(fileName, lines)).getParent();
 
                 // Run asynchronously so that the error message view is not blocked
                 new Thread(() -> CrashReporter.report(ex, logPath)).start();
@@ -237,7 +237,7 @@ public final class SolDesktop {
     //TODO Since this is currently the only implementation of SolFileReader, consider making this into a self-standing class with static methods. Also, consider uniting SolFileReader and IniReader.
     private static class MyReader implements SolFileReader {
         @Override
-        public Path create(String fileName, List<String> lines) {
+        public String create(String fileName, List<String> lines) {
             String path = "";
             if (DebugOptions.DEV_ROOT_PATH != null) {
                 path = DebugOptions.DEV_ROOT_PATH;
@@ -250,7 +250,7 @@ public final class SolDesktop {
             } catch (IOException e) {
                 logger.error("Failed to write to file", e);
             }
-            return file;
+            return file.toAbsolutePath().toString();
         }
 
         @Override

--- a/desktop/src/main/java/org/destinationsol/desktop/SolDesktop.java
+++ b/desktop/src/main/java/org/destinationsol/desktop/SolDesktop.java
@@ -122,7 +122,10 @@ public final class SolDesktop {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                moduleManager = new ModuleManager();
+                try {
+                    moduleManager = new ModuleManager();
+                } catch (Exception ignore) {
+                }
                 initFinished = true;
             }
         }).start();

--- a/engine/src/main/java/org/destinationsol/IniReader.java
+++ b/engine/src/main/java/org/destinationsol/IniReader.java
@@ -19,8 +19,8 @@ import com.badlogic.gdx.files.FileHandle;
 import org.destinationsol.game.SaveManager;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,7 +62,7 @@ public class IniReader {
 
         String path = SaveManager.getResourcePath(fileName);
 
-        FileHandle file = new FileHandle(Paths.get(path).toFile());
+        FileHandle file = new FileHandle(new File(path));
         file.writeString(stringBuilder.toString(), false);
     }
 
@@ -85,7 +85,7 @@ public class IniReader {
     private List<String> fileToLines(String fileName) {
         String path = SaveManager.getResourcePath(fileName);
 
-        FileHandle file = new FileHandle(Paths.get(path).toFile());
+        FileHandle file = new FileHandle(new File(path));
 
         ArrayList<String> res = new ArrayList<>();
         if (!file.exists()) {

--- a/engine/src/main/java/org/destinationsol/SolFileReader.java
+++ b/engine/src/main/java/org/destinationsol/SolFileReader.java
@@ -15,11 +15,10 @@
  */
 package org.destinationsol;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public interface SolFileReader {
-    Path create(String fileName, List<String> lines);
+    String create(String fileName, List<String> lines);
 
     List<String> read(String fileName);
 }

--- a/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
@@ -35,7 +35,7 @@ public class AssetDataFileHandle extends FileHandle {
 
     @Override
     public BufferedInputStream read(int bufferSize) {
-        return (BufferedInputStream) read();
+        return new BufferedInputStream(read());
     }
 
     @Override
@@ -83,8 +83,9 @@ public class AssetDataFileHandle extends FileHandle {
     public long length() {
         int length = -1;
         try {
-            BufferedInputStream stream = dataFile.openStream();
-            //HACK: This method may not produce reliable results in other JVMs.
+            InputStream stream = dataFile.openStream();
+            // HACK: This method may not produce reliable results in other JVMs.
+            // It often only gives the remaining quantity of bytes in the buffer, rather than the stream.
             length = stream.available();
             stream.close();
         } catch (Exception ignore) {

--- a/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
@@ -42,10 +42,13 @@ import java.util.Optional;
 import java.util.Set;
 
 public class AssetHelper {
-    private ModuleAwareAssetTypeManager assetTypeManager;
-    private static String[] folders_;
+    protected ModuleAwareAssetTypeManager assetTypeManager;
+    protected static String[] folders_;
 
-    public AssetHelper(ModuleEnvironment environment) {
+    public AssetHelper() {
+    }
+
+    public void init(ModuleEnvironment environment) {
         assetTypeManager = new ModuleAwareAssetTypeManager();
 
         assetTypeManager.createAssetType(OggSound.class, OggSound::new, "sounds");
@@ -94,7 +97,7 @@ public class AssetHelper {
         folders_ = folders;
     }
 
-    public static String resolveToPath(List<AssetDataFile> assetDataFiles) {
+    public String resolveToPath(List<AssetDataFile> assetDataFiles) {
         for (AssetDataFile assetDataFile : assetDataFiles) {
             List<String> folders = assetDataFile.getPath();
 

--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -52,10 +52,10 @@ public abstract class Assets {
      * Initializes the class for loading assets using the given environment.
      * This function -has- to be called upon startup, and whenever the environment is changed.
      *
-     * @param environment The ModuleEnvironment to load assets from.
+     * @param helper the helper used to initialise the asset system
      */
-    public static void initialize(ModuleEnvironment environment) {
-        assetHelper = new AssetHelper(environment);
+    public static void initialize(AssetHelper helper) {
+        assetHelper = helper;
     }
 
     public static AssetHelper getAssetHelper() {

--- a/engine/src/main/java/org/destinationsol/assets/audio/MusicConfig.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/MusicConfig.java
@@ -44,13 +44,19 @@ public class MusicConfig {
         JSONArray menuMusicArray = config.getJSONArray("menuMusic");
         JSONArray gameMusicArray = config.getJSONArray("gameMusic");
 
-        for (Object musicFileName : menuMusicArray) {
+        // JSONArray.iterator must not be used (foreach uses it internally), as Android does not support it
+        // (you cannot override the dependency either, as it is a system library).
+        for (int index = 0; index < menuMusicArray.length(); index++) {
+            Object musicFileName = menuMusicArray.get(index);
             if (musicFileName instanceof String) {
                 menuMusicSet.add(moduleName + ":" + musicFileName);
             }
         }
 
-        for (Object musicFileName : gameMusicArray) {
+        // JSONArray.iterator must not be used (foreach uses it internally), as Android does not support it
+        // (you cannot override the dependency either, as it is a system library).
+        for (int index = 0; index < gameMusicArray.length(); index++) {
+            Object musicFileName = gameMusicArray.get(index);
             if (musicFileName instanceof String) {
                 gameMusicSet.add(moduleName + ":" + musicFileName);
             }

--- a/engine/src/main/java/org/destinationsol/assets/audio/OggMusicFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/OggMusicFileFormat.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import org.destinationsol.assets.AssetDataFileHandle;
 import org.destinationsol.assets.AssetHelper;
+import org.destinationsol.assets.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
@@ -35,7 +36,7 @@ public class OggMusicFileFormat extends AbstractAssetFileFormat<OggMusicData> {
 
     @Override
     public OggMusicData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
-        String path = AssetHelper.resolveToPath(inputs);
+        String path = Assets.getAssetHelper().resolveToPath(inputs);
 
         FileHandle handle = new AssetDataFileHandle(inputs.get(0));
         return new OggMusicData(Gdx.audio.newMusic(handle));

--- a/engine/src/main/java/org/destinationsol/assets/audio/OggMusicManager.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/OggMusicManager.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.audio.Music;
 import org.destinationsol.GameOptions;
 import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.json.Json;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -197,7 +198,11 @@ public class OggMusicManager {
             Json musicJson = Assets.getJson(urnString);
             JSONObject musicNode = musicJson.getJsonValue();
 
-            for (Object musicFileName : musicNode.getJSONArray("menuMusic")) {
+            JSONArray array = musicNode.getJSONArray("menuMusic");
+            // JSONArray.iterator must not be used (foreach uses it internally), as Android does not support it
+            // (you cannot override the dependency either, as it is a system library).
+            for (int index = 0; index < array.length(); index++) {
+                Object musicFileName = array.get(index);
                 if (!(musicFileName instanceof String)) {
                     break;
                 }

--- a/engine/src/main/java/org/destinationsol/assets/audio/OggSoundFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/OggSoundFileFormat.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import org.destinationsol.assets.AssetHelper;
 import org.destinationsol.assets.AssetDataFileHandle;
+import org.destinationsol.assets.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
@@ -35,7 +36,7 @@ public class OggSoundFileFormat extends AbstractAssetFileFormat<OggSoundData> {
 
     @Override
     public OggSoundData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
-        String path = AssetHelper.resolveToPath(inputs);
+        String path = Assets.getAssetHelper().resolveToPath(inputs);
 
         FileHandle handle = new AssetDataFileHandle(inputs.get(0));
         return new OggSoundData(Gdx.audio.newSound(handle));

--- a/engine/src/main/java/org/destinationsol/assets/emitters/EmitterFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/emitters/EmitterFileFormat.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
 import org.destinationsol.assets.AssetDataFileHandle;
 import org.destinationsol.assets.AssetHelper;
+import org.destinationsol.assets.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
@@ -37,7 +38,7 @@ public class EmitterFileFormat extends AbstractAssetFileFormat<EmitterData> {
 
     @Override
     public EmitterData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
-        String path = AssetHelper.resolveToPath(inputs);
+        String path = Assets.getAssetHelper().resolveToPath(inputs);
 
         FileHandle handle = new AssetDataFileHandle(inputs.get(0));
         BufferedReader reader = new BufferedReader(new InputStreamReader(handle.read()), 512);

--- a/engine/src/main/java/org/destinationsol/assets/fonts/FontFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/fonts/FontFileFormat.java
@@ -19,7 +19,6 @@ import com.badlogic.gdx.Files;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
-import org.destinationsol.assets.AssetHelper;
 import org.destinationsol.assets.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
@@ -27,7 +26,6 @@ import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.List;
 
 @RegisterAssetFileFormat
@@ -41,7 +39,7 @@ public class FontFileFormat extends AbstractAssetFileFormat<FontData> {
         String path = Assets.getAssetHelper().resolveToPath(inputs);
 
         //NOTE: The BitmapFont class relies on direct filesystem access, so jar modules will not be able to define new fonts.
-        FileHandle handle = Gdx.files.getFileHandle(Paths.get(path).toString(), Files.FileType.Internal);
+        FileHandle handle = Gdx.files.getFileHandle(path, Files.FileType.Internal);
         BitmapFont bitmapFont = new BitmapFont(handle, true);
         bitmapFont.setUseIntegerPositions(false);
         return new FontData(bitmapFont);

--- a/engine/src/main/java/org/destinationsol/assets/fonts/FontFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/fonts/FontFileFormat.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import org.destinationsol.assets.AssetHelper;
+import org.destinationsol.assets.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
@@ -37,7 +38,7 @@ public class FontFileFormat extends AbstractAssetFileFormat<FontData> {
 
     @Override
     public FontData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
-        String path = AssetHelper.resolveToPath(inputs);
+        String path = Assets.getAssetHelper().resolveToPath(inputs);
 
         //NOTE: The BitmapFont class relies on direct filesystem access, so jar modules will not be able to define new fonts.
         FileHandle handle = Gdx.files.getFileHandle(Paths.get(path).toString(), Files.FileType.Internal);

--- a/engine/src/main/java/org/destinationsol/assets/json/JsonFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/json/JsonFileFormat.java
@@ -17,6 +17,7 @@ package org.destinationsol.assets.json;
 
 import com.badlogic.gdx.files.FileHandle;
 import org.destinationsol.assets.AssetDataFileHandle;
+import org.destinationsol.assets.Assets;
 import org.json.JSONObject;
 import org.destinationsol.assets.AssetHelper;
 import org.terasology.assets.ResourceUrn;
@@ -35,8 +36,6 @@ public class JsonFileFormat extends AbstractAssetFileFormat<JsonData> {
 
     @Override
     public JsonData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
-        String path = AssetHelper.resolveToPath(inputs);
-
         FileHandle handle = new AssetDataFileHandle(inputs.get(0));
         JSONObject jsonValue = new JSONObject(handle.readString());
 

--- a/engine/src/main/java/org/destinationsol/assets/json/Validator.java
+++ b/engine/src/main/java/org/destinationsol/assets/json/Validator.java
@@ -15,6 +15,8 @@
  */
 package org.destinationsol.assets.json;
 
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
 import org.destinationsol.assets.Assets;
 import org.destinationsol.common.SolException;
 import org.everit.json.schema.Schema;
@@ -46,11 +48,15 @@ public class Validator {
             throw e;
         }
 
-        Schema schemaValidator = SchemaLoader.load(schema);
-        try {
-            schemaValidator.validate(jsonObject);
-        } catch (ValidationException e) {
-            throw new SolException("JSON \"" + jsonPath + "\" could not be validated against schema \"" + schemaPath + "\"." + e.getErrorMessage());
+        if (Gdx.app.getType() != Application.ApplicationType.Android) {
+            // HACK: Android's built-in JSON library overrides the org.json dependency, which breaks the validator
+            //       As such, it is not possible at this time to run the validator in Android.
+            Schema schemaValidator = SchemaLoader.load(schema);
+            try {
+                schemaValidator.validate(jsonObject);
+            } catch (ValidationException e) {
+                throw new SolException("JSON \"" + jsonPath + "\" could not be validated against schema \"" + schemaPath + "\"." + e.getErrorMessage());
+            }
         }
 
         json.dispose();

--- a/engine/src/main/java/org/destinationsol/assets/textures/DSTextureFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/textures/DSTextureFileFormat.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
 import org.destinationsol.assets.AssetDataFileHandle;
 import org.destinationsol.assets.AssetHelper;
+import org.destinationsol.assets.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
@@ -34,7 +35,7 @@ public class DSTextureFileFormat extends AbstractAssetFileFormat<DSTextureData> 
 
     @Override
     public DSTextureData load(ResourceUrn urn, List<AssetDataFile> inputs) {
-        String path = AssetHelper.resolveToPath(inputs);
+        String path = Assets.getAssetHelper().resolveToPath(inputs);
 
         FileHandle handle = new AssetDataFileHandle(inputs.get(0));
         Texture texture = new Texture(handle);

--- a/engine/src/main/java/org/destinationsol/common/SolMath.java
+++ b/engine/src/main/java/org/destinationsol/common/SolMath.java
@@ -500,7 +500,10 @@ public class SolMath {
         if (listNode == null) {
             return res;
         }
-        for (Object val : listNode) {
+        // JSONArray.iterator must not be used (foreach uses it internally), as Android does not support it
+        // (you cannot override the dependency either, as it is a system library).
+        for (int index = 0; index < listNode.length(); index++) {
+            Object val = listNode.get(index);
             if(val instanceof String) {
                 Vector2 vec = readV2((String) val);
                 res.add(vec);

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -15,6 +15,7 @@
  */
 package org.destinationsol.game;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.math.Vector2;
 import com.google.gson.Gson;
@@ -151,7 +152,7 @@ public class SaveManager {
         if (DebugOptions.DEV_ROOT_PATH != null) {
             return DebugOptions.DEV_ROOT_PATH + fileName;
         } else {
-            return fileName;
+            return Gdx.files.getLocalStoragePath() + "/" + fileName;
         }
     }
 

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -36,12 +36,12 @@ import org.destinationsol.game.ship.hulls.HullConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -165,7 +165,7 @@ public class SaveManager {
     public static boolean resourceExists(String fileName) {
         String path = getResourcePath(fileName);
 
-        return new FileHandle(Paths.get(path).toFile()).exists();
+        return new FileHandle(new File(path)).exists();
     }
 
     /**

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -164,7 +164,10 @@ public class SolGame {
         onPausedUpdateSystems.put(0, defaultPausedSystems);
 
         try {
-            for (Class<?> updateSystemClass : ModuleManager.getEnvironment().getSubtypesOf(UpdateAwareSystem.class, element -> element.isAnnotationPresent(RegisterUpdateSystem.class))) {
+            for (Class<?> updateSystemClass : ModuleManager.getEnvironment().getSubtypesOf(UpdateAwareSystem.class)) {
+                if (!updateSystemClass.isAnnotationPresent(RegisterUpdateSystem.class)) {
+                    continue;
+                }
                 RegisterUpdateSystem registerAnnotation = updateSystemClass.getDeclaredAnnotation(RegisterUpdateSystem.class);
                 UpdateAwareSystem system = (UpdateAwareSystem) updateSystemClass.newInstance();
                 if (!registerAnnotation.paused()) {

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetConfig.java
@@ -69,8 +69,9 @@ public class PlanetConfig {
     }
 
     static PlanetConfig load(String name, JSONObject rootNode, HullConfigManager hullConfigs, GameColors cols, ItemManager itemManager, String moduleName) {
-        float minGrav = rootNode.getFloat("minGrav");
-        float maxGrav = rootNode.getFloat("maxGrav");
+        // JSONObject.getDouble must be used, as Android does not support JSONObject.getFloat (you cannot override the dependency either, as it is a system library).
+        float minGrav = (float) rootNode.getDouble("minGrav");
+        float maxGrav = (float) rootNode.getDouble("maxGrav");
         List<DecoConfig> deco = DecoConfig.load(rootNode);
         List<ShipConfig> groundEnemies = ShipConfig.loadList(rootNode.has("groundEnemies") ? rootNode.getJSONArray("groundEnemies") : null, hullConfigs, itemManager);
         List<ShipConfig> highOrbitEnemies = ShipConfig.loadList(rootNode.has("highOrbitEnemies") ? rootNode.getJSONArray("highOrbitEnemies") : null, hullConfigs, itemManager);

--- a/engine/src/main/java/org/destinationsol/game/projectile/ProjectileConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/ProjectileConfigs.java
@@ -75,7 +75,7 @@ public class ProjectileConfigs {
                 float density = (float) node.optDouble("density", -1);
                 float dmg = (float) node.getDouble("dmg");
                 float emTime = (float) node.optDouble("emTime", 0);
-                float aoeRadius = node.optFloat("aoeRadius", -1);
+                float aoeRadius = (float) node.optDouble("aoeRadius", -1);
                 ProjectileConfig config = new ProjectileConfig(tex, texSz, speed, stretch, physSize, dmgType,
                         collisionSound, lightSz, trailEffect, bodyEffect, collisionEffect, collisionEffectBackground,
                         zeroAbsSpeed, origin, acc, workSound, bodyless, density, guideRotationSpeed, dmg, emTime, aoeRadius);

--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -63,6 +63,7 @@ public class MainGameScreen extends SolUiBaseScreen {
     private static final float V_PAD = H_PAD;
     static final float HELPER_ROW_1 = 1 - 3f * CELL_SZ;
     private static final float HELPER_ROW_2 = HELPER_ROW_1 - .5f * CELL_SZ;
+    private static final float HELPER_ROW_3 = HELPER_ROW_2 - .5f * CELL_SZ;
 
     public final ShipUiControl shipControl;
     public final SolUiControl mapControl;
@@ -139,7 +140,7 @@ public class MainGameScreen extends SolUiBaseScreen {
         talkControl = new SolUiControl(talkArea, true, gameOptions.getKeyTalk());
         talkControl.setDisplayName("Talk");
         controls.add(talkControl);
-        Rectangle mercArea = mobile ? btn(lastCol, HELPER_ROW_1, true) : rightPaneLayout.buttonRect(4);
+        Rectangle mercArea = mobile ? btn(lastCol, HELPER_ROW_3, true) : rightPaneLayout.buttonRect(4);
         mercControl = new SolUiControl(mercArea, true, gameOptions.getKeyMercenaryInteraction());
         mercControl.setDisplayName("Mercs");
         controls.add(mercControl);

--- a/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
@@ -47,7 +47,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ReflectPermission;
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Policy;
@@ -115,14 +114,11 @@ public class ModuleManager {
             "com.badlogic.gdx.physics.box2d"
     };
     private static final Class<?>[] CLASS_WHITELIST = new Class<?>[] {
-            com.esotericsoftware.reflectasm.MethodAccess.class,
             InvocationTargetException.class,
             LoggerFactory.class,
             Logger.class,
-            java.awt.datatransfer.UnsupportedFlavorException.class,
             java.nio.ByteBuffer.class,
             java.nio.IntBuffer.class,
-            java.nio.file.attribute.FileTime.class, // java.util.zip dependency
             // This class only operates on Class<?> or Object instances,
             // effectively adding a way to access arrays without knowing their type
             // beforehand. It's safe despite being in java.lang.reflect.
@@ -168,9 +164,8 @@ public class ModuleManager {
     private ModuleRegistry registry;
     private Module engineModule;
 
-    public ModuleManager() {
+    public ModuleManager() throws Exception {
         try {
-            URI engineClasspath = getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
             Reader engineModuleReader = new InputStreamReader(getClass().getResourceAsStream("/module.json"), Charsets.UTF_8);
             ModuleMetadata engineMetadata = new ModuleMetadataJsonAdapter().read(engineModuleReader);
             engineModuleReader.close();
@@ -195,6 +190,7 @@ public class ModuleManager {
             loadEnvironment(requiredModules);
         } catch (Exception e) {
             e.printStackTrace();
+            throw e;
         }
     }
 

--- a/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
@@ -59,7 +59,7 @@ public class ModuleManager {
     private static final Logger logger = LoggerFactory.getLogger(ModuleManager.class);
     // The API whitelist is based off Terasology's
     // https://github.com/MovingBlocks/Terasology/blob/948676050a7827dac5e04927087832ffc462da41/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
-    private static final String[] API_WHITELIST = new String[] {
+    protected static final String[] API_WHITELIST = new String[] {
             "java.lang",
             "java.lang.invoke",
             "java.lang.ref",
@@ -113,7 +113,7 @@ public class ModuleManager {
             "com.badlogic.gdx.physics",
             "com.badlogic.gdx.physics.box2d"
     };
-    private static final Class<?>[] CLASS_WHITELIST = new Class<?>[] {
+    protected static final Class<?>[] CLASS_WHITELIST = new Class<?>[] {
             InvocationTargetException.class,
             LoggerFactory.class,
             Logger.class,
@@ -160,11 +160,14 @@ public class ModuleManager {
             java.io.PipedOutputStream.class
     };
 
-    private static ModuleEnvironment environment;
-    private ModuleRegistry registry;
-    private Module engineModule;
+    protected static ModuleEnvironment environment;
+    protected ModuleRegistry registry;
+    protected Module engineModule;
 
-    public ModuleManager() throws Exception {
+    public ModuleManager() {
+    }
+
+    public void init() throws Exception {
         try {
             Reader engineModuleReader = new InputStreamReader(getClass().getResourceAsStream("/module.json"), Charsets.UTF_8);
             ModuleMetadata engineMetadata = new ModuleMetadataJsonAdapter().read(engineModuleReader);
@@ -224,7 +227,9 @@ public class ModuleManager {
         Policy.setPolicy(new ModuleSecurityPolicy());
         System.setSecurityManager(new ModuleSecurityManager());
         environment = new ModuleEnvironment(registry, permissionFactory);
-        Assets.initialize(environment);
+        AssetHelper helper = new AssetHelper();
+        helper.init(environment);
+        Assets.initialize(helper);
     }
 
     public static ModuleEnvironment getEnvironment() {

--- a/engine/src/test/java/org/destinationsol/testingUtilities/InitializationUtilities.java
+++ b/engine/src/test/java/org/destinationsol/testingUtilities/InitializationUtilities.java
@@ -37,7 +37,12 @@ public final class InitializationUtilities {
         }
         initialized = true;
         DebugOptions.DEV_ROOT_PATH = "engine/src/main/resources/";
-        ModuleManager moduleManager = new ModuleManager();
+        ModuleManager moduleManager;
+        try {
+            moduleManager = new ModuleManager();
+        } catch (Exception ignore) {
+            return;
+        }
         GL20 mockGL = new MockGL();
         Gdx.gl = mockGL;
         Gdx.gl20 = mockGL;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,6 @@
 include 'desktop', 'engine', 'modules'
 import groovy.io.FileType
 
-File androidGradle = new File(rootDir, 'android/build.gradle')
-if (androidGradle.exists()) {
-    include 'android'
-}
-
 File gwtGradle = new File(rootDir, 'gwt/build.gradle')
 if (gwtGradle.exists()) {
     include 'gwt'
@@ -21,4 +16,10 @@ rootDir.eachDir { possibleSubprojectDir ->
         //println "Magic is happening, applying from " + subprojectsSpecificationScript
         apply from: subprojectsSpecificationScript
     }
+}
+
+// This is put last to ensure that Android can detect the modules
+File androidGradle = new File(rootDir, 'android/build.gradle')
+if (androidGradle.exists()) {
+    include 'android'
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description:
This Pull Request provides the engine changes needed to successfully compile and run Destination Sol on Android.

Due to the changes made, this Pull Request, if merged, may cause merge conflicts with other Pull Requests.

This depends on https://github.com/MovingBlocks/DestSolAndroid/pull/1.

# Testing:
## Building and running the Android Facade:
#### Modifying build.gradle to use a custom remote:
- In order to fetch the Android Facade from my fork (that this Pull Request depends on for now), rather than the outdated main repository,
  you should change line 114 of `build.gradle`

from this:
```groovy
    def githubHome = 'MovingBlocks'
```
to this:
```groovy
    def githubHome = 'BenjaminAmos'
```
and you should change line 124 of `build.gradle`

from this:
```groovy
    //println "Fetching $repo from $uri"
```
to this:
```groovy
    branch = 'fix-2.0-build'
```

This will not be needed if https://github.com/MovingBlocks/DestSolAndroid/pull/1 is merged.
#### Building and running the facade
- You can build the android facade by either using the command line tools or using IntelliJ IDEA / Android Studio.
#### Using the command line:
- Download the [Android SDK](https://developer.android.com/studio#downloads) and use the `sdkmanager` tool to install the API 28 build tools.
- In the root project directory, run the command `echo sdk.dir=<SDK_ROOT> > local.properties`, where `<SDK_ROOT>` is the root directory in which
  you installed the Android SDK, to create a new local properties file.
- To fetch the Android facade, in the same root project directory run the command `gradlew fetchAndroid`.
  The command should complete successfully.
- Afterwards, run the command `gradlew android:assembleDebug` to build the APK. This command should also complete successfully.
- Once the command has completed, use the Android emulator or connect a suitable device and ensure that it can be detected by the `adb` tool.
  This can be verified by running the command `adb devices`, which should show the device name in its output.
- Then, run the command `gradlew android:installDebug` to install the APK to the first connected device.
- A new "Destination Sol" app should now be visible on the test device. Run it and play the game.
  It should not crash with any errors or exceptions.
#### Using IntelliJ IDEA (or Android Studio):
- Use the Android plugin (if not installed, then install it) to install the API 28 SDK build tools and platform tools.
- In the root project directory, run the command `gradlew fetchAndroid`. The command should complete successfully.
- Create a new build configuration based on the "Android App" template. You should set the start-up module to the "android" module.
- In the `File->Project Structure->SDKs` menu, add a new SDK and set the build target to `Android API 28` and the Java SDK to `Java 1.8`.
- In the `File->Project Structure->Modules` menu, select the `android` module and open the `Dependencies` tab.
  Set the module SDK to the new SDK you just added.
- Set the current build configuration to the newly created one and run the project using the debug button.
- A new "Destination Sol" app should now be visible on the test device. Run it and play the game.
  It should not crash with any errors or exceptions.

## Testing module support in the Android Facade:
  - The Android Facade will automatically include any modules found in the root directory's `modules` folder into the APK during the build.
### Testing asset modules:
- Add a new module (excluding the "warp" module) into the `modules` directory (you can find them under the [DestinationSol](https://github.com/DestinationSol))
  organisation on GitHub.
- Build and run the Android app, following the instructions above.
- The app should now allow you to play as the faction added by the module you downloaded.
### Testing code modules:
  - Download my [codeModuleTest](https://github.com/BenjaminAmos/codeModuleTest) module and place it in the root directory's `modules` folder.
  - Build and run the Android app, as per the instructions above.
  - Start a new game, with any faction, or continue an existing one.
  - You should see some text in the top-left corner of the screen, showing the words "Game duration: " followed by the quantity of time
    in seconds that that the current game session has been running for.

# Notes:
### General Notes / Issues:
- For some reason, Android does not accept many of the sound files provided with the game when played in the emulator. When I tested this
  on an actual Android device it appeared to work properly.
  They may need to be re-processed into a compatible bitrate format.
- In terms of code modules, I have only tested this with my `codeModuleTest` module. I do not know if any other modules would work.
- This fixes #391
### Implementation Notes:
#### General:
- The minimum Android SDK version is API 24, as this is the minimum version needed to use gestalt's android conversion.
- I used the gestalt Android port provided by @immortius, which worked flawlessly.
#### Building the Android Facade:
##### Fetching dependencies:
- The Android Facade depends on the Android port of gestalt, which has, as far as I can tell, no official release jar. As such, it must be
  built from source in order to be used.
- The gestalt Android port depends on yet another unreleased library: `org.reflections.reflections:0.12-SNAPSHOT`, which also needs
  to be built from source. I could not find any reputable repositories containing this jar either.
- You can find the code used to fetch and build these libraries in the root build.gradle:
https://github.com/BenjaminAmos/DestinationSol/blob/fix-android-build/build.gradle#L155-L220
- I could not successfully use gradle to reference the gestalt Android port's project's directly, which is why the jars are referenced directly
  instead. If anyone can get this to work successfully then I would be extremely greatful.
##### Android's Java libraries:
- I have removed the usages of all the `Java.nio.*` classes in the `engine` module, as these are not present on Android's API 24
  (although they are present on APIs >= 26).
- Android had a built-in implementation of the `org.json.*` classes, which are provided through the system classpath. Unfortunately, these
  libraries have diverged in their API from the version referenced by the engine, which means that it is missing some APIs. These involve
  most prominently, the `iterator()` method, which is used to implement foreach loops and the methods used to convert to and from `Map`
  objects. I am not aware of any known way to override these built-in libraries in favour of more up-to-date ones, so the code needed to
  be adapted instead. 
#### Asset loading:
##### Breakages in the gestalt API:
- The differing gestalt API in the Android port lead to the creation of certain shim classes in order to appease the runtime. This in turn
  lead to the modification of certain classes to move their code from constructors and static methods to overridable methods, which was needed in
  order to bypass the default code provided in-engine.
##### Cached music and sound files:
- The music and sound asset loaders will copy the file contents into a known filesystem path in order to appease the requirements of the
  LibGDX API, which was casting the file reference internally, so that the AssetDataFile shim would not be sufficient. The Android file
  reference class contains a package-private constructor, which means that I am unable to create another shim for Android's files. There
  is no guarentee that the gestalt API is accessing files contained within a flat directory structure (e.g. within folder modules), so
  it was not feasible to reference the file paths directly, hence the need to copy them to a known directory.

Any comments, suggested changes or advice are welcome and appreciated.

<!--
### Pre Pull Request Checklist:
When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones. 
If the code looks good to you and you have already at least some experience writing java, you can even completely skip 
this step
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
-->