### PR TITLE
Jenkins Fix for Bundled JRE Builds

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -117,8 +117,7 @@ task libsDist(type: Copy) {
 
 task distUnbundledJRE() {
     description = "Creates an application package without any bundled JRE."
-
-    dependsOn clean
+    
     dependsOn jar
     dependsOn copyLaunchers
 }


### PR DESCRIPTION
# Description
This was breaking the build when it was combined with other tasks, which is what happens on Jenkins.

# Testing
1. Run this command: `gradlew check jacocoTestReport javadoc distZipBundleJREs`
2. Go into the distribution directory and attempt to run the game that was just built.
Without this fix the game wouldn't run. With this fix it should run.
