### PR TITLE
Gestalt update

### DIFF
--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -43,6 +43,8 @@ repositories {
     maven { url "https://jitpack.io" }
 
     maven { url "https://maven.google.com" }
+
+    maven { url = 'https://heisluft.tk/maven/' }
 }
 
 test {

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -27,10 +27,10 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
     compile "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
 
-    compile(group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.0.5')
-    compile(group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.0.5')
-    compile(group: 'org.terasology.gestalt', name: 'gestalt-module', version: '7.0.5')
-    compile(group: 'org.terasology.gestalt', name: 'gestalt-util', version: '7.0.5')
+    compile(group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.0.6-SNAPSHOT')
+    compile(group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.0.6-SNAPSHOT')
+    compile(group: 'org.terasology.gestalt', name: 'gestalt-module', version: '7.0.6-SNAPSHOT')
+    compile(group: 'org.terasology.gestalt', name: 'gestalt-util', version: '7.0.6-SNAPSHOT')
 
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.4.0'
 

--- a/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
+++ b/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
@@ -16,14 +16,10 @@
 package org.destinationsol.body.components;
 
 import com.badlogic.gdx.physics.box2d.Body;
-import org.terasology.gestalt.entitysystem.component.Component;
+import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
  * Indicates that there is a {@link Body} associated with the entity.
  */
-public class BodyLinked implements Component<BodyLinked> {
-    @Override
-    public void copy(BodyLinked other) {
-
-    }
+public class BodyLinked extends EmptyComponent {
 }

--- a/engine/src/main/java/org/destinationsol/entitysystem/EntitySystemManager.java
+++ b/engine/src/main/java/org/destinationsol/entitysystem/EntitySystemManager.java
@@ -34,6 +34,7 @@ import org.terasology.gestalt.entitysystem.event.impl.EventSystemImpl;
 import org.terasology.gestalt.entitysystem.prefab.GeneratedFromRecipeComponent;
 import org.terasology.gestalt.module.ModuleEnvironment;
 
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 public class EntitySystemManager {
@@ -48,8 +49,10 @@ public class EntitySystemManager {
 
         List<ComponentStore<?>> stores = Lists.newArrayList();
         for (Class<? extends Component> componentType : environment.getSubtypesOf(Component.class)) {
-            stores.add(
-                    new ConcurrentComponentStore<>(new ArrayComponentStore<>(componentManager.getType(componentType))));
+            if (!Modifier.isAbstract(componentType.getModifiers())) {
+                stores.add(
+                        new ConcurrentComponentStore<>(new ArrayComponentStore<>(componentManager.getType(componentType))));
+            }
         }
         stores.add(new ConcurrentComponentStore<>(
                 new ArrayComponentStore<>(componentManager.getType(GeneratedFromRecipeComponent.class))));

--- a/engine/src/main/java/org/destinationsol/force/components/ImmuneToForce.java
+++ b/engine/src/main/java/org/destinationsol/force/components/ImmuneToForce.java
@@ -16,14 +16,10 @@
 package org.destinationsol.force.components;
 
 import org.destinationsol.game.ship.KnockBack;
-import org.terasology.gestalt.entitysystem.component.Component;
+import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
  * Denotes that an entity should not be affected by forces such as gravity or the {@link KnockBack} ship ability.
  */
-public class ImmuneToForce implements Component<ImmuneToForce> {
-    @Override
-    public void copy(ImmuneToForce other) {
-
-    }
+public class ImmuneToForce extends EmptyComponent<ImmuneToForce> {
 }

--- a/engine/src/main/java/org/destinationsol/moneyDropping/components/DropsMoneyOnDeath.java
+++ b/engine/src/main/java/org/destinationsol/moneyDropping/components/DropsMoneyOnDeath.java
@@ -16,14 +16,10 @@
 package org.destinationsol.moneyDropping.components;
 
 import org.destinationsol.game.item.Loot;
-import org.terasology.gestalt.entitysystem.component.Component;
+import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
  * Indicates that when the entity is destroyed, one or more {@link Loot} objects should be created.
  */
-public class DropsMoneyOnDeath implements Component<DropsMoneyOnDeath> {
-    @Override
-    public void copy(DropsMoneyOnDeath other) {
-
-    }
+public class DropsMoneyOnDeath extends EmptyComponent {
 }

--- a/engine/src/main/java/org/destinationsol/rendering/components/Invisible.java
+++ b/engine/src/main/java/org/destinationsol/rendering/components/Invisible.java
@@ -16,14 +16,10 @@
 package org.destinationsol.rendering.components;
 
 import org.destinationsol.rendering.systems.RenderingSystem;
-import org.terasology.gestalt.entitysystem.component.Component;
+import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
  * Denotes that the object should not be drawn by the {@link RenderingSystem}.
  */
-public class Invisible implements Component<Invisible> {
-    @Override
-    public void copy(Invisible other) {
-
-    }
+public class Invisible extends EmptyComponent {
 }

--- a/engine/src/main/java/org/destinationsol/stasis/components/Stasis.java
+++ b/engine/src/main/java/org/destinationsol/stasis/components/Stasis.java
@@ -15,7 +15,7 @@
  */
 package org.destinationsol.stasis.components;
 
-import org.terasology.gestalt.entitysystem.component.Component;
+import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
  * Stasis components are a way to flag a component to indicate that it should be handled in a more resource-efficient
@@ -26,9 +26,5 @@ import org.terasology.gestalt.entitysystem.component.Component;
  * For systems that shouldn't operate on an entity in stasis, there should be a method annotated with "@Before" that
  * consumes that event if the entity has a stasis component.
  */
-public class Stasis implements Component<Stasis> {
-
-    @Override
-    public void copy(Stasis other) {
-    }
+public class Stasis extends EmptyComponent<Stasis> {
 }

--- a/engine/src/test/java/org/destinationsol/gestalt/BulkEntityCreationStressTest.java
+++ b/engine/src/test/java/org/destinationsol/gestalt/BulkEntityCreationStressTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.gestalt;
+
+import org.destinationsol.entitysystem.EntitySystemManager;
+import org.destinationsol.game.context.internal.ContextImpl;
+import org.destinationsol.modules.ModuleManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.terasology.gestalt.entitysystem.component.management.ComponentManager;
+import org.terasology.gestalt.entitysystem.entity.EntityManager;
+
+/**
+ * Test to ensure that 100,000 entities can be created by the {@link EntityManager} without any issues.
+ */
+public class BulkEntityCreationStressTest {
+
+    private EntitySystemManager entitySystemManager;
+
+    @Before
+    public void setUp() throws Exception {
+        ModuleManager moduleManager = new ModuleManager();
+        moduleManager.init();
+        entitySystemManager = new EntitySystemManager(moduleManager.getEnvironment(), new ComponentManager(), new ContextImpl());
+    }
+
+    @Test
+    public void testBulkEntityCreation() {
+        for (int i = 0; i < 100000; i++) {
+            entitySystemManager.getEntityManager().createEntity();
+        }
+    }
+}


### PR DESCRIPTION
# Description
This PR updates the gestalt version from `7.0.5` to `7.0.6-SNAPSHOT`. The new version fixes a bug that prevented the creation of more than 1024 entities, and it also adds an `EmptyComponent` class for components that don't contain data. This PR also refactors the existing data-less components to use `EmptyComponent`.

# Testing
* Run `gradlew clean cleanIdea idea jar` in the terminal
* Start the game. It should run normally.