### PR TITLE
Fixed race condition in Assets

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -264,7 +264,7 @@ public abstract class Assets {
         textureList = null;
     }
 
-    public static List<TextureAtlas.AtlasRegion> listTexturesMatching(String regex) {
+    public static synchronized List<TextureAtlas.AtlasRegion> listTexturesMatching(String regex) {
         boolean listsCached = true;
         if (textureList == null) {
             listsCached = false;


### PR DESCRIPTION
This fixes #538 by making the method synchronized (it was already structured in a way that only works for a single thread, so this just enforces that requirement)