### PR TITLE
Removed old dist and distZip tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Run any commands in the project root directory (where you cloned / extracted the
 * Download / clone the [source from GitHub](https://github.com/MovingBlocks/DestinationSol)
 * To run from the command line: `gradlew run` (on Linux you might need to use `./gradlew run`)
 * To prepare for IntelliJ run: `gradlew idea` then load the generated project via `DestinationSol.ipr`
-* To create a game package for distribution (Windows, Linux, Mac): `gradlew distZip`
+* Distributions (Windows, Linux, Mac) should be obtained from the [Jenkins build server](http://jenkins.terasology.org/view/DestSol/job/DestinationSol/), but you can also create a distribution locally by running: `gradlew distZipBundleJREs`
 
 For Android a little extra setup is needed
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -50,7 +50,7 @@ task run(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = rootProject.projectDir
-    ignoreExitValue = true
+    ignoreExitValue true
 }
 
 jar {
@@ -75,28 +75,6 @@ task moduleDist(type: Sync) {
     }
 }
 
-task dist(type: Sync) {
-    description = "Creates an application package for distribution"
-    dependsOn jar
-
-    into("$distsDir/app")
-
-    from("$rootDir/launcher")
-
-    into('libs') {
-        from configurations.runtime
-        from jar
-    }
-}
-
-dist.finalizedBy moduleDist
-
-task distZip(type: Zip) {
-    dependsOn dist
-    from "$distsDir/app"
-    archiveName = "DestinationSol.zip"
-}
-
 task copyLaunchers (type: Copy) {
     description = "Copy launchers into the distribution folder."
 
@@ -117,7 +95,8 @@ task libsDist(type: Copy) {
 
 task distUnbundledJRE() {
     description = "Creates an application package without any bundled JRE."
-    
+    group 'Distribution'
+
     dependsOn jar
     dependsOn copyLaunchers
 }
@@ -126,6 +105,7 @@ distUnbundledJRE.finalizedBy moduleDist
 
 task distZipUnbundledJRE(type: Zip) {
     description = "Creates an application package and zip archive without any bundled JRE."
+    group 'Distribution'
 
     dependsOn distUnbundledJRE
     from "$distsDir/app"
@@ -134,6 +114,7 @@ task distZipUnbundledJRE(type: Zip) {
 
 task distBundleJREs {
     description = "Creates an application package with a bundled JRE."
+    group 'Distribution'
 
     dependsOn distUnbundledJRE
     dependsOn downloadJreAll
@@ -141,6 +122,7 @@ task distBundleJREs {
 
 task distZipBundleJREs (type: Zip) {
     description = "Creates an application package and zip archive with a bundled JRE."
+    group 'Distribution'
 
     dependsOn distBundleJREs
     from "$distsDir/app"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
Removed the old `dist` and `distZip` gradle tasks that are no longer required now that the JRE is no longer in the repo. These have been replaced by the new gradle tasks in #479.

Also added the gradle tasks to a distribution group, so that if you type `gradle tasks` they are now listed as tasks.

Changed ignoreExitValue as that was used incorrectly and was generating a warning. 

# Testing
Make sure `distZipUnbundledJRE` continues to work.
