### PR TITLE
Drop small money

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/item/ItemManager.java
+++ b/engine/src/main/java/org/destinationsol/game/item/ItemManager.java
@@ -36,7 +36,7 @@ public class ItemManager {
     public final TextureAtlas.AtlasRegion hugeMoneyIcon;
     public final TextureAtlas.AtlasRegion repairIcon;
     private final HashMap<String, SolItem> myM = new HashMap<>();
-    private final ArrayList<SolItem> myL= new ArrayList<>();
+    private final ArrayList<SolItem> myL = new ArrayList<>();
     private final HashMap<String, Engine.Config> engineConfigs = new HashMap<>();
     private final SolItemTypes myTypes;
     private final RepairItem myRepairExample;
@@ -235,6 +235,7 @@ public class ItemManager {
 
     /**
      * Turn money into item drops
+     *
      * @param amount the amount of money to turn into drops
      */
     public List<MoneyItem> moneyToItems(float amount) {
@@ -243,13 +244,15 @@ public class ItemManager {
 
     /**
      * Turn money into item drops, with a specifiable limit to the number of items
-     * @param amount the amount of money to turn into drops
+     *
+     * @param amount            the amount of money to turn into drops
      * @param maxNoItemsCreated -1 for no limit, otherwise the maximum number of money items to create
      */
     public List<MoneyItem> moneyToItems(float amount, int maxNoItemsCreated) {
         ArrayList<MoneyItem> items = new ArrayList<>();
-        int moneyAmount;
-        while (amount > MoneyItem.SMALL_AMOUNTT) {
+        float moneyAmount;
+
+        while (amount > 0) {
             if (amount > MoneyItem.HUGE_AMOUNT) {
                 moneyAmount = MoneyItem.HUGE_AMOUNT;
             } else if (amount > MoneyItem.BIG_AMOUNT) {
@@ -257,13 +260,13 @@ public class ItemManager {
             } else if (amount > MoneyItem.MEDIUM_AMOUNT) {
                 moneyAmount = MoneyItem.MEDIUM_AMOUNT;
             } else {
-                moneyAmount = MoneyItem.SMALL_AMOUNTT;
+                moneyAmount = amount;
             }
             amount -= moneyAmount;
             items.add(moneyItem(moneyAmount));
 
             // do not create any more money items if limit parameter is reached
-            if((maxNoItemsCreated != -1) && (items.size() == maxNoItemsCreated)) {
+            if ((maxNoItemsCreated != -1) && (items.size() == maxNoItemsCreated)) {
                 break;
             }
         }

--- a/engine/src/main/java/org/destinationsol/game/item/MoneyItem.java
+++ b/engine/src/main/java/org/destinationsol/game/item/MoneyItem.java
@@ -20,10 +20,10 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import org.destinationsol.game.SolGame;
 
 public class MoneyItem implements SolItem {
-    public static final int SMALL_AMOUNTT = 10;
-    public static final int MEDIUM_AMOUNT = 3 * SMALL_AMOUNTT;
-    public static final int BIG_AMOUNT = 10 * SMALL_AMOUNTT;
-    public static final int HUGE_AMOUNT = 100 * SMALL_AMOUNTT;
+    public static final int SMALL_AMOUNT = 10;
+    public static final int MEDIUM_AMOUNT = 3 * SMALL_AMOUNT;
+    public static final int BIG_AMOUNT = 10 * SMALL_AMOUNT;
+    public static final int HUGE_AMOUNT = 100 * SMALL_AMOUNT;
 
     private final float amount;
     private final SolItemType itemType;


### PR DESCRIPTION
## Description

Allows dropping any arbitrary amount of money between 0-30 with a small icon instead of discarding amounts below 10.

## Testing

I didn't find a way to directly test this (dropped money on player death != money the player loses), only tested with additional logging added after the counting block.

## Outstanding Work

- [ ] I have several questions regarding this in #430 which might lead to other changes depending of outcome of the answers

# Notes

Fixes #430 