### PR TITLE
Enum fix

### DIFF
--- a/engine/src/main/java/org/destinationsol/GameOptions.java
+++ b/engine/src/main/java/org/destinationsol/GameOptions.java
@@ -187,8 +187,8 @@ public class GameOptions {
         y = reader.getInt("y", 768);
         fullscreen = reader.getBoolean("fullscreen", false);
         controlType = mobile ? ControlType.KEYBOARD : Enums.getIfPresent(ControlType.class,  reader.getString("controlType", "MIXED")).or(ControlType.MIXED);
-        sfxVolume = Volume.valueOf(reader.getString("sfxVolume", "MAX"));
-        musicVolume = Volume.valueOf(reader.getString("musicVolume", "MAX"));
+        sfxVolume = Enums.getIfPresent(Volume.class, reader.getString("sfxVolume", "MAX")).or(Volume.MAX);
+        musicVolume = Enums.getIfPresent(Volume.class, reader.getString("musicVolume", "MAX")).or(Volume.MAX);
         keyUpMouseName = reader.getString("keyUpMouse", DEFAULT_MOUSE_UP);
         keyDownMouseName = reader.getString("keyDownMouse", DEFAULT_MOUSE_DOWN);
         keyUpName = reader.getString("keyUp", DEFAULT_UP);

--- a/engine/src/main/java/org/destinationsol/GameOptions.java
+++ b/engine/src/main/java/org/destinationsol/GameOptions.java
@@ -17,6 +17,7 @@ package org.destinationsol;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
+import com.google.common.base.Enums;
 import org.destinationsol.menu.Resolution;
 import org.destinationsol.menu.ResolutionProvider;
 
@@ -185,7 +186,7 @@ public class GameOptions {
         x = reader.getInt("x", 1366);
         y = reader.getInt("y", 768);
         fullscreen = reader.getBoolean("fullscreen", false);
-        controlType = mobile ? ControlType.KEYBOARD : ControlType.valueOf(reader.getString("controlType", "MIXED"));
+        controlType = mobile ? ControlType.KEYBOARD : Enums.getIfPresent(ControlType.class,  reader.getString("controlType", "MIXED")).or(ControlType.MIXED);
         sfxVolume = Volume.valueOf(reader.getString("sfxVolume", "MAX"));
         musicVolume = Volume.valueOf(reader.getString("musicVolume", "MAX"));
         keyUpMouseName = reader.getString("keyUpMouse", DEFAULT_MOUSE_UP);

--- a/engine/src/test/java/org/destinationsol/IniReaderTest.java
+++ b/engine/src/test/java/org/destinationsol/IniReaderTest.java
@@ -15,6 +15,7 @@
  */
 package org.destinationsol;
 
+import com.google.common.base.Enums;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,6 +53,8 @@ public class IniReaderTest {
                         "anotherFloatKey = 7.3f\n" +
                         "invalidFloatKey = 8,6\n" +
                         "anotherInvalidFloatKey = hi\n" +
+                        "enumInvalid = 1\n" +
+                        "enumValid = KEYBOARD\n" +
                         "UnicodeKey çáč🧝 = unicodevalue áśǵj́ḱĺóí⋄«»⋄⋄ǫő";
         iniReader = new IniReader(new BufferedReader(new StringReader(iniFileContents)));
     }
@@ -100,6 +103,20 @@ public class IniReaderTest {
         assertTrue(Float.compare(iniReader.getFloat("anotherFloatKey", 7.8f), 7.3f) == 0);
         assertTrue(Float.compare(iniReader.getFloat("invalidFloatKey", 7.8f), 7.8f) == 0);
         assertTrue(Float.compare(iniReader.getFloat("anotherInvalidFloatKey", 7.8f), 7.8f) == 0);
+    }
+
+    @Test
+    public void testEnums() {
+        // When no value exists in the file, use the defaultValue in getString.
+        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumDefault", "MIXED")).or(GameOptions.ControlType.KEYBOARD), GameOptions.ControlType.MIXED);
+        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumDefault", "MIXED")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.MIXED);
+
+        // When the value in the file isn't a valid enum, use the default value in getIfPresent
+        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumInvalid", "KEYBOARD")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.MIXED);
+        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumInvalid", "MIXED")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.MIXED);
+
+        // When the value is in the file, use that value regardless of the default values.
+        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumValid", "MIXED")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.KEYBOARD);
     }
 
     //TODO ADD MOAR TESTS

--- a/engine/src/test/java/org/destinationsol/IniReaderTest.java
+++ b/engine/src/test/java/org/destinationsol/IniReaderTest.java
@@ -49,11 +49,13 @@ public class IniReaderTest {
                         "intKey = 5\n" +
                         "invalidIntKey = 3.4\n" +
                         "anotherInvalidIntKey = two\n" +
+                        "blankIntKey = \n" +
                         "floatKey = 6\n" +
                         "anotherFloatKey = 7.3f\n" +
                         "invalidFloatKey = 8,6\n" +
                         "anotherInvalidFloatKey = hi\n" +
                         "enumInvalid = 1\n" +
+                        "enumEmpty =\n" +
                         "enumValid = KEYBOARD\n" +
                         "UnicodeKey çáč🧝 = unicodevalue áśǵj́ḱĺóí⋄«»⋄⋄ǫő";
         iniReader = new IniReader(new BufferedReader(new StringReader(iniFileContents)));
@@ -82,6 +84,7 @@ public class IniReaderTest {
         assertEquals(iniReader.getInt("intKey", 0), 5);
         assertEquals(iniReader.getInt("invalidIntKey", 56), 56);
         assertEquals(iniReader.getInt("anotherInvalidIntKey", 57), 57);
+        assertEquals(iniReader.getInt("blankIntKey", 58), 58);
     }
 
     @Test
@@ -108,16 +111,16 @@ public class IniReaderTest {
     @Test
     public void testEnums() {
         // When no value exists in the file, use the defaultValue in getString.
-        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumDefault", "MIXED")).or(GameOptions.ControlType.KEYBOARD), GameOptions.ControlType.MIXED);
-        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumDefault", "MIXED")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.MIXED);
+        assertEquals(GameOptions.ControlType.MIXED, Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumDefault", "MIXED")).or(GameOptions.ControlType.KEYBOARD));
+        assertEquals(GameOptions.ControlType.MIXED, Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumDefault", "MIXED")).or(GameOptions.ControlType.MIXED));
+        assertEquals(GameOptions.ControlType.KEYBOARD, Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumEmpty", "KEYBOARD")).or(GameOptions.ControlType.MIXED));
 
         // When the value in the file isn't a valid enum, use the default value in getIfPresent
-        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumInvalid", "KEYBOARD")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.MIXED);
-        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumInvalid", "MIXED")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.MIXED);
+        assertEquals(GameOptions.ControlType.MIXED, Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumInvalid", "KEYBOARD")).or(GameOptions.ControlType.MIXED));
+        assertEquals(GameOptions.ControlType.MIXED, Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumInvalid", "MIXED")).or(GameOptions.ControlType.MIXED));
 
         // When the value is in the file, use that value regardless of the default values.
-        assertEquals(Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumValid", "MIXED")).or(GameOptions.ControlType.MIXED), GameOptions.ControlType.KEYBOARD);
+        assertEquals(GameOptions.ControlType.KEYBOARD, Enums.getIfPresent(GameOptions.ControlType.class,  iniReader.getString("enumValid", "MIXED")).or(GameOptions.ControlType.MIXED));
     }
 
-    //TODO ADD MOAR TESTS
 }

--- a/engine/src/test/java/org/destinationsol/IniReaderTest.java
+++ b/engine/src/test/java/org/destinationsol/IniReaderTest.java
@@ -63,28 +63,28 @@ public class IniReaderTest {
 
     @Test
     public void testInputHandling() {
-        assertEquals(iniReader.getString("missingKey", "correctValue"), "correctValue");
-        assertEquals(iniReader.getString("terrible key name", "wrongValue"), "terrible key value");
-        assertEquals(iniReader.getString("partLineCommentKey", "wrongValue"), "correctValue1");
-        assertEquals(iniReader.getString("doubleRequestedKey", "wrongValue"), "validValue2");
-        assertEquals(iniReader.getString("doubleRequestedKey", "wrongValue"), "validValue2");
-        assertEquals(iniReader.getString("this shouldn't throw exception", "correctValue"), "correctValue");
-        assertEquals(iniReader.getString("UnicodeKey çáč🧝", "wrongValue"), "unicodevalue áśǵj́ḱĺóí⋄«»⋄⋄ǫő");
+        assertEquals("correctValue", iniReader.getString("missingKey", "correctValue"));
+        assertEquals("terrible key value", iniReader.getString("terrible key name", "wrongValue"));
+        assertEquals("correctValue1", iniReader.getString("partLineCommentKey", "wrongValue"));
+        assertEquals("validValue2", iniReader.getString("doubleRequestedKey", "wrongValue"));
+        assertEquals("validValue2", iniReader.getString("doubleRequestedKey", "wrongValue"));
+        assertEquals("correctValue", iniReader.getString("this shouldn't throw exception", "correctValue"));
+        assertEquals("unicodevalue áśǵj́ḱĺóí⋄«»⋄⋄ǫő", iniReader.getString("UnicodeKey çáč🧝", "wrongValue"));
     }
 
     @Test
     public void testGetString() {
-        assertEquals(iniReader.getString("asdfghjk", "correctValue"), "correctValue");
-        assertEquals(iniReader.getString("validStringKey", "wrongValue"), "validString");
+        assertEquals("correctValue", iniReader.getString("asdfghjk", "correctValue"));
+        assertEquals("validString", iniReader.getString("validStringKey", "wrongValue"));
     }
 
     @Test
     public void testGetInt() {
-        assertEquals(iniReader.getInt("asdfghjk", 55), 55);
-        assertEquals(iniReader.getInt("intKey", 0), 5);
-        assertEquals(iniReader.getInt("invalidIntKey", 56), 56);
-        assertEquals(iniReader.getInt("anotherInvalidIntKey", 57), 57);
-        assertEquals(iniReader.getInt("blankIntKey", 58), 58);
+        assertEquals(55, iniReader.getInt("asdfghjk", 55));
+        assertEquals(5, iniReader.getInt("intKey", 0));
+        assertEquals(56, iniReader.getInt("invalidIntKey", 56));
+        assertEquals(57, iniReader.getInt("anotherInvalidIntKey", 57));
+        assertEquals(58, iniReader.getInt("blankIntKey", 58));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
Fix for #474. Loading enums from the ini file no longer causes a crash.

# Testing
In the settings.ini file, change the value of `controlType` to 1, or any other invalid value, and run the game. The game will no longer crash and will set `controlType` to the default value.
The same change has been made to the other enums in the ini file; `sfxVolume` and` musicVolume`

### Pre Pull Request Checklist:
<!-- When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones. 
If the code looks good to you and you have already at least some experience writing java, you can even completely skip 
this step -->
- [x] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [x] There are no errors present in the project
- [x] Code has been formatted and indented
- [x] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
