### PR TITLE
Pannable Map

### DIFF
--- a/engine/src/main/java/org/destinationsol/GameOptions.java
+++ b/engine/src/main/java/org/destinationsol/GameOptions.java
@@ -79,11 +79,16 @@ public class GameOptions {
 
         public Volume advance() {
             switch (this) {
-                case OFF: return LOW;
-                case LOW: return MEDIUM;
-                case MEDIUM: return HIGH;
-                case HIGH: return MAX;
-                case MAX: return OFF;
+                case OFF:
+                    return LOW;
+                case LOW:
+                    return MEDIUM;
+                case MEDIUM:
+                    return HIGH;
+                case HIGH:
+                    return MAX;
+                case MAX:
+                    return OFF;
             }
             return MAX;
         }
@@ -224,7 +229,7 @@ public class GameOptions {
 
     public void advanceResolution() {
         //lazy initialize provider because graphics is not available at the constructor
-        if(resolutionProvider == null){
+        if (resolutionProvider == null) {
             resolutionProvider = new ResolutionProvider(asList(Gdx.graphics.getDisplayModes()));
         }
         Resolution nextResolution = resolutionProvider.increase();
@@ -257,7 +262,7 @@ public class GameOptions {
 
     public void advanceMapScrollSpeed() {
         mapScrollSpeed++;
-        if(mapScrollSpeed > 15) {
+        if (mapScrollSpeed > 15) {
             mapScrollSpeed = 1;
         }
     }

--- a/engine/src/main/java/org/destinationsol/GameOptions.java
+++ b/engine/src/main/java/org/destinationsol/GameOptions.java
@@ -17,6 +17,8 @@ package org.destinationsol;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.math.MathUtils;
+import org.destinationsol.common.SolMath;
 import org.destinationsol.menu.Resolution;
 import org.destinationsol.menu.ResolutionProvider;
 
@@ -125,6 +127,7 @@ public class GameOptions {
     public static final int DEFAULT_BUTTON_DOWN = -1;
     public static final int DEFAULT_BUTTON_LEFT = -1;
     public static final int DEFAULT_BUTTON_RIGHT = -1;
+    public static final int DEFAULT_MAP_SCOLL_SPEED = 5;
 
     public int x;
     public int y;
@@ -168,6 +171,7 @@ public class GameOptions {
     private int controllerButtonRight;
     private int controllerButtonUp;
     private int controllerButtonDown;
+    private int mapScrollSpeed;
 
     private ResolutionProvider resolutionProvider;
 
@@ -215,6 +219,7 @@ public class GameOptions {
         controllerButtonUp = reader.getInt("controllerButtonUp", DEFAULT_BUTTON_UP);
         controllerButtonDown = reader.getInt("controllerButtonDown", DEFAULT_BUTTON_DOWN);
         canSellEquippedItems = reader.getBoolean("canSellEquippedItems", false);
+        mapScrollSpeed = reader.getInt("mapScrollSpeed", DEFAULT_MAP_SCOLL_SPEED);
     }
 
     public void advanceResolution() {
@@ -250,6 +255,13 @@ public class GameOptions {
         save();
     }
 
+    public void advanceMapScrollSpeed() {
+        mapScrollSpeed++;
+        if(mapScrollSpeed > 10) {
+            mapScrollSpeed = 1;
+        }
+    }
+
     /**
      * Save the configuration settings to file.
      */
@@ -267,7 +279,8 @@ public class GameOptions {
                 "isControllerAxisUpDownInverted", isControllerAxisUpDownInverted(), "controllerButtonShoot", getControllerButtonShoot(),
                 "controllerButtonShoot2", getControllerButtonShoot2(), "controllerButtonAbility", getControllerButtonAbility(),
                 "controllerButtonLeft", getControllerButtonLeft(), "controllerButtonRight", getControllerButtonRight(),
-                "controllerButtonUp", getControllerButtonUp(), "controllerButtonDown", getControllerButtonDown());
+                "controllerButtonUp", getControllerButtonUp(), "controllerButtonDown", getControllerButtonDown(),
+                "mapScrollSpeed", getMapScrollSpeed());
     }
 
     /**
@@ -977,5 +990,13 @@ public class GameOptions {
 
     public void setControllerButtonDown(int controllerButtonDown) {
         this.controllerButtonDown = controllerButtonDown;
+    }
+
+    public int getMapScrollSpeed() {
+        return mapScrollSpeed;
+    }
+
+    public void setMapScrollSpeed(int mapScrollSpeed) {
+        this.mapScrollSpeed = mapScrollSpeed;
     }
 }

--- a/engine/src/main/java/org/destinationsol/GameOptions.java
+++ b/engine/src/main/java/org/destinationsol/GameOptions.java
@@ -17,8 +17,6 @@ package org.destinationsol;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.math.MathUtils;
-import org.destinationsol.common.SolMath;
 import org.destinationsol.menu.Resolution;
 import org.destinationsol.menu.ResolutionProvider;
 
@@ -127,7 +125,8 @@ public class GameOptions {
     public static final int DEFAULT_BUTTON_DOWN = -1;
     public static final int DEFAULT_BUTTON_LEFT = -1;
     public static final int DEFAULT_BUTTON_RIGHT = -1;
-    public static final int DEFAULT_MAP_SCOLL_SPEED = 5;
+    public static final int DEFAULT_MAP_SCROLL_SPEED = 10;
+    public static final int DEFAULT_MOBILE_MAP_SCROLL_SPEED = 5;
 
     public int x;
     public int y;
@@ -176,6 +175,7 @@ public class GameOptions {
     private ResolutionProvider resolutionProvider;
 
     public GameOptions(boolean mobile, SolFileReader solFileReader) {
+
         IniReader reader = new IniReader(FILE_NAME, solFileReader);
         x = reader.getInt("x", 1366);
         y = reader.getInt("y", 768);
@@ -219,7 +219,7 @@ public class GameOptions {
         controllerButtonUp = reader.getInt("controllerButtonUp", DEFAULT_BUTTON_UP);
         controllerButtonDown = reader.getInt("controllerButtonDown", DEFAULT_BUTTON_DOWN);
         canSellEquippedItems = reader.getBoolean("canSellEquippedItems", false);
-        mapScrollSpeed = reader.getInt("mapScrollSpeed", DEFAULT_MAP_SCOLL_SPEED);
+        mapScrollSpeed = reader.getInt("mapScrollSpeed", mobile ? DEFAULT_MOBILE_MAP_SCROLL_SPEED : DEFAULT_MAP_SCROLL_SPEED);
     }
 
     public void advanceResolution() {
@@ -257,7 +257,7 @@ public class GameOptions {
 
     public void advanceMapScrollSpeed() {
         mapScrollSpeed++;
-        if(mapScrollSpeed > 10) {
+        if(mapScrollSpeed > 15) {
             mapScrollSpeed = 1;
         }
     }

--- a/engine/src/main/java/org/destinationsol/game/GridDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/GridDrawer.java
@@ -24,7 +24,7 @@ public class GridDrawer {
     public void draw(GameDrawer drawer, SolGame game, float gridSz, TextureAtlas.AtlasRegion tex) {
         SolCam cam = game.getCam();
         float lw = 4 * cam.getRealLineWidth();
-        Vector2 camPos = cam.getPosition().cpy().add(game.getMapDrawer().getMapDrawPosAdditive());
+        Vector2 camPos = cam.getPosition().cpy().add(game.getMapDrawer().getMapDrawPositionAdditive());
         float viewDist = cam.getViewDistance(cam.getRealZoom());
         float x = (int) ((camPos.x - viewDist) / gridSz) * gridSz;
         float y = (int) ((camPos.y - viewDist) / gridSz) * gridSz;

--- a/engine/src/main/java/org/destinationsol/game/GridDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/GridDrawer.java
@@ -24,7 +24,7 @@ public class GridDrawer {
     public void draw(GameDrawer drawer, SolGame game, float gridSz, TextureAtlas.AtlasRegion tex) {
         SolCam cam = game.getCam();
         float lw = 4 * cam.getRealLineWidth();
-        Vector2 camPos = cam.getPosition();
+        Vector2 camPos = cam.getPosition().cpy().add(game.getMapDrawer().getMapDrawPosAdditive());
         float viewDist = cam.getViewDistance(cam.getRealZoom());
         float x = (int) ((camPos.x - viewDist) / gridSz) * gridSz;
         float y = (int) ((camPos.y - viewDist) / gridSz) * gridSz;

--- a/engine/src/main/java/org/destinationsol/game/MapDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/MapDrawer.java
@@ -84,7 +84,7 @@ public class MapDrawer implements UpdateAwareSystem{
     private float skullTime;
     private float areaSkullTime;
 
-    private final Vector2 mapDrawPosAdditive = new Vector2();
+    private final Vector2 mapDrawPositionAdditive = new Vector2();
 
     MapDrawer() {
         DisplayDimensions displayDimensions = SolApplication.displayDimensions;
@@ -125,31 +125,31 @@ public class MapDrawer implements UpdateAwareSystem{
     }
 
     public void draw(GameDrawer drawer, SolGame game) {
-        SolCam cam = game.getCam();
-        float iconSz = getIconRadius(cam) * 2;
-        float starNodeW = cam.getViewHeight(zoom) * STAR_NODE_SZ;
-        float viewDist = cam.getViewDistance(zoom);
+        SolCam camera = game.getCam();
+        float iconSz = getIconRadius(camera) * 2;
+        float starNodeW = camera.getViewHeight(zoom) * STAR_NODE_SZ;
+        float viewDist = camera.getViewDistance(zoom);
         FactionManager factionManager = game.getFactionMan();
         Hero hero = game.getHero();
         Planet np = game.getPlanetManager().getNearestPlanet();
-        Vector2 camPos = cam.getPosition();
-        float camAngle = cam.getAngle();
+        Vector2 cameraPosition = camera.getPosition();
+        float camAngle = camera.getAngle();
         float heroDmgCap = hero.isTranscendent() ? Float.MAX_VALUE : HardnessCalc.getShipDmgCap(hero.getShip());
 
         //Update drawing camera's position in-case the map is panned around
-        OrthographicCamera drawCamera = cam.getCamera();
-        drawCamera.position.add(new Vector3(mapDrawPosAdditive, 0));
+        OrthographicCamera drawCamera = camera.getCamera();
+        drawCamera.position.add(new Vector3(mapDrawPositionAdditive, 0));
         drawCamera.update();
         drawer.updateMatrix(game);
 
         game.getGridDrawer().draw(drawer, game, GRID_SZ, lineTexture);
-        drawPlanets(drawer, game, viewDist, np, camPos, heroDmgCap, camAngle);
-        drawMazes(drawer, game, viewDist, np, camPos, heroDmgCap, camAngle);
-        drawStarNodes(drawer, game, viewDist, camPos, starNodeW);
+        drawPlanets(drawer, game, viewDist, np, cameraPosition, heroDmgCap, camAngle);
+        drawMazes(drawer, game, viewDist, np, cameraPosition, heroDmgCap, camAngle);
+        drawStarNodes(drawer, game, viewDist, cameraPosition, starNodeW);
         drawWaypoints(drawer, game, iconSz, viewDist);
 
         // using ui textures
-        drawIcons(drawer, game, iconSz, viewDist, factionManager, hero, camPos, heroDmgCap);
+        drawIcons(drawer, game, iconSz, viewDist, factionManager, hero, cameraPosition, heroDmgCap);
 
         if (game.getScreens().mapScreen.isPickingWaypointSpot()) {
             drawer.drawString("Click a spot for the new waypoint", drawCamera.position.x, drawCamera.position.y + (zoom* 1.5f), 0.125f * zoom, true, Color.RED);
@@ -160,7 +160,7 @@ public class MapDrawer implements UpdateAwareSystem{
         }
 
         //Reset the camera's position for use in any other class
-        drawCamera.position.set(new Vector3(camPos.x, camPos.y,0));
+        drawCamera.position.set(new Vector3(cameraPosition.x, cameraPosition.y,0));
         drawCamera.update();
     }
 
@@ -508,7 +508,7 @@ public class MapDrawer implements UpdateAwareSystem{
         return waypointTexture;
     }
 
-    public Vector2 getMapDrawPosAdditive() {
-        return mapDrawPosAdditive;
+    public Vector2 getMapDrawPositionAdditive() {
+        return mapDrawPositionAdditive;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/MapDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/MapDrawer.java
@@ -84,7 +84,7 @@ public class MapDrawer implements UpdateAwareSystem{
     private float skullTime;
     private float areaSkullTime;
 
-    private final Vector3 mapDrawPosAdditive = new Vector3();
+    private final Vector2 mapDrawPosAdditive = new Vector2();
 
     MapDrawer() {
         DisplayDimensions displayDimensions = SolApplication.displayDimensions;
@@ -138,7 +138,7 @@ public class MapDrawer implements UpdateAwareSystem{
 
         //Update drawing camera's position in-case the map is panned around
         OrthographicCamera drawCamera = cam.getCamera();
-        drawCamera.position.add(mapDrawPosAdditive);
+        drawCamera.position.add(new Vector3(mapDrawPosAdditive, 0));
         drawCamera.update();
         drawer.updateMatrix(game);
 
@@ -152,11 +152,11 @@ public class MapDrawer implements UpdateAwareSystem{
         drawIcons(drawer, game, iconSz, viewDist, factionManager, hero, camPos, heroDmgCap);
 
         if (game.getScreens().mapScreen.isPickingWaypointSpot()) {
-            drawer.drawString("Click a spot for the new waypoint", hero.getPosition().x, hero.getPosition().y + (zoom* 1.5f), 0.125f * zoom, true, Color.RED);
+            drawer.drawString("Click a spot for the new waypoint", drawCamera.position.x, drawCamera.position.y + (zoom* 1.5f), 0.125f * zoom, true, Color.RED);
         }
 
         if (game.getScreens().mapScreen.isPickingWaypointToRemove()) {
-            drawer.drawString("Click a waypoint to remove", hero.getPosition().x, hero.getPosition().y + (zoom* 1.5f), 0.125f * zoom, true, Color.RED);
+            drawer.drawString("Click a waypoint to remove", drawCamera.position.x, drawCamera.position.y + (zoom* 1.5f), 0.125f * zoom, true, Color.RED);
         }
 
         //Reset the camera's position for use in any other class
@@ -508,7 +508,7 @@ public class MapDrawer implements UpdateAwareSystem{
         return waypointTexture;
     }
 
-    public Vector3 getMapDrawPosAdditive() {
+    public Vector2 getMapDrawPosAdditive() {
         return mapDrawPosAdditive;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/MapDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/MapDrawer.java
@@ -16,10 +16,12 @@
 package org.destinationsol.game;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
 import org.destinationsol.Const;
 import org.destinationsol.SolApplication;
 import org.destinationsol.assets.Assets;
@@ -82,6 +84,8 @@ public class MapDrawer implements UpdateAwareSystem{
     private float skullTime;
     private float areaSkullTime;
 
+    private final Vector3 mapDrawPosAdditive = new Vector3();
+
     MapDrawer() {
         DisplayDimensions displayDimensions = SolApplication.displayDimensions;
 
@@ -132,7 +136,12 @@ public class MapDrawer implements UpdateAwareSystem{
         float camAngle = cam.getAngle();
         float heroDmgCap = hero.isTranscendent() ? Float.MAX_VALUE : HardnessCalc.getShipDmgCap(hero.getShip());
 
+        //Update drawing camera's position in-case the map is panned around
+        OrthographicCamera drawCamera = cam.getCamera();
+        drawCamera.position.add(mapDrawPosAdditive);
+        drawCamera.update();
         drawer.updateMatrix(game);
+
         game.getGridDrawer().draw(drawer, game, GRID_SZ, lineTexture);
         drawPlanets(drawer, game, viewDist, np, camPos, heroDmgCap, camAngle);
         drawMazes(drawer, game, viewDist, np, camPos, heroDmgCap, camAngle);
@@ -149,6 +158,10 @@ public class MapDrawer implements UpdateAwareSystem{
         if (game.getScreens().mapScreen.isPickingWaypointToRemove()) {
             drawer.drawString("Click a waypoint to remove", hero.getPosition().x, hero.getPosition().y + (zoom* 1.5f), 0.125f * zoom, true, Color.RED);
         }
+
+        //Reset the camera's position for use in any other class
+        drawCamera.position.set(new Vector3(camPos.x, camPos.y,0));
+        drawCamera.update();
     }
 
     public float getIconRadius(SolCam cam) {
@@ -493,5 +506,9 @@ public class MapDrawer implements UpdateAwareSystem{
 
     public TextureAtlas.AtlasRegion getWaypointTexture() {
         return waypointTexture;
+    }
+
+    public Vector3 getMapDrawPosAdditive() {
+        return mapDrawPosAdditive;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/SolCam.java
+++ b/engine/src/main/java/org/destinationsol/game/SolCam.java
@@ -169,8 +169,9 @@ public class SolCam implements UpdateAwareSystem {
         myCam.zoom = myZoom;
     }
 
-    private void applyPos(float posX, float posY) {
+    public void applyPos(float posX, float posY) {
         myCam.position.set(posX, posY, 0);
+        myCam.update();
     }
 
     private void applyInput(SolGame game) {
@@ -277,6 +278,10 @@ public class SolCam implements UpdateAwareSystem {
 
     public float getRealZoom() {
         return myCam.zoom;
+    }
+
+    public OrthographicCamera getCamera() {
+        return myCam;
     }
 
     public boolean isVisible(Vector2 position) {

--- a/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
@@ -18,7 +18,6 @@ package org.destinationsol.game.screens;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.destinationsol.game.MapDrawer;
@@ -85,7 +84,7 @@ public class MapScreen extends SolUiBaseScreen {
         SolInputManager im = solApplication.getInputManager();
 
         if (justClosed) {
-            mapDrawer.getMapDrawPosAdditive().set(0,0);
+            mapDrawer.getMapDrawPositionAdditive().set(0, 0);
             isPickingWaypointSpot = false;
             addWaypointControl.setDisplayName(NEW_WAYPOINT_TEXT);
             im.setScreen(solApplication, game.getScreens().mainGameScreen);
@@ -113,16 +112,16 @@ public class MapScreen extends SolUiBaseScreen {
             }
         }
 
-        if(im.touchDragged) {
+        if (im.touchDragged) {
             //Scroll factor negates the drag and adjusts it to map's zoom
-            float scrollFactor = -mapDrawer.getZoom()/ Gdx.graphics.getHeight() * gameOptions.getMapScrollSpeed();
+            float scrollFactor = -mapDrawer.getZoom() / Gdx.graphics.getHeight() * gameOptions.getMapScrollSpeed();
             float rotateAngle = game.getCam().getAngle();
-            mapDrawer.getMapDrawPosAdditive().add(im.getDrag().scl(scrollFactor).rotate(rotateAngle));
+            mapDrawer.getMapDrawPositionAdditive().add(im.getDrag().scl(scrollFactor).rotate(rotateAngle));
         }
 
         if (isPickingWaypointSpot) {
             if (inputPointers[0].isJustUnPressed() && !addWaypointControl.isJustOff()) {
-                Vector2 mapCamPos = game.getCam().getPosition().add(mapDrawer.getMapDrawPosAdditive());
+                Vector2 mapCamPos = game.getCam().getPosition().add(mapDrawer.getMapDrawPositionAdditive());
                 Vector2 clickPosition = new Vector2(inputPointers[0].x, inputPointers[0].y);
                 Vector2 worldPosition = screenPositionToWorld(clickPosition, mapCamPos, mapZoom);
                 ArrayList<Waypoint> waypoints = game.getHero().getWaypoints();

--- a/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
@@ -117,7 +117,8 @@ public class MapScreen extends SolUiBaseScreen {
         if(im.touchDragged) {
             //Scroll factor negates the drag and adjusts it to map's zoom
             float scrollFactor = -mapDrawer.getZoom()/ Gdx.graphics.getHeight() * SCROLL_SPEED;
-            mapDrawer.getMapDrawPosAdditive().add(im.getDrag().scl(scrollFactor));
+            float rotateAngle = game.getCam().getAngle();
+            mapDrawer.getMapDrawPosAdditive().add(im.getDrag().scl(scrollFactor).rotate(rotateAngle));
         }
 
         if (isPickingWaypointSpot) {

--- a/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
@@ -41,7 +41,6 @@ public class MapScreen extends SolUiBaseScreen {
     private final String REMOVE_WAYPOINT_TEXT = "Marker-";
     private final String CANCEL_TEXT = "Cancel";
     private final int MIN_WAYPOINT_DIST = 5;
-    private final int SCROLL_SPEED = 5;
 
     private boolean isPickingWaypointSpot = false;
     private boolean isPickingWaypointToRemove = false;
@@ -116,7 +115,7 @@ public class MapScreen extends SolUiBaseScreen {
 
         if(im.touchDragged) {
             //Scroll factor negates the drag and adjusts it to map's zoom
-            float scrollFactor = -mapDrawer.getZoom()/ Gdx.graphics.getHeight() * SCROLL_SPEED;
+            float scrollFactor = -mapDrawer.getZoom()/ Gdx.graphics.getHeight() * gameOptions.getMapScrollSpeed();
             float rotateAngle = game.getCam().getAngle();
             mapDrawer.getMapDrawPosAdditive().add(im.getDrag().scl(scrollFactor).rotate(rotateAngle));
         }

--- a/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
@@ -86,7 +86,7 @@ public class MapScreen extends SolUiBaseScreen {
         SolInputManager im = solApplication.getInputManager();
 
         if (justClosed) {
-            mapDrawer.getMapDrawPosAdditive().set(0,0, 0);
+            mapDrawer.getMapDrawPosAdditive().set(0,0);
             isPickingWaypointSpot = false;
             addWaypointControl.setDisplayName(NEW_WAYPOINT_TEXT);
             im.setScreen(solApplication, game.getScreens().mainGameScreen);
@@ -117,13 +117,14 @@ public class MapScreen extends SolUiBaseScreen {
         if(im.touchDragged) {
             //Scroll factor negates the drag and adjusts it to map's zoom
             float scrollFactor = -mapDrawer.getZoom()/ Gdx.graphics.getHeight() * SCROLL_SPEED;
-            mapDrawer.getMapDrawPosAdditive().add(new Vector3(im.getDrag().scl(scrollFactor), 0));
+            mapDrawer.getMapDrawPosAdditive().add(im.getDrag().scl(scrollFactor));
         }
 
         if (isPickingWaypointSpot) {
             if (inputPointers[0].isJustUnPressed() && !addWaypointControl.isJustOff()) {
+                Vector2 mapCamPos = game.getCam().getPosition().add(mapDrawer.getMapDrawPosAdditive());
                 Vector2 clickPosition = new Vector2(inputPointers[0].x, inputPointers[0].y);
-                Vector2 worldPosition = screenPositionToWorld(clickPosition, game.getCam().getPosition(), mapZoom);
+                Vector2 worldPosition = screenPositionToWorld(clickPosition, mapCamPos, mapZoom);
                 ArrayList<Waypoint> waypoints = game.getHero().getWaypoints();
 
                 //make sure waypoints aren't too close to each other

--- a/engine/src/main/java/org/destinationsol/menu/OptionsScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/OptionsScreen.java
@@ -120,7 +120,7 @@ public class OptionsScreen extends SolUiBaseScreen {
         }
 
         mapScrollSpeedControl.setDisplayName("Map Pan Speed: " + options.getMapScrollSpeed());
-        if(mapScrollSpeedControl.isJustOff()) {
+        if (mapScrollSpeedControl.isJustOff()) {
             options.advanceMapScrollSpeed();
         }
     }

--- a/engine/src/main/java/org/destinationsol/menu/OptionsScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/OptionsScreen.java
@@ -39,13 +39,26 @@ public class OptionsScreen extends SolUiBaseScreen {
     private final SolUiControl inputMapControl;
     private final SolUiControl soundVolumeControl;
     private final SolUiControl musicVolumeControl;
+    private final SolUiControl mapScrollSpeedControl;
 
     OptionsScreen(MenuLayout menuLayout, GameOptions gameOptions) {
         displayDimensions = SolApplication.displayDimensions;
 
-        resolutionControl = new SolUiControl(menuLayout.buttonRect(-1, 1), true);
+        musicVolumeControl = new SolUiControl(menuLayout.buttonRect(-1, -2), true);
+        musicVolumeControl.setDisplayName("Music Volume");
+        controls.add(musicVolumeControl);
+
+        soundVolumeControl = new SolUiControl(menuLayout.buttonRect(-1, -1), true);
+        soundVolumeControl.setDisplayName("Sound Volume");
+        controls.add(soundVolumeControl);
+
+        resolutionControl = new SolUiControl(menuLayout.buttonRect(-1, 0), true);
         resolutionControl.setDisplayName("Resolution");
         controls.add(resolutionControl);
+
+        mapScrollSpeedControl = new SolUiControl(menuLayout.buttonRect(-1, 1), true);
+        mapScrollSpeedControl.setDisplayName("Map Pan Speed");
+        controls.add(mapScrollSpeedControl);
 
         inputTypeControl = new SolUiControl(menuLayout.buttonRect(-1, 2), true, Input.Keys.C);
         inputTypeControl.setDisplayName("Control Type");
@@ -58,14 +71,6 @@ public class OptionsScreen extends SolUiBaseScreen {
         backControl = new SolUiControl(menuLayout.buttonRect(-1, 4), true, gameOptions.getKeyEscape());
         backControl.setDisplayName("Back");
         controls.add(backControl);
-
-        soundVolumeControl = new SolUiControl(menuLayout.buttonRect(-1, 0), true);
-        soundVolumeControl.setDisplayName("Sound Volume");
-        controls.add(soundVolumeControl);
-
-        musicVolumeControl = new SolUiControl(menuLayout.buttonRect(-1, -1), true);
-        musicVolumeControl.setDisplayName("Music Volume");
-        controls.add(musicVolumeControl);
 
         backgroundTexture = Assets.getAtlasRegion("engine:mainMenuBg", Texture.TextureFilter.Linear);
     }
@@ -112,6 +117,11 @@ public class OptionsScreen extends SolUiBaseScreen {
         if (musicVolumeControl.isJustOff()) {
             options.advanceMusicVolMul();
             solApplication.getMusicManager().changeVolume(options);
+        }
+
+        mapScrollSpeedControl.setDisplayName("Map Pan Speed: " + options.getMapScrollSpeed());
+        if(mapScrollSpeedControl.isJustOff()) {
+            options.advanceMapScrollSpeed();
         }
     }
 

--- a/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
@@ -54,6 +54,8 @@ public class SolInputManager {
     private final InputPointer flashInputPointer;
     private final Vector2 mousePos;
     private final Vector2 mousePrevPos;
+    private final Vector2 lastTouchDragPos;
+    private final Vector2 drag;
     private final PlayableSound hoverSound;
     private final TextureAtlas.AtlasRegion uiCursor;
     private final Color warnColor;
@@ -66,6 +68,7 @@ public class SolInputManager {
     private float warnPercentage;
     private boolean warnPercGrows;
     private Boolean scrolledUp;
+    public boolean touchDragged;
 
     public SolInputManager(OggSoundManager soundManager, Context context) {
         this.context = context;
@@ -78,6 +81,8 @@ public class SolInputManager {
         flashInputPointer = new InputPointer();
         mousePos = new Vector2();
         mousePrevPos = new Vector2();
+        lastTouchDragPos = new Vector2();
+        drag = new Vector2();
 
         // Create an empty 1x1 pixmap to use as hidden cursor
         Pixmap pixmap = new Pixmap(1, 1, RGBA8888);
@@ -125,6 +130,7 @@ public class SolInputManager {
     }
 
     void maybeFlashPressed(int x, int y) {
+        lastTouchDragPos.set(x, y);
         setPointerPosition(flashInputPointer, x, y);
         for (SolUiScreen screen : screens) {
             List<SolUiControl> controls = screen.getControls();
@@ -137,7 +143,13 @@ public class SolInputManager {
                 return;
             }
         }
+    }
 
+    void maybeTouchDragged(int x, int y) {
+        Vector2 newPos = new Vector2(x, y);
+        drag.set(newPos.sub(lastTouchDragPos));
+        touchDragged = lastTouchDragPos.x != x || lastTouchDragPos.y != y;
+        lastTouchDragPos.set(x, y);
     }
 
     public void setScreen(SolApplication solApplication, SolUiScreen screen) {
@@ -235,6 +247,7 @@ public class SolInputManager {
         addRemoveScreens();
         updateWarnPerc();
         scrolledUp = null;
+        touchDragged = false;
     }
 
     private void updateWarnPerc() {
@@ -376,6 +389,10 @@ public class SolInputManager {
 
     public Boolean getScrolledUp() {
         return scrolledUp;
+    }
+
+    public Vector2 getDrag() {
+        return drag;
     }
 
     public void dispose() {

--- a/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
@@ -54,7 +54,7 @@ public class SolInputManager {
     private final InputPointer flashInputPointer;
     private final Vector2 mousePos;
     private final Vector2 mousePrevPos;
-    private final Vector2 lastTouchDragPos;
+    private final Vector2 lastTouchDragPosition;
     private final Vector2 drag;
     private final PlayableSound hoverSound;
     private final TextureAtlas.AtlasRegion uiCursor;
@@ -81,7 +81,7 @@ public class SolInputManager {
         flashInputPointer = new InputPointer();
         mousePos = new Vector2();
         mousePrevPos = new Vector2();
-        lastTouchDragPos = new Vector2();
+        lastTouchDragPosition = new Vector2();
         drag = new Vector2();
 
         // Create an empty 1x1 pixmap to use as hidden cursor
@@ -130,7 +130,7 @@ public class SolInputManager {
     }
 
     void maybeFlashPressed(int x, int y) {
-        lastTouchDragPos.set(x, y);
+        lastTouchDragPosition.set(x, y);
         setPointerPosition(flashInputPointer, x, y);
         for (SolUiScreen screen : screens) {
             List<SolUiControl> controls = screen.getControls();
@@ -146,10 +146,10 @@ public class SolInputManager {
     }
 
     void maybeTouchDragged(int x, int y) {
-        Vector2 newPos = new Vector2(x, y);
-        drag.set(newPos.sub(lastTouchDragPos));
-        touchDragged = lastTouchDragPos.x != x || lastTouchDragPos.y != y;
-        lastTouchDragPos.set(x, y);
+        Vector2 newPosition = new Vector2(x, y);
+        drag.set(newPosition.sub(lastTouchDragPosition));
+        touchDragged = lastTouchDragPosition.x != x || lastTouchDragPosition.y != y;
+        lastTouchDragPosition.set(x, y);
     }
 
     public void setScreen(SolApplication solApplication, SolUiScreen screen) {

--- a/engine/src/main/java/org/destinationsol/ui/SolInputProcessor.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputProcessor.java
@@ -56,6 +56,7 @@ public class SolInputProcessor implements InputProcessor {
 
     @Override
     public boolean touchDragged(int screenX, int screenY, int pointer) {
+        inputManager.maybeTouchDragged(screenX, screenY);
         return false;
     }
 


### PR DESCRIPTION
# Description
Allows the game map to be pannable using the mouse/touch.

# Testing
### Using Mouse
The map can be panned with the mouse simply by holding left click and dragging the mouse around.
### Android
Map can be panned around by touching the screen and moving your finger around.

# Notes
Map panning should work fine on Android since I've used LibGDX's in-built [touchDragged](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/InputProcessor.html#touchDragged-int-int-int-) function. Although further testing would be appreciated since this is the first ever implementation of such.

# Outstanding work
- [x] Make sure grid map is drawn to fill the new panned screen.
- [x] Add compatibility with the new waypoint system.
- [x] Add a settings option for scroll speed.