### PR TITLE
Add 'die' console command

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/Console.java
+++ b/engine/src/main/java/org/destinationsol/game/Console.java
@@ -208,7 +208,7 @@ public class Console implements SolUiScreen {
      */
     public void registerCharEntered(char c) {
         if (isActive) {
-            if (c == '\r') {
+            if (c == '\r' || c == '\n') {
                 inputHandler.handle(inputLine.toString(), this);
                 inputLine = new StringBuilder();
                 return;

--- a/engine/src/main/java/org/destinationsol/game/Hero.java
+++ b/engine/src/main/java/org/destinationsol/game/Hero.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.GameOptions;
 import org.destinationsol.assets.audio.OggMusicManager;
 import org.destinationsol.common.SolException;
+import org.destinationsol.game.console.commands.DieCommandHandler;
 import org.destinationsol.game.console.commands.PositionCommandHandler;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.item.Armor;
@@ -50,12 +51,9 @@ public class Hero {
         setSolShip(shipHero, solGame);
     }
 
-    public void initialise() {
-        if (!Console.getInstance().getDefaultInputHandler().commandExists("position")) {
-            Console.getInstance().getDefaultInputHandler().registerCommand("position", new PositionCommandHandler(this));
-        } else {
-            ((PositionCommandHandler) Console.getInstance().getDefaultInputHandler().getRegisteredCommand("position")).hero = this;
-        }
+    public void initialise(SolGame game) {
+        Console.getInstance().getDefaultInputHandler().registerOrReplaceCommand("position", new PositionCommandHandler(this));
+        Console.getInstance().getDefaultInputHandler().registerOrReplaceCommand("die", new DieCommandHandler(this, game));
     }
 
     public void setTranscendent(StarPort.Transcendent transcendentHero) {

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -214,7 +214,7 @@ public class SolGame {
                 this,
                 solApplication.getOptions().controlType == GameOptions.ControlType.MOUSE,
                 isNewShip);
-        hero.initialise();
+        hero.initialise(this);
     }
 
     private ShipConfig readShipFromConfigOrLoadFromSaveIfNull(String shipName, boolean isNewShip) {

--- a/engine/src/main/java/org/destinationsol/game/console/ShellInputHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/ShellInputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,10 +43,11 @@ public class ShellInputHandler implements ConsoleInputHandler {
     }
 
     /**
-     * Registers a command with this input handler. If the command is already registered throws a {@link SolException}
+     * Registers a command with this input handler.
      *
      * @param cmdName Name, that is first word, of the command
      * @param callback This callback will be called with the full entered command
+     * @throws SolException If the command is already registered
      */
     public void registerCommand(String cmdName, ConsoleInputHandler callback) {
         if (commandExists(cmdName)) {

--- a/engine/src/main/java/org/destinationsol/game/console/ShellInputHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/ShellInputHandler.java
@@ -17,6 +17,8 @@ package org.destinationsol.game.console;
 
 import org.destinationsol.common.SolException;
 import org.destinationsol.game.Console;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +31,7 @@ import java.util.Map;
 public class ShellInputHandler implements ConsoleInputHandler {
 
     private final Map<String, ConsoleInputHandler> commands;
+    private static Logger logger = LoggerFactory.getLogger(ShellInputHandler.class);
 
     public ShellInputHandler() {
         commands = new HashMap<>();
@@ -40,7 +43,7 @@ public class ShellInputHandler implements ConsoleInputHandler {
     }
 
     /**
-     * Registers a command with this input handler.
+     * Registers a command with this input handler. If the command is already registered throws a {@link SolException}
      *
      * @param cmdName Name, that is first word, of the command
      * @param callback This callback will be called with the full entered command
@@ -48,6 +51,20 @@ public class ShellInputHandler implements ConsoleInputHandler {
     public void registerCommand(String cmdName, ConsoleInputHandler callback) {
         if (commandExists(cmdName)) {
             throw new SolException("Trying to register command that already exists (" + cmdName + ")");
+        }
+        commands.put(cmdName, callback);
+    }
+
+    /**
+     * Registers a command with this input handler. If the command was already registered then it is replaced
+     *
+     * @param cmdName Name, that is first word, of the command
+     * @param callback This callback will be called with the full entered command
+     */
+    public void registerOrReplaceCommand(String cmdName, ConsoleInputHandler callback) {
+        if (commandExists(cmdName)) {
+            commands.remove(cmdName);
+            logger.debug("Command " + cmdName + " already exists, replacing it with given parameter");
         }
         commands.put(cmdName, callback);
     }

--- a/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.console.commands;
+
+import org.destinationsol.game.Console;
+import org.destinationsol.game.DmgType;
+import org.destinationsol.game.Hero;
+import org.destinationsol.game.SolGame;
+import org.destinationsol.game.console.ConsoleInputHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A command used to instantly destroy the hero's ship, mostly for debugging purposes.
+ */
+public class DieCommandHandler implements ConsoleInputHandler {
+    public Hero hero;
+    public SolGame game;
+
+    public DieCommandHandler(Hero hero, SolGame game) {
+        this.hero = hero;
+        this.game = game;
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(DieCommandHandler.class);
+
+    @Override
+    public void handle(String input, Console console) {
+        if(hero.isTranscendent()) {
+            logger.warn("Cannot kill hero when transcendent!");
+            console.println("Cannot kill hero when transcendent!");
+        }
+        if(!hero.isAlive()) {
+            logger.warn("Hero is already dead!");
+            console.println("Hero is already dead!");
+        }
+        hero.getShip().receivePiercingDmg(hero.getHull().getHullConfig().getMaxLife() + 1, game, hero.getPosition(), DmgType.CRASH);
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -434,6 +434,21 @@ public class SolShip implements SolObject {
             }
             dmg *= (1 - myArmor.getPerc());
         }
+        getHitWith(dmg, game, position, dmgType);
+    }
+
+    /**
+     * Like {{@link #receiveDmg(float, SolGame, Vector2, DmgType)} but shield and armor are ignored, the damage goes straight to the hull
+     */
+    public void receivePiercingDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+        if (dmg <= 0) {
+            return;
+        }
+
+        getHitWith(dmg, game, position, dmgType);
+    }
+
+    private void getHitWith(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
         playHitSound(game, position, dmgType);
 
         boolean wasAlive = myHull.life > 0;


### PR DESCRIPTION
# Description
First commit fixes enter not detected (for me the enter keypress generated '\n' instead of '\r' on windows, weird)
Second commit adds 'die' console command, which kills the player ship by damaging the hull with it's maximum health. Very handy for debugging current issues around dying/respawning.

# Testing
Start the game, bring down the console with the backtick character (`), then type in 'die' and press enter. The player's ship should explode, and items should be thrown out just like if the player died normally during gameplay. 