### PR TITLE
drop-in framerate synchronization code from LWJGL forums

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -41,6 +41,7 @@ import org.destinationsol.ui.ResizeSubscriber;
 import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.SolLayouts;
 import org.destinationsol.ui.UiDrawer;
+import org.destinationsol.util.FramerateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.module.sandbox.API;
@@ -89,7 +90,7 @@ public class SolApplication implements ApplicationListener {
         // Initiate Box2D to make sure natives are loaded early enough
         Box2D.init();
         this.moduleManager = moduleManager;
-        this.targetFPS = 1.0f / targetFPS;
+        this.targetFPS = targetFPS;
         resizeSubscribers = new HashSet<>();
     }
 
@@ -139,14 +140,7 @@ public class SolApplication implements ApplicationListener {
             timeAccumulator -= Const.REAL_TIME_STEP;
         }
 
-        //HACK: A crude and primitive frame-limiter...
-        try {
-            if (Gdx.graphics.getDeltaTime() < targetFPS) {
-                Thread.sleep((long) ((targetFPS - Gdx.graphics.getDeltaTime()) * 1000) * 2);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        FramerateLimiter.synchronizeFPS(Math.round(targetFPS));
 
         try {
             draw();

--- a/engine/src/main/java/org/destinationsol/util/FramerateLimiter.java
+++ b/engine/src/main/java/org/destinationsol/util/FramerateLimiter.java
@@ -1,0 +1,52 @@
+package org.destinationsol.util;
+
+public class FramerateLimiter {
+    protected static long variableYieldTime;
+    protected static long  lastTime;
+
+    /**
+     * SOURCE: http://forum.lwjgl.org/index.php?topic=5653.0
+     * An accurate sync method that adapts automatically
+     * to the system it runs on to provide reliable results.
+     *
+     * @param fps The desired frame rate, in frames per second
+     * @author kappa (On the LWJGL Forums)
+     */
+    public static void synchronizeFPS(int fps) {
+        if (fps <= 0) return;
+
+        long sleepTime = 1000000000 / fps; // nanoseconds to sleep this frame
+        // yieldTime + remainder micro & nano seconds if smaller than sleepTime
+        long yieldTime = Math.min(sleepTime, variableYieldTime + sleepTime % (1000*1000));
+        long overSleep = 0; // time the sync goes over by
+
+        try {
+            while (true) {
+                long t = System.nanoTime() - lastTime;
+
+                if (t < sleepTime - yieldTime) {
+                    Thread.sleep(1);
+                }else if (t < sleepTime) {
+                    // burn the last few CPU cycles to ensure accuracy
+                    Thread.yield();
+                } else {
+                    overSleep = t - sleepTime;
+                    break; // exit while loop
+                }
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            lastTime = System.nanoTime() - Math.min(overSleep, sleepTime);
+
+            // auto tune the time sync should yield
+            if (overSleep > variableYieldTime) {
+                // increase by 200 microseconds (1/5 a ms)
+                variableYieldTime = Math.min(variableYieldTime + 200*1000, sleepTime);
+            } else if (overSleep < variableYieldTime - 200*1000) {
+                // decrease by 2 microseconds
+                variableYieldTime = Math.max(variableYieldTime - 2*1000, 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
Fix #389 by adding in code from LWJGL forums to synchronize framerate.
Source: http://forum.lwjgl.org/index.php?topic=5653.0

# Testing
In the graphic card's driver disable vsync, and start the game. You should see the game run on 100 frames per second. It might take a few seconds for this algorithm to converge to 100.