### PR TITLE
Loot dropping upon death

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -32,12 +32,15 @@ import org.destinationsol.entitysystem.EntitySystemManager;
 import org.destinationsol.entitysystem.SerialisationManager;
 import org.destinationsol.game.DebugOptions;
 import org.destinationsol.game.FactionInfo;
+import org.destinationsol.game.ObjectManager;
 import org.destinationsol.game.SaveManager;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.WorldConfig;
 import org.destinationsol.game.console.adapter.ParameterAdapterManager;
 import org.destinationsol.game.context.Context;
 import org.destinationsol.game.context.internal.ContextImpl;
+import org.destinationsol.game.item.ItemManager;
+import org.destinationsol.game.item.LootBuilder;
 import org.destinationsol.menu.MenuScreens;
 import org.destinationsol.menu.background.MenuBackgroundManager;
 import org.destinationsol.modules.ModuleManager;
@@ -272,8 +275,11 @@ public class SolApplication implements ApplicationListener {
         context.get(ComponentSystemManager.class).preBegin();
         FactionInfo factionInfo = new FactionInfo();
         solGame = new SolGame(shipName, tut, isNewGame, commonDrawer, context, worldConfig);
-
         context.put(SolGame.class, solGame);
+
+        context.put(LootBuilder.class, solGame.getLootBuilder());
+        context.put(ItemManager.class, solGame.getItemMan());
+        context.put(ObjectManager.class, solGame.getObjectManager());
 
         entitySystemManager = new EntitySystemManager(moduleManager.getEnvironment(), componentManager, context);
 

--- a/engine/src/main/java/org/destinationsol/loot/components/DropsLootOnDeath.java
+++ b/engine/src/main/java/org/destinationsol/loot/components/DropsLootOnDeath.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.loot.components;
+
+import org.destinationsol.game.item.Loot;
+import org.terasology.gestalt.entitysystem.component.Component;
+
+/**
+ * Indicates that when the entity is destroyed, one or more {@link Loot} objects should be created.
+ */
+public class DropsLootOnDeath implements Component<DropsLootOnDeath> {
+    @Override
+    public void copy(DropsLootOnDeath other) {
+
+    }
+}

--- a/engine/src/main/java/org/destinationsol/loot/systems/LootDroppingSystem.java
+++ b/engine/src/main/java/org/destinationsol/loot/systems/LootDroppingSystem.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.loot.systems;
+
+import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.common.In;
+import org.destinationsol.common.SolMath;
+import org.destinationsol.common.SolRandom;
+import org.destinationsol.entitysystem.EventReceiver;
+import org.destinationsol.game.SolGame;
+import org.destinationsol.game.item.Loot;
+import org.destinationsol.game.item.MoneyItem;
+import org.destinationsol.location.components.Position;
+import org.destinationsol.location.components.Velocity;
+import org.destinationsol.loot.components.DropsLootOnDeath;
+import org.destinationsol.removal.DefaultDestructionSystem;
+import org.destinationsol.removal.DestroyEvent;
+import org.destinationsol.size.components.Size;
+import org.terasology.gestalt.entitysystem.entity.EntityRef;
+import org.terasology.gestalt.entitysystem.event.Before;
+import org.terasology.gestalt.entitysystem.event.EventResult;
+import org.terasology.gestalt.entitysystem.event.ReceiveEvent;
+
+import java.util.List;
+
+/**
+ * When an entity with a {@link DropsLootOnDeath} component is destroyed, this system creates an amount of loot based
+ * on its {@link Size}.
+ */
+public class LootDroppingSystem implements EventReceiver {
+
+    @In
+    private SolGame game;
+
+    @ReceiveEvent(components = {DropsLootOnDeath.class, Position.class, Velocity.class, Size.class})
+    @Before(DefaultDestructionSystem.class)
+    public EventResult onDestroy(DestroyEvent event, EntityRef entity) {
+
+        Vector2 basePosition = entity.getComponent(Position.class).get().position;
+        Vector2 baseVelocity = entity.getComponent(Velocity.class).get().velocity;
+        float size = entity.getComponent(Size.class).get().size;
+
+        float thrMoney = size * 40f * SolRandom.randomFloat(.3f, 1);
+        List<MoneyItem> moneyItems = game.getItemMan().moneyToItems(thrMoney);
+        for (MoneyItem item : moneyItems) {
+            float velocityAngle = SolRandom.randomFloat(180);
+            Vector2 lootVelocity = new Vector2();
+            SolMath.fromAl(lootVelocity, velocityAngle, SolRandom.randomFloat(0, Loot.MAX_SPD));
+            lootVelocity.add(baseVelocity);
+            Vector2 lootPosition = new Vector2();
+            SolMath.fromAl(lootPosition, velocityAngle, SolRandom.randomFloat(0, size / 2));
+            lootPosition.add(basePosition);
+            Loot l = game.getLootBuilder().build(game, lootPosition, item, lootVelocity, Loot.MAX_LIFE, SolRandom.randomFloat(Loot.MAX_ROT_SPD), null);
+            game.getObjectManager().addObjDelayed(l);
+        }
+
+        return EventResult.CONTINUE;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/loot/systems/LootDroppingSystem.java
+++ b/engine/src/main/java/org/destinationsol/loot/systems/LootDroppingSystem.java
@@ -20,8 +20,11 @@ import org.destinationsol.common.In;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.common.SolRandom;
 import org.destinationsol.entitysystem.EventReceiver;
+import org.destinationsol.game.ObjectManager;
 import org.destinationsol.game.SolGame;
+import org.destinationsol.game.item.ItemManager;
 import org.destinationsol.game.item.Loot;
+import org.destinationsol.game.item.LootBuilder;
 import org.destinationsol.game.item.MoneyItem;
 import org.destinationsol.location.components.Position;
 import org.destinationsol.location.components.Velocity;
@@ -45,6 +48,15 @@ public class LootDroppingSystem implements EventReceiver {
     @In
     private SolGame game;
 
+    @In
+    private LootBuilder lootBuilder;
+
+    @In
+    private ItemManager itemManager;
+
+    @In
+    private ObjectManager objectManager;
+
     @ReceiveEvent(components = {DropsLootOnDeath.class, Position.class, Velocity.class, Size.class})
     @Before(DefaultDestructionSystem.class)
     public EventResult onDestroy(DestroyEvent event, EntityRef entity) {
@@ -54,7 +66,7 @@ public class LootDroppingSystem implements EventReceiver {
         float size = entity.getComponent(Size.class).get().size;
 
         float thrMoney = size * 40f * SolRandom.randomFloat(.3f, 1);
-        List<MoneyItem> moneyItems = game.getItemMan().moneyToItems(thrMoney);
+        List<MoneyItem> moneyItems = itemManager.moneyToItems(thrMoney);
         for (MoneyItem item : moneyItems) {
             float velocityAngle = SolRandom.randomFloat(180);
             Vector2 lootVelocity = new Vector2();
@@ -63,8 +75,8 @@ public class LootDroppingSystem implements EventReceiver {
             Vector2 lootPosition = new Vector2();
             SolMath.fromAl(lootPosition, velocityAngle, SolRandom.randomFloat(0, size / 2));
             lootPosition.add(basePosition);
-            Loot l = game.getLootBuilder().build(game, lootPosition, item, lootVelocity, Loot.MAX_LIFE, SolRandom.randomFloat(Loot.MAX_ROT_SPD), null);
-            game.getObjectManager().addObjDelayed(l);
+            Loot l = lootBuilder.build(game, lootPosition, item, lootVelocity, Loot.MAX_LIFE, SolRandom.randomFloat(Loot.MAX_ROT_SPD), null);
+            objectManager.addObjDelayed(l);
         }
 
         return EventResult.CONTINUE;

--- a/engine/src/main/java/org/destinationsol/size/components/Size.java
+++ b/engine/src/main/java/org/destinationsol/size/components/Size.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.size.components;
+
+import org.terasology.gestalt.entitysystem.component.Component;
+
+/**
+ * The area that an entity takes up.
+ */
+public class Size implements Component<Size> {
+
+    public float size;
+
+    @Override
+    public void copy(Size other) {
+        this.size = other.size;
+    }
+}


### PR DESCRIPTION
# Description
This PR adds a system for creating `Loot` objects when an entity with a `DropsLoot` component dies. `Loot` is the DS object that is created when certain `SolObject`s (e.g. ships) are destroyed. The logic was pulled from `Asteroid`, although `SolShip` uses a similar structure.

This is built upon PRs #519 and #522. It makes use of the `DestroyEvent` from 519, as well as `Position` and `Velocity` from 522.

# Testing
First, copy/paste the following three fields to SolApplication:
```
private boolean madeLootEntity = false;
    private int counter = 0;
    EntityRef entity;
```
Next, add the following code after line 231 (inside the `if` statement that confims that `solGame` isn't null):
```
            if (!madeLootEntity) {

            entity = entitySystemManager.getEntityManager().createEntity(new DropsLootOnDeath(), new Position(), new Velocity(), new Size());

            Position position = entity.getComponent(Position.class).get();
            position.position = solgame.getHero().getPosition().cpy();
            position.position.x += 1;
            position.position.y += 3;
            entity.setComponent(position);

            Size size = new Size();
            size.size = 20;
            entity.setComponent(size);

            madeLootEntity = true;
        }
        counter++;
        if (counter == 500) {
            entitySystemManager.sendEvent(new DestroyEvent(), entity);
        }
```

That code does a few things:
* Creates an entity with the requisite components to drop loot upon dying
* Moves the entity one unit down and three to the right, so that the loot won't be absorbed by the station
* After several seconds, the `EntitySystemManager` will send a `DestroyEvent` to the entity, causing loot to appear on screen