### PR TITLE
Added support for JSON asset deltas and fonts in modules

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
@@ -70,11 +70,13 @@ public class AssetDataFileHandle extends FileHandle {
 
     @Override
     public FileHandle parent() {
+        // HACK: LibGDX's BitmapFontData uses this method to obtain a file in the same directory
         return this;
     }
 
     @Override
     public FileHandle child(String name) {
+        // HACK: LibGDX's BitmapFontData uses this method to obtain a file in the same directory
         return new FileHandle(path() + "/" + name);
     }
 

--- a/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
@@ -69,6 +69,16 @@ public class AssetDataFileHandle extends FileHandle {
     }
 
     @Override
+    public FileHandle parent() {
+        return this;
+    }
+
+    @Override
+    public FileHandle child(String name) {
+        return new FileHandle(path() + "/" + name);
+    }
+
+    @Override
     public String pathWithoutExtension() {
         String path = path();
         return path.substring(0, path.indexOf(extension()));

--- a/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetDataFileHandle.java
@@ -20,6 +20,7 @@ import org.terasology.gestalt.assets.format.AssetDataFile;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * AssetDataFileHandle is an instance of FileHandle that provides access to an AssetDataFile, rather than an actual file.
@@ -65,7 +66,17 @@ public class AssetDataFileHandle extends FileHandle {
 
     @Override
     public String path() {
-        return String.join("/", dataFile.getPath());
+        List<String> path = dataFile.getPath();
+
+        StringBuilder builder = new StringBuilder();
+        for (int segmentNo = 0; segmentNo < path.size(); segmentNo++) {
+            builder.append(path.get(segmentNo));
+            if (segmentNo != path.size() - 1) {
+                builder.append('/');
+            }
+        }
+
+        return builder.toString();
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
@@ -24,6 +24,7 @@ import org.destinationsol.assets.emitters.EmitterFileFormat;
 import org.destinationsol.assets.fonts.Font;
 import org.destinationsol.assets.fonts.FontFileFormat;
 import org.destinationsol.assets.json.Json;
+import org.destinationsol.assets.json.JsonDeltaFileFormat;
 import org.destinationsol.assets.json.JsonFileFormat;
 import org.destinationsol.assets.textures.DSTexture;
 import org.destinationsol.assets.textures.DSTextureFileFormat;
@@ -64,7 +65,9 @@ public class AssetHelper {
         ((AssetFileDataProducer)assetTypeManager.getAssetType(Emitter.class).get().getProducers().get(0)).addAssetFormat(new EmitterFileFormat());
 
         assetTypeManager.createAssetType(Json.class, Json::new, "collisionMeshes", "ships", "items", "configs", "grounds", "mazes", "asteroids", "schemas");
-        ((AssetFileDataProducer)assetTypeManager.getAssetType(Json.class).get().getProducers().get(0)).addAssetFormat(new JsonFileFormat());
+        AssetFileDataProducer dataProducer = (AssetFileDataProducer) assetTypeManager.getAssetType(Json.class).get().getProducers().get(0);
+        dataProducer.addAssetFormat(new JsonFileFormat());
+        dataProducer.addDeltaFormat(new JsonDeltaFileFormat());
 
         assetTypeManager.createAssetType(DSTexture.class, DSTexture::new, "textures", "ships", "items", "grounds", "mazes", "asteroids");
         ((AssetFileDataProducer)assetTypeManager.getAssetType(DSTexture.class).get().getProducers().get(0)).addAssetFormat(new DSTextureFileFormat());

--- a/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
@@ -69,7 +69,7 @@ public class AssetHelper {
         dataProducer.addAssetFormat(new JsonFileFormat());
         dataProducer.addDeltaFormat(new JsonDeltaFileFormat());
 
-        assetTypeManager.createAssetType(DSTexture.class, DSTexture::new, "textures", "ships", "items", "grounds", "mazes", "asteroids");
+        assetTypeManager.createAssetType(DSTexture.class, DSTexture::new, "textures", "ships", "items", "grounds", "mazes", "asteroids", "fonts");
         ((AssetFileDataProducer)assetTypeManager.getAssetType(DSTexture.class).get().getProducers().get(0)).addAssetFormat(new DSTextureFileFormat());
 
         assetTypeManager.switchEnvironment(environment);

--- a/engine/src/main/java/org/destinationsol/assets/fonts/FontFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/fonts/FontFileFormat.java
@@ -15,10 +15,9 @@
  */
 package org.destinationsol.assets.fonts;
 
-import com.badlogic.gdx.Files;
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import org.destinationsol.assets.AssetDataFileHandle;
 import org.destinationsol.assets.Assets;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.format.AbstractAssetFileFormat;
@@ -36,11 +35,15 @@ public class FontFileFormat extends AbstractAssetFileFormat<FontData> {
 
     @Override
     public FontData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
-        String path = Assets.getAssetHelper().resolveToPath(inputs);
+        AssetDataFileHandle fontDataHandle = new AssetDataFileHandle(inputs.get(0));
+        BitmapFont.BitmapFontData fontData = new BitmapFont.BitmapFontData(fontDataHandle, true);
 
-        //NOTE: The BitmapFont class relies on direct filesystem access, so jar modules will not be able to define new fonts.
-        FileHandle handle = Gdx.files.getFileHandle(path, Files.FileType.Internal);
-        BitmapFont bitmapFont = new BitmapFont(handle, true);
+        String[] fontTexturePath = fontData.imagePaths[0].split("/");
+        String fontTextureName = fontTexturePath[fontTexturePath.length - 1];
+        fontTextureName = fontTextureName.substring(0, fontTextureName.lastIndexOf('.'));
+        TextureRegion fontTexture = new TextureRegion(Assets.getDSTexture(urn.getModuleName() + ":" + fontTextureName).getTexture());
+
+        BitmapFont bitmapFont = new BitmapFont(fontData, fontTexture, false);
         bitmapFont.setUseIntegerPositions(false);
         return new FontData(bitmapFont);
     }

--- a/engine/src/main/java/org/destinationsol/assets/json/JsonDeltaFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/json/JsonDeltaFileFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/assets/json/JsonDeltaFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/json/JsonDeltaFileFormat.java
@@ -48,6 +48,17 @@ public class JsonDeltaFileFormat extends AbstractAssetAlterationFileFormat<JsonD
         mergeObjects(jsonValue, deltaJsonValue);
     }
 
+    /**
+     * This method merges the JSONObject input with its delta by recursively checking for differing values.
+     *
+     * If a value does not exist in the delta, then the original input value is preserved. Otherwise, if the value is
+     * a primitive type (excluding array), then the delta value will override the input value. For JSONObject values,
+     * this method is called recursively to merge the sub-objects together. In the case of arrays, all of the values
+     * in the delta array are appended to the input array.
+     *
+     * @param input the JSONObject to merge into
+     * @param delta the JSONObject to merge with
+     */
     private void mergeObjects(JSONObject input, JSONObject delta) {
         for (String key : input.keySet()) {
             Object subObject = input.get(key);

--- a/engine/src/main/java/org/destinationsol/assets/json/JsonDeltaFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/json/JsonDeltaFileFormat.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.assets.json;
+
+import com.badlogic.gdx.files.FileHandle;
+import org.destinationsol.assets.AssetDataFileHandle;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.terasology.gestalt.assets.format.AbstractAssetAlterationFileFormat;
+import org.terasology.gestalt.assets.format.AssetDataFile;
+import org.terasology.gestalt.assets.module.annotations.RegisterAssetDeltaFileFormat;
+
+import java.io.IOException;
+
+@RegisterAssetDeltaFileFormat
+public class JsonDeltaFileFormat extends AbstractAssetAlterationFileFormat<JsonData> {
+    public JsonDeltaFileFormat() {
+        super("json");
+    }
+
+    /**
+     * Applies an alteration to the given assetData
+     *
+     * @param input     The input corresponding to this asset
+     * @param assetData An assetData to update
+     * @throws IOException If there are any errors loading the alteration
+     */
+    @Override
+    public void apply(AssetDataFile input, JsonData assetData) throws IOException {
+        FileHandle handle = new AssetDataFileHandle(input);
+        JSONObject deltaJsonValue = new JSONObject(handle.readString());
+
+        JSONObject jsonValue = assetData.getJsonValue();
+        mergeObjects(jsonValue, deltaJsonValue);
+    }
+
+    private void mergeObjects(JSONObject input, JSONObject delta) {
+        for (String key : input.keySet()) {
+            Object subObject = input.get(key);
+            if (!delta.has(key)) {
+                // Value is not modified
+                continue;
+            }
+
+            if (subObject instanceof JSONObject) {
+                Object deltaObject = delta.get(key);
+                if (deltaObject instanceof JSONObject) {
+                    mergeObjects((JSONObject) subObject, (JSONObject) deltaObject);
+                } else {
+                    throw new JSONException("Error when parsing delta: Type " + deltaObject.getClass().getSimpleName() + " does not equal JSONObject");
+                }
+
+                continue;
+            }
+
+            if (subObject instanceof JSONArray) {
+                Object deltaObject = delta.get(key);
+                if (deltaObject instanceof JSONArray) {
+                    mergeArray((JSONArray) subObject, (JSONArray) deltaObject);
+                } else {
+                    throw new JSONException("Error when parsing delta: Type " + deltaObject.getClass().getSimpleName() + " does not equal JSONArray");
+                }
+
+                continue;
+            }
+
+            // Assume that a primitive type is used (primitive types cannot be merged, only overridden)
+            input.put(key, delta.get(key));
+        }
+    }
+
+    /**
+     * Merges the input with its delta by adding all values from the delta to the input.
+     */
+    private void mergeArray(JSONArray input, JSONArray delta) {
+        for (int index = 0; index < delta.length(); index++) {
+            input.put(delta.get(index));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request implements asset deltas for JSON assets, using gestalt's `AssetAlterationFileFormat` class. It also implements loading fonts from modules.

# Testing
_Note: This also tests override functionality, although this should have worked before, as it is handled by gestalt natively._
### Set-up
 - Clone my [deltasTest](https://github.com/BenjaminAmos/deltasTest) module using the command `groovyw module get deltasTest -remote BenjaminAmos`
 -  Run the game (use `gradlew run` or start the game from an IDE)
### Overrides
 - Notice that the font has changed
 - Notice that the in-game ui cursor is now red
 - Start a new game, or continue an existing one
 - Notice that the starting station has changed colour
### Deltas
 - Start a new game, or continue an existing one
 - Notice that the starting station is considerably larger
 - Notice that the starting station possesses wave guns, rather than the standard built-in gun.  If you attack the station then it will now fire waves, rather than bullets.
 - Notice that there are now lights in-front of the starting station, marking a path towards the force beacon.

# Notes
 - With JSON merging, arrays will be merged, so that all the values in the delta are appended to the existing array. To override values, an override file should be used instead (which will replace the entire file).
 - In order to override/augment assets in a module, the overriding module must depend on the overridden module (if you remove the dependency on `engine` from a module, then it can not override `engine` assets).
 - Tha asset types appear to be registered twice: once through the `@RegisterAssetFileFormat` and `@RegisterAssetDeltaFileFormat` annotations and again in `AssetHelper.init`. The game does not appear to be affected by this though, so I have left the existing code in-place.
 - To get the Android facade to work with these changes, as small modification will need to be made to it. You will need to apply the following change to [line 64](https://github.com/MovingBlocks/DestSolAndroid/blob/22aa08be8adf63792c063ec297b1df4b627ab150/src/org/destinationsol/android/AndroidAssetHelper.java#L64) of `src/org/destinationsol/android/AndroidAssetHelper.java`:
```diff
-        assetTypeManager.createAssetType(DSTexture.class, DSTexture::new, "textures", "ships", "items", "grounds", "mazes", "asteroids");
+        assetTypeManager.createAssetType(DSTexture.class, DSTexture::new, "textures", "ships", "items", "grounds", "mazes", "asteroids", "fonts");
```
<!--
### Pre Pull Request Checklist:
When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones. 
If the code looks good to you and you have already at least some experience writing java, you can even completely skip 
this step
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
-->