### PR TITLE
Automatically launch game in a preview in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,8 @@ image: gitpod/workspace-full-vnc
 
 ports:
   - port: 6080
+    onOpen: open-preview
 
 tasks:
   - init: ./gradlew
+    command: ./gradlew run


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

Hi there! 👋 I tried DestinationSol in Gitpod, got super excited, and wanted to suggest two small improvements to the Gitpod config.

# Description
> Please describe what this PR does and why it does it

- Automatically run `./gradlew run` when starting a Gitpod workspace
- Automatically open port `6080` in a preview side panel when it becomes active

This is what it looks like on start-up:

<img width="1552" alt="Screenshot 2020-04-06 at 19 42 57" src="https://user-images.githubusercontent.com/599268/78588747-70440480-783f-11ea-927e-84fdc3430347.png">

# Testing
> If the PR is testable, please describe how to test it here

You can test this PR by simply opening it in Gitpod:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MovingBlocks/DestinationSol/pull/507)

# Notes
> Include any extra notes here

### Pre Pull Request Checklist:
<!-- When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones. 
If the code looks good to you and you have already at least some experience writing java, you can even completely skip 
this step -->
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [x] There are no errors present in the project
- [x] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
