### PR TITLE
audio/menu: Don't reset main menu music when exiting options menu

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/audio/OggMusicManager.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/OggMusicManager.java
@@ -37,12 +37,13 @@ import java.util.Set;
  * until another is chosen. By default, music does not play concurrently.
  */
 public class OggMusicManager {
+    public static final String NO_MUSIC = "";
     public static final String MENU_MUSIC_SET = "menu";
     public static final String GAME_MUSIC_SET = "game";
     private final Map<String, List<Music>> musicMap;
     private Music currentlyPlaying;
     private String currentlyRegisteredModule;
-    private String currentMusicSet = "";
+    private String currentMusicSet = NO_MUSIC;
     private Logger logger = LoggerFactory.getLogger(OggMusicManager.class);
 
     /**
@@ -136,7 +137,7 @@ public class OggMusicManager {
         if (currentlyPlaying != null) {
             currentlyPlaying.stop();
         }
-        currentMusicSet = "";
+        currentMusicSet = NO_MUSIC;
     }
 
     /**

--- a/engine/src/main/java/org/destinationsol/assets/audio/OggMusicManager.java
+++ b/engine/src/main/java/org/destinationsol/assets/audio/OggMusicManager.java
@@ -42,6 +42,7 @@ public class OggMusicManager {
     private final Map<String, List<Music>> musicMap;
     private Music currentlyPlaying;
     private String currentlyRegisteredModule;
+    private String currentMusicSet = "";
     private Logger logger = LoggerFactory.getLogger(OggMusicManager.class);
 
     /**
@@ -110,6 +111,7 @@ public class OggMusicManager {
                 index = 0;
             }
         }
+        currentMusicSet = musicSet;
         final Music music = musicMap.get(musicSet).get(index);
         music.setOnCompletionListener(a -> playMusic(musicSet, options));
         playMusicTrack(music, options);
@@ -134,6 +136,7 @@ public class OggMusicManager {
         if (currentlyPlaying != null) {
             currentlyPlaying.stop();
         }
+        currentMusicSet = "";
     }
 
     /**
@@ -224,5 +227,9 @@ public class OggMusicManager {
 
     public void resetMusic() {
         musicMap.put(GAME_MUSIC_SET, new ArrayList<>());
+    }
+
+    public String getCurrentMusicSet() {
+        return currentMusicSet;
     }
 }

--- a/engine/src/main/java/org/destinationsol/menu/MainMenuScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/MainMenuScreen.java
@@ -120,7 +120,10 @@ public class MainMenuScreen extends SolUiBaseScreen {
 
     @Override
     public void onAdd(SolApplication solApplication) {
-        solApplication.getMusicManager().playMusic(OggMusicManager.MENU_MUSIC_SET, gameOptions);
+        final OggMusicManager musicManager = solApplication.getMusicManager();
+        if (!musicManager.getCurrentMusicSet().equals(OggMusicManager.MENU_MUSIC_SET)) {
+            musicManager.playMusic(OggMusicManager.MENU_MUSIC_SET, gameOptions);
+        }
     }
 
     @Override


### PR DESCRIPTION
This resolves the bug that the game music of the title screen would reset when exiting the options menu.

I don't really like having to add extra state tracking here, so if there's a better solution, feel free to tell me.