### PR TITLE
Add `respawn` command

### DIFF
--- a/config/gradle/ide.gradle
+++ b/config/gradle/ide.gradle
@@ -35,7 +35,7 @@ ext {
         def copyrightManager = iprNode.find { it.@name == 'CopyrightManager' }
         copyrightManager.@default = "TerasologyEngine"
         def copyright = copyrightManager.appendNode("copyright")
-        copyright.appendNode("option", [name: "notice", value: 'Copyright 2018 MovingBlocks\n\nLicensed under the Apache License, Version 2.0 (the "License");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an "AS IS" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.'])
+        copyright.appendNode("option", [name: "notice", value: 'Copyright 2019 MovingBlocks\n\nLicensed under the Apache License, Version 2.0 (the "License");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an "AS IS" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.'])
         copyright.appendNode("option", [name: "keyword", value: "Copyright"])
         copyright.appendNode("option", [name: "allowReplaceKeyword", value: ""])
         copyright.appendNode("option", [name: "myName", value: "TerasologyEngine"])

--- a/engine/src/main/java/org/destinationsol/game/Hero.java
+++ b/engine/src/main/java/org/destinationsol/game/Hero.java
@@ -21,6 +21,7 @@ import org.destinationsol.assets.audio.OggMusicManager;
 import org.destinationsol.common.SolException;
 import org.destinationsol.game.console.commands.DieCommandHandler;
 import org.destinationsol.game.console.commands.PositionCommandHandler;
+import org.destinationsol.game.console.commands.RespawnCommandHandler;
 import org.destinationsol.game.input.Pilot;
 import org.destinationsol.game.item.Armor;
 import org.destinationsol.game.item.ItemContainer;
@@ -30,8 +31,6 @@ import org.destinationsol.game.ship.FarShip;
 import org.destinationsol.game.ship.ShipAbility;
 import org.destinationsol.game.ship.SolShip;
 import org.destinationsol.game.ship.hulls.Hull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A wrapper class for the Hero, that handles the normal and transcendent ships transparently.
@@ -54,6 +53,7 @@ public class Hero {
     public void initialise(SolGame game) {
         Console.getInstance().getDefaultInputHandler().registerOrReplaceCommand("position", new PositionCommandHandler(this));
         Console.getInstance().getDefaultInputHandler().registerOrReplaceCommand("die", new DieCommandHandler(this, game));
+        Console.getInstance().getDefaultInputHandler().registerOrReplaceCommand("respawn", new RespawnCommandHandler(this, game));
     }
 
     public void setTranscendent(StarPort.Transcendent transcendentHero) {
@@ -74,7 +74,7 @@ public class Hero {
         }
         GameOptions options = solGame.getSolApplication().getOptions();
         //Satisfying unit tests
-        if(hero.getHull() != null)
+        if (hero.getHull() != null)
             solGame.getSolApplication().getMusicManager().registerModuleMusic(hero.getHull().getHullConfig().getInternalName().split(":")[0], options);
         solGame.getSolApplication().getMusicManager().playMusic(OggMusicManager.GAME_MUSIC_SET, options);
     }

--- a/engine/src/main/java/org/destinationsol/game/console/ConsoleInputHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/ConsoleInputHandler.java
@@ -24,7 +24,7 @@ public interface ConsoleInputHandler {
     /**
      * Handles user input from console.
      *
-     * @param input User input from console
+     * @param input   User input from console
      * @param console Console from where the input originates
      */
     void handle(String input, Console console);

--- a/engine/src/main/java/org/destinationsol/game/console/ConsoleInputHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/ConsoleInputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/game/console/ShellInputHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/ShellInputHandler.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 /**
  * Default user input handler used by {@link Console}.
- *
+ * <p>
  * Can register additional accepted commands and handle their params.
  */
 public class ShellInputHandler implements ConsoleInputHandler {
@@ -45,7 +45,7 @@ public class ShellInputHandler implements ConsoleInputHandler {
     /**
      * Registers a command with this input handler.
      *
-     * @param cmdName Name, that is first word, of the command
+     * @param cmdName  Name, that is first word, of the command
      * @param callback This callback will be called with the full entered command
      * @throws SolException If the command is already registered
      */
@@ -59,13 +59,13 @@ public class ShellInputHandler implements ConsoleInputHandler {
     /**
      * Registers a command with this input handler. If the command was already registered then it is replaced
      *
-     * @param cmdName Name, that is first word, of the command
+     * @param cmdName  Name, that is first word, of the command
      * @param callback This callback will be called with the full entered command
      */
     public void registerOrReplaceCommand(String cmdName, ConsoleInputHandler callback) {
         if (commandExists(cmdName)) {
             commands.remove(cmdName);
-            logger.debug("Command " + cmdName + " already exists, replacing it with given parameter");
+            logger.debug("Command {} already exists, replacing it with given parameter", cmdName);
         }
         commands.put(cmdName, callback);
     }
@@ -75,8 +75,8 @@ public class ShellInputHandler implements ConsoleInputHandler {
      *
      * @param cmdName Name, that is first word, of the command
      */
-    public boolean commandExists(String cmdName) {
-        return commands.keySet().contains(cmdName);
+    private boolean commandExists(String cmdName) {
+        return commands.containsKey(cmdName);
     }
 
     /**
@@ -93,9 +93,9 @@ public class ShellInputHandler implements ConsoleInputHandler {
 
     @Override
     public void handle(String input, Console console) {
-        for (String cmdName : commands.keySet()) {
-            if (input.startsWith(cmdName + " ") || input.equals(cmdName)) {
-                commands.get(cmdName).handle(input, console);
+        for (Map.Entry<String, ConsoleInputHandler> command : commands.entrySet()) {
+            if (input.startsWith(command.getKey() + " ") || input.equals(command.getKey())) {
+                command.getValue().handle(input, console);
                 break;
             }
         }

--- a/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
@@ -27,8 +27,9 @@ import org.slf4j.LoggerFactory;
  * A command used to instantly destroy the hero's ship, mostly for debugging purposes.
  */
 public class DieCommandHandler implements ConsoleInputHandler {
-    public Hero hero;
-    public SolGame game;
+
+    private Hero hero;
+    private SolGame game;
 
     public DieCommandHandler(Hero hero, SolGame game) {
         this.hero = hero;
@@ -39,14 +40,16 @@ public class DieCommandHandler implements ConsoleInputHandler {
 
     @Override
     public void handle(String input, Console console) {
-        if(hero.isTranscendent()) {
+        if (hero.isTranscendent()) {
             logger.warn("Cannot kill hero when transcendent!");
             console.println("Cannot kill hero when transcendent!");
+            return;
         }
-        if(!hero.isAlive()) {
+        if (!hero.isAlive()) {
             logger.warn("Hero is already dead!");
             console.println("Hero is already dead!");
+            return;
         }
-        hero.getShip().receivePiercingDmg(hero.getHull().getHullConfig().getMaxLife() + 1, game, hero.getPosition(), DmgType.CRASH);
+        hero.getShip().receivePiercingDmg(hero.getHull().getHullConfig().getMaxLife() + 1f, game, hero.getPosition(), DmgType.CRASH);
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/console/commands/PositionCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/PositionCommandHandler.java
@@ -24,16 +24,16 @@ import java.util.Locale;
 
 /**
  * A command used to output the position of the hero.
- *
+ * <p>
  * It takes only (optionally) a single parameter: the format to output the position in.
+ *
  * @see PositionCommandHandler.PositionFormat for more details
  */
 public class PositionCommandHandler implements ConsoleInputHandler {
     /**
      * The format that the position should be outputted in.
      */
-    public enum PositionFormat
-    {
+    public enum PositionFormat {
         /**
          * A minimal output, designed to be as concise and to-the-point as possible.
          */
@@ -48,6 +48,7 @@ public class PositionCommandHandler implements ConsoleInputHandler {
         BOLD,
         /**
          * The default formatting of the position, used internally by the engine.
+         *
          * @see Vector2.toString()
          */
         INTERNAL
@@ -55,16 +56,19 @@ public class PositionCommandHandler implements ConsoleInputHandler {
 
     /**
      * The hero to track the position of.
+     *
      * @see Hero for more information.
      */
     public Hero hero;
     /**
      * The character that the bars will consist of when outputting in the BOLD format
+     *
      * @see PositionFormat.BOLD
      */
     private final char boldLineCharacter = '*';
     /**
      * The number of additional characters to add to the bars when outputting in the BOLD format
+     *
      * @see PositionFormat.BOLD
      */
     private final int boldExtraCharacters = 6;
@@ -83,8 +87,7 @@ public class PositionCommandHandler implements ConsoleInputHandler {
         if (args.length == 2) {
             try {
                 outputFormat = PositionFormat.valueOf(args[1].toUpperCase(Locale.ENGLISH));
-            }
-            catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException e) {
                 console.println("Invalid position format: \"" + args[1] + "\"!");
                 console.println("Currently available formats: ");
                 for (PositionFormat format : PositionFormat.values()) {

--- a/engine/src/main/java/org/destinationsol/game/console/commands/PositionCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/PositionCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class PositionCommandHandler implements ConsoleInputHandler {
      */
     private final int boldExtraCharacters = 6;
     private final PositionFormat defaultFormat = PositionFormat.TERSE;
-    
+
     public PositionCommandHandler(Hero player) {
         hero = player;
     }

--- a/engine/src/main/java/org/destinationsol/game/console/commands/RespawnCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/RespawnCommandHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.console.commands;
+
+import org.destinationsol.game.Console;
+import org.destinationsol.game.Hero;
+import org.destinationsol.game.SolGame;
+import org.destinationsol.game.console.ConsoleInputHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A command used to respawn player's ship
+ */
+public class RespawnCommandHandler implements ConsoleInputHandler {
+
+    private Hero hero;
+    private SolGame game;
+
+    public RespawnCommandHandler(Hero hero, SolGame game) {
+        this.hero = hero;
+        this.game = game;
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(RespawnCommandHandler.class);
+
+    @Override
+    public void handle(String input, Console console) {
+        if (hero.isAlive()) {
+            logger.warn("Cannot respawn hero when not dead!");
+            console.println("Cannot respawn hero when not dead!");
+            return;
+        }
+        game.respawn();
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/console/commands/package-info.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/game/console/commands/package-info.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/package-info.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@API package org.destinationsol.game.console.commands;
+@API
+package org.destinationsol.game.console.commands;
 
 import org.terasology.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/game/console/package-info.java
+++ b/engine/src/main/java/org/destinationsol/game/console/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/game/console/package-info.java
+++ b/engine/src/main/java/org/destinationsol/game/console/package-info.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@API package org.destinationsol.game.console;
+@API
+package org.destinationsol.game.console;
 
 import org.terasology.module.sandbox.API;

--- a/engine/src/test/java/org/destinationsol/game/console/commands/DieCommandHandlerTest.java
+++ b/engine/src/test/java/org/destinationsol/game/console/commands/DieCommandHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.console.commands;
+
+import org.destinationsol.game.Console;
+import org.destinationsol.game.Hero;
+import org.destinationsol.game.SolGame;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DieCommandHandlerTest {
+
+    private DieCommandHandler commandHandler;
+    private Hero hero;
+    private Console console;
+
+    @Before
+    public void init() {
+        SolGame game = Mockito.mock(SolGame.class);
+        hero = Mockito.mock(Hero.class, Mockito.RETURNS_DEEP_STUBS);
+        commandHandler = new DieCommandHandler(hero, game);
+        console = Mockito.mock(Console.class);
+    }
+
+    @Test
+    public void shouldKillWhenAliveAndNotTranscendent() {
+        Mockito.when(hero.isTranscendent()).thenReturn(false);
+        Mockito.when(hero.isAlive()).thenReturn(true);
+        Mockito.verify(hero, Mockito.never()).getShip();
+    }
+
+    @Test
+    public void shouldNotKillWhenTranscendent() {
+        Mockito.when(hero.isTranscendent()).thenReturn(true);
+        commandHandler.handle("respawn", console);
+        Mockito.verify(hero, Mockito.never()).getShip();
+    }
+
+    @Test
+    public void shouldNotKillWhenAlreadyDead() {
+        Mockito.when(hero.isAlive()).thenReturn(false);
+        commandHandler.handle("respawn", console);
+        Mockito.verify(hero, Mockito.never()).getShip();
+    }
+
+}

--- a/engine/src/test/java/org/destinationsol/game/console/commands/RespawnCommandHandlerTest.java
+++ b/engine/src/test/java/org/destinationsol/game/console/commands/RespawnCommandHandlerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.console.commands;
+
+import org.destinationsol.game.Console;
+import org.destinationsol.game.Hero;
+import org.destinationsol.game.SolGame;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+public class RespawnCommandHandlerTest {
+
+    private RespawnCommandHandler commandHandler;
+    private SolGame game;
+    private Hero hero;
+    private Console console;
+
+    @Before
+    public void init() {
+        game = Mockito.mock(SolGame.class);
+        hero = Mockito.mock(Hero.class);
+        commandHandler = new RespawnCommandHandler(hero, game);
+        console = Mockito.mock(Console.class);
+    }
+
+    @Test
+    public void shouldRespawnWhenDead() {
+        Mockito.when(hero.isAlive()).thenReturn(false);
+        commandHandler.handle("respawn", console);
+        Mockito.verify(game, Mockito.times(1)).respawn();
+    }
+
+    @Test
+    public void shouldNotRespawnWhenAlive() {
+        Mockito.when(hero.isAlive()).thenReturn(true);
+        commandHandler.handle("respawn", console);
+        Mockito.verify(game, Mockito.never()).respawn();
+    }
+}


### PR DESCRIPTION
## Description

When I was testing the drop of a low amount of money, I've found the `die` console command very useful, but soon found out that it's a bit impractical as it has been missing quick way to respawn.
This PR adds `respawn` command to respawn the player's ship after it died.

## Testing

1. Start a new or even existing game
1. Open console
1. Type `respawn`, should show a message that you can't respawn when not dead.
1. Type `die` to kill yourself.
1. Type `respawn` to respawn your ship.

## Notes

Along with the `respawn` command, there are few other commits dealing with few other things in `org.destinationsol.game.console` package:
  - adds unit test for `die` command
  - fixes behaviour of `die` command (was still applying damage no matter of the outcome of alive/transcendent checks)
  - fixes various SonarLint issues in `ShellInputHandler`
  - reformats code inside the package
  - updates the copyright year to 2019 in package files as well as gradle `idea` task
