### PR TITLE
Remove 32-bit Linux Support.

### DIFF
--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -19,7 +19,6 @@ def jreVersion = '8u212'
 def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
 def jreUrlFilenames = [
         lwjreLinux64 : 'linux-amd64.tar.gz',
-        lwjreLinux   : 'linux-i586.tar.gz',
         lwjre        : 'windows-i586.zip',
         lwjreOSX     : 'macos-amd64.zip'
 ]

--- a/launcher/sol.sh
+++ b/launcher/sol.sh
@@ -1,1 +1,1 @@
-lwjreLinux/bin/java -jar libs/solDesktop.jar
+lwjreLinux64/bin/java -jar libs/solDesktop.jar

--- a/steam/ContentBuilder/scripts/depot_build_342983.vdf
+++ b/steam/ContentBuilder/scripts/depot_build_342983.vdf
@@ -10,21 +10,6 @@
 	// the location of this script file, which probably isn't what you want
 	"ContentRoot"	""
 
-	// include all files recursivley
-  "FileMapping"
-  {
-  	// This can be a full path, or a path relative to ContentRoot
-    "LocalPath" "lwjreLinux\*"
-
-    // This is a path relative to the install folder of your game
-    "DepotPath" "lwjreLinux\"
-
-    // If LocalPath contains wildcards, setting this means that all
-    // matching files within subdirectories of LocalPath will also
-    // be included.
-    "recursive" "1"
-  }
-
   "FileMapping"
   {
   	// This can be a full path, or a path relative to ContentRoot
@@ -54,19 +39,6 @@
     "recursive" "1"
   }
 
-  "FileMapping"
-  {
-  	// This can be a full path, or a path relative to ContentRoot
-    "LocalPath" "sol64.sh"
-
-    // This is a path relative to the install folder of your game
-    "DepotPath" "."
-
-    // If LocalPath contains wildcards, setting this means that all
-    // matching files within subdirectories of LocalPath will also
-    // be included.
-    "recursive" "0"
-  }
 
 	// but exclude all symbol files
 	// This can be a full path, or a path relative to ContentRoot


### PR DESCRIPTION
Changed the Linux start script to use the 64-bit version of Linux.

<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
Removes support for 32-bit Linux as it's no longer supported by LWJGL3 as described in #477.
* Changed the Linux start script to use the 64-bit of the JRE.
* Left the existing 64-bit start script for backwards compatibility.
* Removed the 32-bit JRE from the download script.
* Updated the Steam script to no longer upload the 32-bit JRE. Also doesn't upload the 64-bit start script as that has never been used on Steam.


# Testing
Test the distribution build still works and is able to run on Linux from the `sol.sh` start script.

