### PR TITLE
Change desktop logger to Logback

### DIFF
--- a/config/gradle/ide.gradle
+++ b/config/gradle/ide.gradle
@@ -106,7 +106,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.destinationsol.desktop.SolDesktop"/>
-              <option name="VM_PARAMETERS" value="-splash:engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png %s -Xms256m -Xmx1024m -Dlog4j.configuration=log4j-debug.properties"/>
+              <option name="VM_PARAMETERS" value="-splash:engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png %s -Xms256m -Xmx1024m/>
               <option name="PROGRAM_PARAMETERS" value="-noCrashReport %s"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -31,19 +31,27 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx-controllers-lwjgl3:$gdxVersion"
 
     compile group: 'org.terasology.crashreporter', name: 'cr-destsol', version: '4.0.0'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.25'
+
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    runtime group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
+    runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+
+    /* Add this to the android distribution!
+    runtime group: 'com.github.tony19', name: 'logback-android', version: '2.0.0'
+    runtime group: 'com.github.tony19', name: 'logback-android-classic', version: '1.1.1-6'
+    */
 }
 
 task run(type: JavaExec) {
     dependsOn classes
     //TODO: Remove extra args when the splash screen works on Macs again - see https://github.com/MovingBlocks/DestinationSol/issues/414
     if (System.properties["os.name"].toLowerCase().contains("mac")) {
-        jvmArgs = ["-splash:../engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png", "-XstartOnFirstThread", "-Dlog4j.configuration=log4j-debug.properties"]
+        jvmArgs = ["-splash:../engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png", "-XstartOnFirstThread"]
         String[] runArgs = ["-noSplash"]
         args runArgs
     }
     else {
-        jvmArgs = ["-splash:../engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png", "-Dlog4j.configuration=log4j-debug.properties"]
+        jvmArgs = ["-splash:../engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png"]
     }
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
@@ -148,7 +156,7 @@ eclipse {
                         <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
                         <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.destinationsol.desktop.SolDesktop"/>
                         <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="DestinationSol-desktop"/>
-                        <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-splash:../engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png -Dlog4j.configuration=log4j-debug.properties"/>
+                        <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-splash:../engine/src/main/resources/assets/textures/mainMenu/mainMenuLogo.png"/>
                         <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:DestinationSol-engine}"/>
                     </launchConfiguration>
                 ''')
@@ -174,6 +182,6 @@ task afterEclipseImport(description: "Post processing after project generation",
 
 tasks.withType(JavaExec) {
     if (System.getProperty('DEBUG', 'false') == 'true') {
-        jvmArgs '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9099', '-Dlog4j.configuration=log4j-debug.properties'
+        jvmArgs '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9099'
     }
 }

--- a/desktop/src/main/resources/assets/logback.xml
+++ b/desktop/src/main/resources/assets/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <tagEncoder>
+            <pattern>%logger{12}</pattern>
+        </tagEncoder>
+        <encoder>
+            <pattern>%-5level [%thread] (%F:%L) %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
     testCompile group: 'org.jboss.shrinkwrap', name: 'shrinkwrap-depchain-java7', version: '1.1.3'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.0'
+
+    // Logging
+    testRuntime group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
+    testRuntime group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }
 
 task cacheReflections {

--- a/engine/src/main/resources/log4j-debug.properties
+++ b/engine/src/main/resources/log4j-debug.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=DEBUG, STDOUT
-log4j.logger.deng=DEBUG
-log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
-log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
-log4j.appender.STDOUT.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n

--- a/engine/src/main/resources/log4j.properties
+++ b/engine/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger=DEBUG, STDOUT
-log4j.logger.deng=DEBUG
-log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
-log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
-log4j.appender.STDOUT.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
-log4j.appender.STDOUT.threshold=INFO

--- a/engine/src/test/resources/assets/logback.xml
+++ b/engine/src/test/resources/assets/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.classic.android.LogcatAppender">
+        <tagEncoder>
+            <pattern>%logger{12}</pattern>
+        </tagEncoder>
+        <encoder>
+            <pattern>%-5level [%thread] (%F:%L) %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
# Description
Work in progress, do not merge!
This is a prototype for #416. I got the Engine tests and desktop to work with SLF4J and Logback, but I do not know how to download the android part.

# Testing
1. Run JUnit tests from the Engine directory. They do not log anything, but you should not receive an exception from SLF4J about missing logger
2. Start the game with the "run" task, and see if messages are printed to console

# Outstanding Work
- [ ] Download android, copy logback.xml to src/main/resource/assets/logback.xml
- [ ] Change build.gradle to use 
```
runtime group: 'com.github.tony19', name: 'logback-android', version: '2.0.0'
runtime group: 'com.github.tony19', name: 'logback-android-classic', version: '1.1.1-6'
```
Instead of ch.qos.logback
- [] Test if logging works when the game is started (it might output an error, or just simply doesn't paste any text. See http://logback.qos.ch/manual/configuration.html#automaticStatusPrinting for help with debugging the logging configuration