### PR TITLE
Position command refactor

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/console/commands/PositionCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/PositionCommandHandler.java
@@ -67,46 +67,41 @@ public class PositionCommandHandler implements ConsoleInputHandler {
     private Hero hero;
 
     /**
-     * The character that the bars will consist of when outputting in the BOLD format
+     * The character that the bars will consist of when outputting in the BOLD format.
      *
      * @see PositionFormat#BOLD
      */
     private static final char BOLD_LINE_CHARACTER = '*';
 
     /**
-     * The number of additional characters to add to the bars when outputting in the BOLD format
+     * The number of additional characters to add to the bars when outputting in the BOLD format.
      *
      * @see PositionFormat#BOLD
      */
     private static final int BOLD_EXTRA_CHARACTERS = 6;
 
     /**
-     * The default format ouf output if not specified
+     * The default format ouf output if not specified.
      */
     private static final PositionFormat DEFAULT_FORMAT = PositionFormat.TERSE;
 
-    public PositionCommandHandler(Hero player) {
-        hero = player;
+    public PositionCommandHandler(Hero hero) {
+        this.hero = hero;
     }
 
     @Override
     public void handle(String input, Console console) {
-        Vector2 heroPosition = hero.getPosition();
         String[] args = input.split(" ", 2);
 
-        PositionFormat outputFormat = DEFAULT_FORMAT;
-        if (args.length == 2) {
-            try {
-                outputFormat = PositionFormat.valueOf(args[1].toUpperCase(Locale.ENGLISH));
-            } catch (IllegalArgumentException e) {
-                console.warn("Invalid position format: \"" + args[1] + "\"!");
-                console.warn("Currently available formats: ");
-                for (PositionFormat format : PositionFormat.values()) {
-                    console.warn("   " + format.toString());
-                }
-                return;
-            }
+        PositionFormat outputFormat;
+        try {
+            outputFormat = determineFormat(args);
+        } catch (IllegalArgumentException e) {
+            printFormatHelp(args[1], console);
+            return;
         }
+
+        Vector2 heroPosition = hero.getPosition();
 
         switch (outputFormat) {
             case TERSE:
@@ -117,23 +112,43 @@ public class PositionCommandHandler implements ConsoleInputHandler {
                 console.info("The hero's Y co-ordinate is: " + heroPosition.y);
                 break;
             case BOLD:
-                String xOutputString = "X: " + heroPosition.x;
-                String yOutputString = "Y: " + heroPosition.y;
-
-                StringBuilder boldLine = new StringBuilder();
-                int boldLineLength = Math.max(xOutputString.length(), yOutputString.length());
-                for (int i = 0; i < boldLineLength + BOLD_EXTRA_CHARACTERS; i++) {
-                    boldLine.append(BOLD_LINE_CHARACTER);
-                }
-
-                console.info(boldLine.toString());
-                console.info(xOutputString);
-                console.info(yOutputString);
-                console.info(boldLine.toString());
+                printBoldFormat(heroPosition, console);
                 break;
             case INTERNAL:
                 console.info(heroPosition.toString());
                 break;
         }
+    }
+
+    private PositionFormat determineFormat(String[] args) {
+        PositionFormat outputFormat = DEFAULT_FORMAT;
+        if (args.length == 2) {
+            outputFormat = PositionFormat.valueOf(args[1].toUpperCase(Locale.ENGLISH));
+        }
+        return outputFormat;
+    }
+
+    private void printFormatHelp(String requested, Console console) {
+        console.warn("Invalid position format: \"" + requested + "\"!");
+        console.warn("Currently available formats: ");
+        for (PositionFormat format : PositionFormat.values()) {
+            console.warn("   " + format.toString());
+        }
+    }
+
+    private void printBoldFormat(Vector2 heroPosition, Console console) {
+        String xOutputString = "X: " + heroPosition.x;
+        String yOutputString = "Y: " + heroPosition.y;
+
+        StringBuilder boldLine = new StringBuilder();
+        int boldLineLength = Math.max(xOutputString.length(), yOutputString.length());
+        for (int i = 0; i < boldLineLength + BOLD_EXTRA_CHARACTERS; i++) {
+            boldLine.append(BOLD_LINE_CHARACTER);
+        }
+
+        console.info(boldLine.toString());
+        console.info(xOutputString);
+        console.info(yOutputString);
+        console.info(boldLine.toString());
     }
 }

--- a/engine/src/test/java/org/destinationsol/game/console/commands/DieCommandHandlerTest.java
+++ b/engine/src/test/java/org/destinationsol/game/console/commands/DieCommandHandlerTest.java
@@ -20,41 +20,55 @@ import org.destinationsol.game.Hero;
 import org.destinationsol.game.SolGame;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
 public class DieCommandHandlerTest {
 
     private DieCommandHandler commandHandler;
+
+    @Mock
+    private SolGame game;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Hero hero;
+
+    @Mock
     private Console console;
 
     @Before
     public void init() {
-        SolGame game = Mockito.mock(SolGame.class);
-        hero = Mockito.mock(Hero.class, Mockito.RETURNS_DEEP_STUBS);
         commandHandler = new DieCommandHandler(hero, game);
-        console = Mockito.mock(Console.class);
     }
 
     @Test
     public void shouldKillWhenAliveAndNotTranscendent() {
-        Mockito.when(hero.isTranscendent()).thenReturn(false);
-        Mockito.when(hero.isAlive()).thenReturn(true);
-        Mockito.verify(hero, Mockito.never()).getShip();
+        when(hero.isTranscendent()).thenReturn(false);
+        when(hero.isAlive()).thenReturn(true);
+        commandHandler.handle("die", console);
+        verify(hero, Mockito.times(1)).getShip();
     }
 
     @Test
     public void shouldNotKillWhenTranscendent() {
-        Mockito.when(hero.isTranscendent()).thenReturn(true);
-        commandHandler.handle("respawn", console);
-        Mockito.verify(hero, Mockito.never()).getShip();
+        when(hero.isTranscendent()).thenReturn(true);
+        commandHandler.handle("die", console);
+        verify(console, times(1)).warn(anyString());
+        verify(hero, never()).getShip();
     }
 
     @Test
     public void shouldNotKillWhenAlreadyDead() {
-        Mockito.when(hero.isAlive()).thenReturn(false);
-        commandHandler.handle("respawn", console);
-        Mockito.verify(hero, Mockito.never()).getShip();
+        when(hero.isAlive()).thenReturn(false);
+        commandHandler.handle("die", console);
+        verify(console, times(1)).warn(anyString());
+        verify(hero, never()).getShip();
     }
 
 }

--- a/engine/src/test/java/org/destinationsol/game/console/commands/PositionCommandHandlerTest.java
+++ b/engine/src/test/java/org/destinationsol/game/console/commands/PositionCommandHandlerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.console.commands;
+
+import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.game.Console;
+import org.destinationsol.game.Hero;
+import org.destinationsol.game.SolGame;
+import org.destinationsol.game.ship.SolShip;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PositionCommandHandlerTest {
+
+    private PositionCommandHandler commandHandler;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private SolGame game;
+
+    @Mock
+    private SolShip ship;
+
+    @Mock
+    private Console console;
+
+    @Before
+    public void init() {
+        when(ship.getPosition()).thenReturn(new Vector2(1f, 2f));
+        Hero hero = new Hero(ship, game);
+        commandHandler = new PositionCommandHandler(hero);
+    }
+
+    @Test
+    public void shouldPrintErrorOnUnknownFormat() {
+        commandHandler.handle("position xyz", console);
+        verify(console, never()).info(anyString());
+        verify(console, times(1)).warn("Invalid position format: \"xyz\"!");
+    }
+
+    @Test
+    public void shouldPrintAvailableFormatsOnUnknownFormat() {
+        int formatsCount = PositionCommandHandler.PositionFormat.values().length;
+        int additionalLines = 2; //one for warning about unsupported format, one for list header
+        int totalLines = formatsCount + additionalLines;
+        commandHandler.handle("position xyz", console);
+        verify(console, times(totalLines)).warn(anyString());
+    }
+
+    @Test
+    public void checkTerseOutput() {
+        commandHandler.handle("position terse", console);
+        verify(console, only()).info("X: " + ship.getPosition().x + "   Y: " + ship.getPosition().y);
+    }
+
+    @Test
+    public void checkVerboseOutput() {
+        commandHandler.handle("position verbose", console);
+        verify(console, times(1)).info("The hero's X co-ordinate is: " + ship.getPosition().x);
+        verify(console, times(1)).info("The hero's Y co-ordinate is: " + ship.getPosition().y);
+    }
+
+    @Test
+    public void checkBoldOutput() {
+        commandHandler.handle("position bold", console);
+        //Size of wanted message is known for test coordinates as well for the separator
+        verify(console, times(2)).info("************");
+        verify(console, times(1)).info("X: " + ship.getPosition().x);
+        verify(console, times(1)).info("Y: " + ship.getPosition().y);
+    }
+
+    @Test
+    public void checkInternalOutput() {
+        commandHandler.handle("position internal", console);
+        verify(console, times(1)).info(ship.getPosition().toString());
+    }
+
+
+}

--- a/engine/src/test/java/org/destinationsol/game/console/commands/PositionCommandHandlerTest.java
+++ b/engine/src/test/java/org/destinationsol/game/console/commands/PositionCommandHandlerTest.java
@@ -51,8 +51,9 @@ public class PositionCommandHandlerTest {
     }
 
     @Test
-    public void shouldPrintErrorOnUnknownFormat() {
+    public void shouldPrintWarningOnUnknownFormat() {
         commandHandler.handle("position xyz", console);
+        verify(ship, never()).getPosition();
         verify(console, never()).info(anyString());
         verify(console, times(1)).warn("Invalid position format: \"xyz\"!");
     }
@@ -64,6 +65,12 @@ public class PositionCommandHandlerTest {
         int totalLines = formatsCount + additionalLines;
         commandHandler.handle("position xyz", console);
         verify(console, times(totalLines)).warn(anyString());
+    }
+
+    @Test
+    public void checkDefaultOutput() {
+        commandHandler.handle("position", console);
+        verify(console, only()).info("X: " + ship.getPosition().x + "   Y: " + ship.getPosition().y);
     }
 
     @Test

--- a/engine/src/test/java/org/destinationsol/game/console/commands/RespawnCommandHandlerTest.java
+++ b/engine/src/test/java/org/destinationsol/game/console/commands/RespawnCommandHandlerTest.java
@@ -20,37 +20,43 @@ import org.destinationsol.game.Hero;
 import org.destinationsol.game.SolGame;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RespawnCommandHandlerTest {
 
     private RespawnCommandHandler commandHandler;
+
+    @Mock
     private SolGame game;
+
+    @Mock
     private Hero hero;
+
+    @Mock
     private Console console;
 
     @Before
     public void init() {
-        game = Mockito.mock(SolGame.class);
-        hero = Mockito.mock(Hero.class);
         commandHandler = new RespawnCommandHandler(hero, game);
-        console = Mockito.mock(Console.class);
     }
 
     @Test
     public void shouldRespawnWhenDead() {
-        Mockito.when(hero.isAlive()).thenReturn(false);
+        when(hero.isAlive()).thenReturn(false);
         commandHandler.handle("respawn", console);
-        Mockito.verify(game, Mockito.times(1)).respawn();
+        verify(game, times(1)).respawn();
     }
 
     @Test
     public void shouldNotRespawnWhenAlive() {
-        Mockito.when(hero.isAlive()).thenReturn(true);
+        when(hero.isAlive()).thenReturn(true);
         commandHandler.handle("respawn", console);
-        Mockito.verify(game, Mockito.never()).respawn();
+        verify(console, times(1)).warn(anyString());
+        verify(game, never()).respawn();
     }
 }


### PR DESCRIPTION
## Description

I've been messing around console commands lately and realized that the `position` command required some love to be more readable and was missing a test.
This PR provides both :)

## Testing

Apart from unit test created for this command, you can test it directly in-game:

1. Start a game
1. Open the console
1. Write `position` command + required format - `terse`, `verbose`, `bold`, `internal` or none (defaults to `terse`, anything else will print out a warning with a list of available ones

## Notes

- during the writing of the test for `position` command, I've switched to using static import for Mockito as well as annotated mocks, as it started to be a bit messy, I've done the same for remaining commands test
- the change mentioned above helped to discover that the test for `die` command was completely wrong, testing different command or nothing at all, it's fixed within this PR