### PR TITLE
Projectiles affect entities

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -321,7 +321,7 @@ public class SolApplication implements ApplicationListener {
 
         solGame.createUpdateSystems(context);
 
-        solGame.startGame(shipName, isNewGame, worldConfig, new SolNames());
+        solGame.startGame(shipName, isNewGame, worldConfig, new SolNames(), entitySystemManager);
 
         // Big, fat, ugly HACK to get a working classloader
         // Serialisation and thus a classloader is not needed when there are no components

--- a/engine/src/main/java/org/destinationsol/game/SolContactListener.java
+++ b/engine/src/main/java/org/destinationsol/game/SolContactListener.java
@@ -63,15 +63,15 @@ public class SolContactListener implements ContactListener {
 
         //TODO This is legacy code for handling contact with a Projectile, which currently is designed to work with SolObjects.
         // Once Projectile has been converted to be an entity, this should be refactored.
-        SolObject oA = (SolObject) dataA;
-        SolObject oB = (SolObject) dataB;
-        boolean aIsProj = oA instanceof Projectile;
-        if (!aIsProj && !(oB instanceof Projectile)) {
+        SolObject firstSolObject = (SolObject) dataA;
+        SolObject secondSolObject = (SolObject) dataB;
+        boolean firstSolObjectIsProjectile = firstSolObject instanceof Projectile;
+        if (!firstSolObjectIsProjectile && !(secondSolObject instanceof Projectile)) {
             return;
         }
-        Projectile proj = (Projectile) (aIsProj ? oA : oB);
-        SolObject o = aIsProj ? oB : oA;
-        proj.setObstacle(o, myGame);
+        Projectile projectile = (Projectile) (firstSolObjectIsProjectile ? firstSolObject : secondSolObject);
+        SolObject solObject = firstSolObjectIsProjectile ? secondSolObject : firstSolObject;
+        projectile.setObstacle(solObject, myGame);
     }
 
     @Override
@@ -109,18 +109,18 @@ public class SolContactListener implements ContactListener {
 
         //TODO This is legacy code for handling contact between SolObjects.
         // Once every SolObject has been converted to an entity, this can be removed.
-        SolObject soa = (SolObject) dataA;
-        SolObject sob = (SolObject) dataB;
-        if (soa instanceof Projectile && ((Projectile) soa).getConfig().density <= 0) {
+        SolObject firstSolObject = (SolObject) dataA;
+        SolObject secondSolObject = (SolObject) dataB;
+        if (firstSolObject instanceof Projectile && ((Projectile) firstSolObject).getConfig().density <= 0) {
             return;
         }
-        if (sob instanceof Projectile && ((Projectile) sob).getConfig().density <= 0) {
+        if (secondSolObject instanceof Projectile && ((Projectile) secondSolObject).getConfig().density <= 0) {
             return;
         }
-        soa.handleContact(sob, absImpulse, myGame, collPos);
-        sob.handleContact(soa, absImpulse, myGame, collPos);
-        myGame.getSpecialSounds().playColl(myGame, absImpulse, soa, collPos);
-        myGame.getSpecialSounds().playColl(myGame, absImpulse, sob, collPos);
+        firstSolObject.handleContact(secondSolObject, absImpulse, myGame, collPos);
+        secondSolObject.handleContact(firstSolObject, absImpulse, myGame, collPos);
+        myGame.getSpecialSounds().playColl(myGame, absImpulse, firstSolObject, collPos);
+        myGame.getSpecialSounds().playColl(myGame, absImpulse, secondSolObject, collPos);
 
     }
 

--- a/engine/src/main/java/org/destinationsol/game/SolContactListener.java
+++ b/engine/src/main/java/org/destinationsol/game/SolContactListener.java
@@ -50,24 +50,28 @@ public class SolContactListener implements ContactListener {
             EntityRef entityB = (EntityRef) dataB;
             entitySystemManager.sendEvent(new ContactEvent(entityB, contact), entityA);
             entitySystemManager.sendEvent(new ContactEvent(entityA, contact), entityB);
+        }
+
+        //TODO This is a patch to smooth over contact between an Entity and a Projectile. Once Projectile has been converted
+        // to be an Entity, this can be removed.
+        if (dataA instanceof EntityRef) {
+            dataA = new SolObjectEntityWrapper((EntityRef) dataA);
+        }
+        if (dataB instanceof EntityRef) {
+            dataB = new SolObjectEntityWrapper((EntityRef) dataB);
+        }
+
+        //TODO This is legacy code for handling contact with a Projectile, which currently is designed to work with SolObjects.
+        // Once Projectile has been converted to be an entity, this should be refactored.
+        SolObject oA = (SolObject) dataA;
+        SolObject oB = (SolObject) dataB;
+        boolean aIsProj = oA instanceof Projectile;
+        if (!aIsProj && !(oB instanceof Projectile)) {
             return;
         }
-
-        if (dataA instanceof SolObject && dataB instanceof SolObject) {
-            SolObject oA = (SolObject) contact.getFixtureA().getBody().getUserData();
-            SolObject oB = (SolObject) contact.getFixtureB().getBody().getUserData();
-
-            boolean aIsProj = oA instanceof Projectile;
-            if (!aIsProj && !(oB instanceof Projectile)) {
-                return;
-            }
-
-            Projectile proj = (Projectile) (aIsProj ? oA : oB);
-            SolObject o = aIsProj ? oB : oA;
-            proj.setObstacle(o, myGame);
-        }
-
-        //TODO handle contact between an entity and a SolObject
+        Projectile proj = (Projectile) (aIsProj ? oA : oB);
+        SolObject o = aIsProj ? oB : oA;
+        proj.setObstacle(o, myGame);
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -111,6 +111,8 @@ public class SolGame {
     private SortedMap<Integer, List<UpdateAwareSystem>> onPausedUpdateSystems;
     private SortedMap<Integer, List<UpdateAwareSystem>> updateSystems;
 
+    private EntitySystemManager entitySystemManager;
+
     public SolGame(String shipName, boolean isTutorial, boolean isNewGame, CommonDrawer commonDrawer, Context context,
                    WorldConfig worldConfig) {
         // TODO: make this non-static
@@ -210,7 +212,9 @@ public class SolGame {
         }
     }
 
-    public void startGame(String shipName, boolean isNewGame, WorldConfig worldConfig, SolNames solNames) {
+    public void startGame(String shipName, boolean isNewGame, WorldConfig worldConfig, SolNames solNames, EntitySystemManager entitySystemManager) {
+        this.entitySystemManager = entitySystemManager;
+
         respawnState = new RespawnState();
         SolRandom.setSeed(worldConfig.getSeed());
         planetManager.fill(solNames, worldConfig.getNumberOfSystems());
@@ -549,6 +553,10 @@ public class SolGame {
 
     public TutorialManager getTutMan() {
         return tutorialManager;
+    }
+
+    public EntitySystemManager getEntitySystemManager() {
+        return entitySystemManager;
     }
 
     public void setRespawnState() {

--- a/engine/src/main/java/org/destinationsol/game/projectile/PointProjectileBody.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/PointProjectileBody.java
@@ -22,7 +22,9 @@ import org.destinationsol.Const;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.SolObject;
+import org.destinationsol.game.SolObjectEntityWrapper;
 import org.destinationsol.game.ship.SolShip;
+import org.terasology.gestalt.entitysystem.entity.EntityRef;
 
 public class PointProjectileBody implements ProjectileBody {
     private final Vector2 position;
@@ -107,15 +109,22 @@ public class PointProjectileBody implements ProjectileBody {
 
         @Override
         public float reportRayFixture(Fixture fixture, Vector2 point, Vector2 normal, float fraction) {
-            if (fixture.getBody().getUserData() instanceof SolObject) {
-                SolObject o = (SolObject) fixture.getBody().getUserData();
-                boolean oIsMassless = o instanceof Projectile && ((Projectile) o).isMassless();
-                if (!oIsMassless && projectile.shouldCollide(o, fixture, game.getFactionMan())) {
-                    position.set(point);
-                    projectile.setObstacle(o, game);
-                    return 0;
-                }
+
+            //TODO This is a patch to smooth over contact between an Entity and a Projectile. Once Projectile has been
+            // converted to be an Entity, this can be removed.
+            Object userData = fixture.getBody().getUserData();
+            if (userData instanceof EntityRef) {
+                userData = new SolObjectEntityWrapper((EntityRef) userData);
             }
+
+            SolObject o = (SolObject) userData;
+            boolean oIsMassless = o instanceof Projectile && ((Projectile) o).isMassless();
+            if (!oIsMassless && projectile.shouldCollide(o, fixture, game.getFactionMan())) {
+                position.set(point);
+                projectile.setObstacle(o, game);
+                return 0;
+            }
+
             return -1;
         }
     }

--- a/engine/src/main/java/org/destinationsol/game/projectile/PointProjectileBody.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/PointProjectileBody.java
@@ -117,11 +117,13 @@ public class PointProjectileBody implements ProjectileBody {
                 userData = new SolObjectEntityWrapper((EntityRef) userData);
             }
 
-            SolObject o = (SolObject) userData;
-            boolean oIsMassless = o instanceof Projectile && ((Projectile) o).isMassless();
-            if (!oIsMassless && projectile.shouldCollide(o, fixture, game.getFactionMan())) {
+            //At this point, the object will either be an entity wrapped in a SolObjectEntityWrapper, or it will have already been a SolObject
+            SolObject solObject = (SolObject) userData;
+            
+            boolean objectIsMassless = solObject instanceof Projectile && ((Projectile) solObject).isMassless();
+            if (!objectIsMassless && projectile.shouldCollide(solObject, fixture, game.getFactionMan())) {
                 position.set(point);
-                projectile.setObstacle(o, game);
+                projectile.setObstacle(solObject, game);
                 return 0;
             }
 

--- a/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
@@ -144,16 +144,16 @@ public class Projectile implements SolObject {
                 if (config.density > 0) {
                     obstacle = null;
                     wasDamageDealt = true;
+                } else {
+                    collided(game);
+
+                    //TODO Once SolShip is an entity, this should be refactored to work with it
+//                    if (config.emTime > 0 && obstacle instanceof SolShip) {
+//                        ((SolShip) obstacle).disableControls(config.emTime, game);
+//                    }
+
+                    return;
                 }
-
-                collided(game);
-
-                //TODO Once SolShip is an entity, this should be refactored to work with it
-//                if (config.emTime > 0 && obstacle instanceof SolShip) {
-//                    ((SolShip) obstacle).disableControls(config.emTime, game);
-//                }
-
-                return;
 
             } else {
                 //TODO this else block is legacy code for handling contact between a SolObject and an entity. Once every

--- a/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
@@ -41,6 +41,8 @@ import org.destinationsol.game.particle.EffectConfig;
 import org.destinationsol.game.particle.LightSource;
 import org.destinationsol.game.ship.SolShip;
 import org.destinationsol.health.events.DamageEvent;
+import org.destinationsol.location.components.Position;
+import org.terasology.gestalt.entitysystem.entity.EntityIterator;
 import org.terasology.gestalt.entitysystem.entity.EntityRef;
 
 import java.util.ArrayList;
@@ -119,13 +121,24 @@ public class Projectile implements SolObject {
         body.update(game);
 
         if (obstacle != null) {
+
             //This handles collision of a Projectile with an entity.
             if (obstacle instanceof SolObjectEntityWrapper) {
                 EntityRef entity = ((SolObjectEntityWrapper) obstacle).getEntity();
-                if (config.aoeRadius >= 0) { //This checks if the projectile does Area-Of-Effect damage. If it does not, the value is usually -1
-                    //TODO enable Area-Of-Effect damage to entities
-                } else {
-                    game.getEntitySystemManager().sendEvent(new DamageEvent(config.dmg), entity);
+
+                if (!wasDamageDealt) {
+                    if (config.aoeRadius >= 0) { //This checks if the projectile does Area-Of-Effect damage. If it does not, the value is usually -1
+                        EntityIterator iterator = game.getEntitySystemManager().getEntityManager().iterate(new Position());
+                        while (iterator.next()) {
+                            Vector2 entityPosition = iterator.getEntity().getComponent(Position.class).get().position;
+                            if (getPosition().dst2(entityPosition) <= config.aoeRadius) {
+                                game.getEntitySystemManager().sendEvent(new DamageEvent(config.dmg), entity);
+                            }
+                        }
+
+                    } else {
+                        game.getEntitySystemManager().sendEvent(new DamageEvent(config.dmg), entity);
+                    }
                 }
 
                 if (config.density > 0) {

--- a/engine/src/main/java/org/destinationsol/health/components/Health.java
+++ b/engine/src/main/java/org/destinationsol/health/components/Health.java
@@ -22,8 +22,8 @@ import org.terasology.gestalt.entitysystem.component.Component;
  */
 public final class Health implements Component<Health> {
 
-    public int maxHealth = 30;
-    public int currentHealth = 30;
+    public float maxHealth = 30;
+    public float currentHealth = 30;
 
     @Override
     public void copy(Health other) {

--- a/engine/src/main/java/org/destinationsol/health/events/DamageEvent.java
+++ b/engine/src/main/java/org/destinationsol/health/events/DamageEvent.java
@@ -22,13 +22,13 @@ import org.terasology.gestalt.entitysystem.event.Event;
  */
 public class DamageEvent implements Event {
 
-    private int damage;
+    private float damage;
 
-    public DamageEvent(int damage) {
+    public DamageEvent(float damage) {
         this.damage = damage;
     }
 
-    public int getDamage() {
+    public float getDamage() {
         return damage;
     }
 }


### PR DESCRIPTION
# Description
This adds working projectile collision with entities. When an entity is shot, this PR makes it so that the entity takes damage and absorbs the projectile properly.

# Testing
When the game starts, a golden asteroid should appear. Shooting it should destroy it.

To test the area-of-effect damage, run `groovyw module get makeshift -remote ThisIsPIRI` then start the game as the `Titanomachy`. Shooting the asteroid with the nuclear missile should destroy the asteroid.
