### PR TITLE
Download JRE During Build Distribution Task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ engine/src/main/resources/settings.ini
 engine/src/main/resources/mercenaries.json
 engine/src/main/resources/world.ini
 engine/src/main/resources/world.json
+
+# Ignore donwloaded JREs
+jre/**

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Uses Bellsoft Liberica JRE
+def jreVersion = '8u212'
+def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
+def jreUrlFilenames = [
+        lwjreLinux64 : 'linux-amd64.tar.gz',
+        lwjreLinux   : 'linux-i586.tar.gz',
+        lwjre        : 'windows-i586.zip',
+        lwjreOSX     : 'macos-amd64.zip'
+]
+
+task downloadJreAll {
+    group 'Download'
+    description 'Downloads JRE for all platforms'
+}
+
+jreUrlFilenames.each { os, file ->
+    def packedJre = new File("$rootDir/jre/$jreVersion/$file")
+    def unpackedJre = new File("$distsDir/app/$os")
+
+    def downloadTask = task("downloadJre$os") {
+        group 'Download'
+        description "Downloads JRE for $os"
+
+        doFirst {
+            download {
+                src "$jreUrlBase-$file"
+                dest packedJre
+                overwrite false
+            }
+        }
+
+        doLast {
+            // Unpack the JRE
+            if (!unpackedJre.exists()) {
+                unpackedJre.mkdirs()
+                copy {
+                    from(file.endsWith("zip")
+                            ? zipTree(packedJre)
+                            : tarTree(packedJre)) {
+                        eachFile { fcd ->
+                            fcd.relativePath = new RelativePath(
+                                    true, fcd.relativePath.segments.drop(1))
+                        }
+                        includeEmptyDirs = false
+                    }
+                    into unpackedJre
+                }
+            }
+        }
+    }
+
+    downloadJreAll.dependsOn downloadTask
+}
+
+

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,4 +1,25 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'de.undercouch.download' version '4.0.4'
+}
+
 apply from: '../config/gradle/common.gradle'
+apply from: "../config/gradle/jre.gradle"
 
 project.ext.mainClassName = "org.destinationsol.desktop.SolDesktop"
 
@@ -104,10 +125,25 @@ task distUnbundledJRE() {
 distUnbundledJRE.finalizedBy libsDist
 distUnbundledJRE.finalizedBy moduleDist
 
-task distUnbundledJREZip(type: Zip) {
+task distZipUnbundledJRE(type: Zip) {
     description = "Creates an application package and zip archive without any bundled JRE."
 
     dependsOn distUnbundledJRE
+    from "$distsDir/app"
+    archiveName = "DestinationSol.zip"
+}
+
+task distBundleJREs {
+    description = "Creates an application package with a bundled JRE."
+
+    dependsOn distUnbundledJRE
+    dependsOn downloadJreAll
+}
+
+task distZipBundleJREs (type: Zip) {
+    description = "Creates an application package and zip archive with a bundled JRE."
+
+    dependsOn distBundleJREs
     from "$distsDir/app"
     archiveName = "DestinationSol.zip"
 }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -76,6 +76,42 @@ task distZip(type: Zip) {
     archiveName = "DestinationSol.zip"
 }
 
+task copyLaunchers (type: Copy) {
+    description = "Copy launchers into the distribution folder."
+
+    from("$rootDir/launcher")
+    include("*.sh", "*.exe")
+    into("$distsDir/app")
+}
+
+task libsDist(type: Copy) {
+    description = "Copy libs directory into the distribution folder."
+
+    dependsOn jar
+
+    from jar
+    from configurations.runtime
+    into("$distsDir/app/libs")
+}
+
+task distUnbundledJRE() {
+    description = "Creates an application package without any bundled JRE."
+
+    dependsOn clean
+    dependsOn jar
+    dependsOn copyLaunchers
+}
+distUnbundledJRE.finalizedBy libsDist
+distUnbundledJRE.finalizedBy moduleDist
+
+task distUnbundledJREZip(type: Zip) {
+    description = "Creates an application package and zip archive without any bundled JRE."
+
+    dependsOn distUnbundledJRE
+    from "$distsDir/app"
+    archiveName = "DestinationSol.zip"
+}
+
 // TODO: LibGDX Generated config for Eclipse. Needs adjustment for assets not being in the Android facade
 eclipse {
     project {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This adds a new gradle task called `distZipBundleJREs` that is intended to replace the existing `distZip` task. 

The existing `distZip` task builds a distribution of Destination Sol and is used by Jenkins. The problem with this task is that it relies on having the JREs in the repo which we want to remove as part of #413.

The new task `distZipBundleJREs` is functionally similar in that it creates the distribution of Destination Sol. The difference is that the required JREs are downloaded as part of this task so they no longer need to be stored in the repo. 

There are also additional tasks that have been added, which may be useful on their own:
* `distUnbundledJRE` - creates a distribution without any bundled JREs. 
* `distZipUnbundledJRE` same as `distUnbundledJRE` and also creates a zip file.
* `distZipBundleJREs` - same as `distZipBundleJREs` mentioned above, but doesn't create the zip file.

# Testing
From the project root directory run `gradlew distZipBundleJREs` this will create the distribution in the builds/distribution folder. The output of this task should be compared with the output of running the current dist task `gradlew distZip`. The contents of the JRE folders will be different as the bundled JRE uses Liberica 8u212 whereas the JREs in the repo are a very old Oracle version. 

The JRE has changed from an old Oracle version to Liberica 8u212, so ideally the game should be tested to make sure it runs on all supported operating systems. 

# Outstanding Work
There isn't any outstanding work for this PR, but there are some additional tasks that can be done which are dependent on other work
- [ ] Once #413 has removed the JREs from the repo, the gradle scripts can be updated to remove the `dist` and `distZip` tasks.
- [ ] #477 has identified that 32-bit Linux is no longer supported so the downloaded JRE can be removed as part of that task.
- [ ] Once this is merged, Jenkins can be updated to use the `distZipBundleJREs` task.

