### PR TITLE
Impulse handling

### DIFF
--- a/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
+++ b/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
@@ -37,8 +37,9 @@ public class BodyLinked implements Component<BodyLinked> {
         if (mass <= 0) {
             logger.error("Invalid value for the mass. It can't be less than or equal to zero.");
             this.mass = 1;
+        } else {
+            this.mass = mass;
         }
-        this.mass = mass;
     }
 
     public float getMass() {

--- a/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
+++ b/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
@@ -16,10 +16,30 @@
 package org.destinationsol.body.components;
 
 import com.badlogic.gdx.physics.box2d.Body;
-import org.terasology.gestalt.entitysystem.component.EmptyComponent;
+import org.destinationsol.body.systems.BodyHandlerSystem;
+import org.terasology.gestalt.entitysystem.component.Component;
+
 
 /**
- * Indicates that there is a {@link Body} associated with the entity.
+ * Indicates that there is a {@link Body} associated with the entity. It also contains the mass of the entity.
  */
-public class BodyLinked extends EmptyComponent<BodyLinked> {
+public class BodyLinked implements Component<BodyLinked> {
+
+    private float mass;
+
+    /**
+     * Sets the mass of the entity. This is called every tick by the {@link BodyHandlerSystem}.
+     */
+    public void setMass(float mass) {
+        this.mass = mass;
+    }
+
+    public float getMass() {
+        return mass;
+    }
+
+    @Override
+    public void copy(BodyLinked other) {
+        this.mass = other.getMass();
+    }
 }

--- a/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
+++ b/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
@@ -17,6 +17,8 @@ package org.destinationsol.body.components;
 
 import com.badlogic.gdx.physics.box2d.Body;
 import org.destinationsol.body.systems.BodyHandlerSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.entitysystem.component.Component;
 
 
@@ -24,6 +26,7 @@ import org.terasology.gestalt.entitysystem.component.Component;
  * Indicates that there is a {@link Body} associated with the entity. It also contains the mass of the entity.
  */
 public class BodyLinked implements Component<BodyLinked> {
+    private static final Logger logger = LoggerFactory.getLogger(BodyLinked.class);
 
     private float mass;
 
@@ -31,6 +34,10 @@ public class BodyLinked implements Component<BodyLinked> {
      * Sets the mass of the entity. This is called every tick by the {@link BodyHandlerSystem}.
      */
     public void setMass(float mass) {
+        if (mass <= 0) {
+            logger.error("Invalid value for the mass. It can't be less than or equal to zero.");
+            this.mass = 1;
+        }
         this.mass = mass;
     }
 

--- a/engine/src/main/java/org/destinationsol/body/systems/BodyHandlerSystem.java
+++ b/engine/src/main/java/org/destinationsol/body/systems/BodyHandlerSystem.java
@@ -66,6 +66,9 @@ public class BodyHandlerSystem implements EventReceiver {
 
         createBodyIfNonexistent(entity);
         Body body = referenceToBodyObjects.get(entity);
+        BodyLinked bodyLinkedComponent = entity.getComponent(BodyLinked.class).get();
+        bodyLinkedComponent.setMass(body.getMass());
+        entity.setComponent(bodyLinkedComponent);
 
         if (entity.hasComponent(Position.class)) {
             entitySystemManager.sendEvent(new PositionUpdateEvent(body.getPosition()), entity);
@@ -85,7 +88,7 @@ public class BodyHandlerSystem implements EventReceiver {
      */
     @ReceiveEvent(components = {BodyLinked.class, Position.class})
     public EventResult onForce(ForceEvent event, EntityRef entity) {
-        if (!referenceToBodyObjects.containsKey(entity)){
+        if (!referenceToBodyObjects.containsKey(entity)) {
             return EventResult.CANCEL;
         }
 

--- a/engine/src/main/java/org/destinationsol/force/components/Durability.java
+++ b/engine/src/main/java/org/destinationsol/force/components/Durability.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.force.components;
+
+import org.destinationsol.force.events.ImpulseEvent;
+import org.terasology.gestalt.entitysystem.component.Component;
+
+/**
+ * Contains the durability of on entity, used for calculating how much damage the entity takes when receiving an
+ * {@link ImpulseEvent}. A durability value greater than one means that the entity takes less damage, and a durability
+ * between zero and one means more damage.
+ */
+public class Durability implements Component<Durability> {
+
+    private float durability;
+
+    public float getDurability() {
+        return durability;
+    }
+
+    /**
+     * This sets the durability of an entity. If the value passed in is less than or equal to zero, the durability
+     * defaults to be one.
+     */
+    public void setDurability(float durability) {
+        if (durability <= 0) {
+            this.durability = 1;
+        }
+        this.durability = durability;
+    }
+
+    @Override
+    public void copy(Durability other) {
+        this.durability = other.durability;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/force/components/Durability.java
+++ b/engine/src/main/java/org/destinationsol/force/components/Durability.java
@@ -43,8 +43,9 @@ public class Durability implements Component<Durability> {
         if (durability <= 0) {
             logger.error("Invalid value for the durability. It can't be less than or equal to zero.");
             this.durability = 1;
+        } else {
+            this.durability = durability;
         }
-        this.durability = durability;
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/force/components/Durability.java
+++ b/engine/src/main/java/org/destinationsol/force/components/Durability.java
@@ -16,6 +16,8 @@
 package org.destinationsol.force.components;
 
 import org.destinationsol.force.events.ImpulseEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.entitysystem.component.Component;
 
 /**
@@ -24,6 +26,8 @@ import org.terasology.gestalt.entitysystem.component.Component;
  * between zero and one means more damage.
  */
 public class Durability implements Component<Durability> {
+
+    private static final Logger logger = LoggerFactory.getLogger(Durability.class);
 
     private float durability;
 
@@ -37,6 +41,7 @@ public class Durability implements Component<Durability> {
      */
     public void setDurability(float durability) {
         if (durability <= 0) {
+            logger.error("Invalid value for the durability. It can't be less than or equal to zero.");
             this.durability = 1;
         }
         this.durability = durability;

--- a/engine/src/main/java/org/destinationsol/force/systems/ImpulseHandlingSystem.java
+++ b/engine/src/main/java/org/destinationsol/force/systems/ImpulseHandlingSystem.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.asteroids.systems;
+package org.destinationsol.force.systems;
 
-import org.destinationsol.asteroids.components.AsteroidMesh;
 import org.destinationsol.body.components.BodyLinked;
 import org.destinationsol.common.In;
 import org.destinationsol.entitysystem.EntitySystemManager;
 import org.destinationsol.entitysystem.EventReceiver;
+import org.destinationsol.force.components.Durability;
 import org.destinationsol.force.events.ImpulseEvent;
 import org.destinationsol.health.components.Health;
 import org.destinationsol.health.events.DamageEvent;
@@ -27,23 +27,26 @@ import org.terasology.gestalt.entitysystem.entity.EntityRef;
 import org.terasology.gestalt.entitysystem.event.EventResult;
 import org.terasology.gestalt.entitysystem.event.ReceiveEvent;
 
-//TODO refactor this to be generic. It currently applies ImpulseEvents to entities with AsteroidMesh components.
-public class AsteroidImpulseHandler implements EventReceiver {
-
-    private static final float DURABILITY = .5f;
+/**
+ * When this receives an {@link ImpulseEvent}, it sends a {@link DamageEvent} to the entity that is scaled according to
+ * the entity's mass and durability.
+ */
+public class ImpulseHandlingSystem implements EventReceiver {
 
     @In
     private EntitySystemManager entitySystemManager;
 
-    @ReceiveEvent(components = {AsteroidMesh.class, Health.class, BodyLinked.class})
-    public EventResult onImpulse(ImpulseEvent event, EntityRef entity){
+    @ReceiveEvent(components = {Health.class, BodyLinked.class})
+    public EventResult onImpulse(ImpulseEvent event, EntityRef entity) {
 
-        //TODO get the mass from the body
-        float mass = 1;
+        float mass = entity.getComponent(BodyLinked.class).get().getMass();
+        float damage = event.getMagnitude() / mass;
 
-        float damage = event.getMagnitude() / mass / DURABILITY;
+        if (entity.hasComponent(Durability.class)) {
+            entity.getComponent(Durability.class).get().getDurability();
+        }
+
         entitySystemManager.sendEvent(new DamageEvent((int) damage), entity);
-
         return EventResult.CONTINUE;
     }
 }

--- a/engine/src/main/java/org/destinationsol/force/systems/ImpulseHandlingSystem.java
+++ b/engine/src/main/java/org/destinationsol/force/systems/ImpulseHandlingSystem.java
@@ -43,7 +43,8 @@ public class ImpulseHandlingSystem implements EventReceiver {
         float damage = event.getMagnitude() / mass;
 
         if (entity.hasComponent(Durability.class)) {
-            entity.getComponent(Durability.class).get().getDurability();
+            float durability = entity.getComponent(Durability.class).get().getDurability();
+            damage /= durability;
         }
 
         entitySystemManager.sendEvent(new DamageEvent((int) damage), entity);

--- a/engine/src/main/java/org/destinationsol/force/systems/ImpulseHandlingSystem.java
+++ b/engine/src/main/java/org/destinationsol/force/systems/ImpulseHandlingSystem.java
@@ -47,7 +47,7 @@ public class ImpulseHandlingSystem implements EventReceiver {
             damage /= durability;
         }
 
-        entitySystemManager.sendEvent(new DamageEvent((int) damage), entity);
+        entitySystemManager.sendEvent(new DamageEvent(damage), entity);
         return EventResult.CONTINUE;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/input/SmallObjAvoider.java
+++ b/engine/src/main/java/org/destinationsol/game/input/SmallObjAvoider.java
@@ -23,8 +23,10 @@ import com.badlogic.gdx.physics.box2d.World;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.SolObject;
+import org.destinationsol.game.SolObjectEntityWrapper;
 import org.destinationsol.game.planet.Planet;
 import org.destinationsol.game.ship.SolShip;
+import org.terasology.gestalt.entitysystem.entity.EntityRef;
 
 public class SmallObjAvoider {
     public static final float MANEUVER_TIME = 2f;
@@ -85,7 +87,11 @@ public class SmallObjAvoider {
     private class MyRayBack implements RayCastCallback {
         @Override
         public float reportRayFixture(Fixture fixture, Vector2 point, Vector2 normal, float fraction) {
-            SolObject o = (SolObject) fixture.getBody().getUserData();
+            Object data = fixture.getBody().getUserData();
+            if (data instanceof EntityRef) {
+                data = new SolObjectEntityWrapper((EntityRef) data);
+            }
+            SolObject o = (SolObject) data;
             if (myShip == o) {
                 return -1;
             }

--- a/engine/src/main/java/org/destinationsol/game/input/SmallObjAvoider.java
+++ b/engine/src/main/java/org/destinationsol/game/input/SmallObjAvoider.java
@@ -91,8 +91,8 @@ public class SmallObjAvoider {
             if (data instanceof EntityRef) {
                 data = new SolObjectEntityWrapper((EntityRef) data);
             }
-            SolObject o = (SolObject) data;
-            if (myShip == o) {
+            SolObject solObject = (SolObject) data;
+            if (myShip == solObject) {
                 return -1;
             }
             myCollided = true;


### PR DESCRIPTION
# Description
This changes impulse handling from being asteroid-specific to being general purpose by adding a `mass` field in `BodyLinked` and by creating a `Durability` component. It also changes the `AsteroidImpulseHandler` to be a general `ImpulseHandlingSystem`.

# Testing
Start the game with a Loaded Imperial Large ship. The asteroid should be harder to destroy (because it now has a mass that is higher than one).
