### PR TITLE
Rubble creation

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -57,6 +57,7 @@ import org.destinationsol.location.components.Position;
 import org.destinationsol.menu.MenuScreens;
 import org.destinationsol.menu.background.MenuBackgroundManager;
 import org.destinationsol.modules.ModuleManager;
+import org.destinationsol.rubble.components.CreatesRubbleOnDestruction;
 import org.destinationsol.size.components.Size;
 import org.destinationsol.ui.DebugCollector;
 import org.destinationsol.ui.DisplayDimensions;
@@ -280,7 +281,7 @@ public class SolApplication implements ApplicationListener {
                 health.currentHealth = 1;
 
                 EntityRef entityRef = entitySystemManager.getEntityManager().createEntity(graphicsComponent, position, size,
-                        new Angle(), new Velocity(), new AsteroidMesh(), health, new DropsMoneyOnDeath());
+                        new Angle(), new Velocity(), new AsteroidMesh(), health, new DropsMoneyOnDeath(), new CreatesRubbleOnDestruction());
                 
                 entityRef.setComponent(new BodyLinked());
                 entityCreated = true;

--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -41,7 +41,7 @@ import org.destinationsol.game.drawables.DrawableLevel;
 import org.destinationsol.health.components.Health;
 import org.destinationsol.location.components.Angle;
 import org.destinationsol.location.components.Velocity;
-import org.destinationsol.moneyDropping.components.DropsMoneyOnDeath;
+import org.destinationsol.moneyDropping.components.DropsMoneyOnDestruction;
 import org.destinationsol.rendering.RenderableElement;
 import org.destinationsol.rendering.components.Renderable;
 import org.destinationsol.rendering.events.RenderEvent;
@@ -281,7 +281,7 @@ public class SolApplication implements ApplicationListener {
                 health.currentHealth = 1;
 
                 EntityRef entityRef = entitySystemManager.getEntityManager().createEntity(graphicsComponent, position, size,
-                        new Angle(), new Velocity(), new AsteroidMesh(), health, new DropsMoneyOnDeath(), new CreatesRubbleOnDestruction());
+                        new Angle(), new Velocity(), new AsteroidMesh(), health, new DropsMoneyOnDestruction(), new CreatesRubbleOnDestruction());
                 
                 entityRef.setComponent(new BodyLinked());
                 entityCreated = true;

--- a/engine/src/main/java/org/destinationsol/body/systems/BodyHandlerSystem.java
+++ b/engine/src/main/java/org/destinationsol/body/systems/BodyHandlerSystem.java
@@ -68,13 +68,13 @@ public class BodyHandlerSystem implements EventReceiver {
         Body body = referenceToBodyObjects.get(entity);
 
         if (entity.hasComponent(Position.class)) {
-            entitySystemManager.sendEvent(new PositionUpdateEvent(body.getPosition()), entity);
+            entitySystemManager.sendEvent(new PositionUpdateEvent(body.getPosition().cpy()), entity);
         }
         if (entity.hasComponent(Angle.class)) {
             entitySystemManager.sendEvent(new AngleUpdateEvent(body.getAngle()), entity);
         }
         if (entity.hasComponent(Velocity.class)) {
-            entitySystemManager.sendEvent(new VelocityUpdateEvent(body.getLinearVelocity()), entity);
+            entitySystemManager.sendEvent(new VelocityUpdateEvent(body.getLinearVelocity().cpy()), entity);
         }
         return EventResult.CONTINUE;
     }

--- a/engine/src/main/java/org/destinationsol/game/Rubble.java
+++ b/engine/src/main/java/org/destinationsol/game/Rubble.java
@@ -23,7 +23,7 @@ import org.destinationsol.game.drawables.Drawable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Shard implements SolObject {
+public class Rubble implements SolObject {
 
     private final Body body;
     private final Vector2 position;
@@ -32,7 +32,7 @@ public class Shard implements SolObject {
 
     private float angle;
 
-    Shard(Body body, ArrayList<Drawable> drawables) {
+    Rubble(Body body, ArrayList<Drawable> drawables) {
         this.drawables = drawables;
         this.body = body;
         position = new Vector2();

--- a/engine/src/main/java/org/destinationsol/game/RubbleBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/RubbleBuilder.java
@@ -29,7 +29,7 @@ import org.destinationsol.game.ship.ShipBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ShardBuilder {
+public class RubbleBuilder {
     public static final float MIN_SCALE = .07f;
     public static final float MAX_SCALE = .12f;
     public static final float SIZE_TO_SHARD_COUNT = 13f;
@@ -38,7 +38,7 @@ public class ShardBuilder {
     private final CollisionMeshLoader myCollisionMeshLoader;
     private final List<TextureAtlas.AtlasRegion> myTextures;
 
-    public ShardBuilder() {
+    public RubbleBuilder() {
         myCollisionMeshLoader = new CollisionMeshLoader("engine:miscCollisionMeshes");
         myTextures = Assets.listTexturesMatching("engine:shard_.*");
     }
@@ -46,12 +46,12 @@ public class ShardBuilder {
     public void buildExplosionShards(SolGame game, Vector2 position, Vector2 baseVelocity, float size) {
         int count = (int) (size * SIZE_TO_SHARD_COUNT);
         for (int i = 0; i < count; i++) {
-            Shard s = build(game, position, baseVelocity, size);
+            Rubble s = build(game, position, baseVelocity, size);
             game.getObjectManager().addObjDelayed(s);
         }
     }
 
-    public Shard build(SolGame game, Vector2 basePos, Vector2 baseVelocity, float size) {
+    public Rubble build(SolGame game, Vector2 basePos, Vector2 baseVelocity, float size) {
 
         ArrayList<Drawable> drawables = new ArrayList<>();
         float scale = SolRandom.randomFloat(MIN_SCALE, MAX_SCALE);
@@ -68,8 +68,8 @@ public class ShardBuilder {
         body.setLinearVelocity(velocity);
         SolMath.free(velocity);
 
-        Shard shard = new Shard(body, drawables);
-        body.setUserData(shard);
-        return shard;
+        Rubble rubble = new Rubble(body, drawables);
+        body.setUserData(rubble);
+        return rubble;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -154,6 +154,7 @@ public class SolGame {
         lootBuilder = new LootBuilder();
         mapDrawer = new MapDrawer();
         shardBuilder = new ShardBuilder();
+        context.put(ShardBuilder.class, shardBuilder);
         galaxyFiller = new GalaxyFiller(hullConfigManager);
         starPortBuilder = new StarPort.Builder();
         drawableDebugger = new DrawableDebugger();

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -26,7 +26,6 @@ import org.destinationsol.SolApplication;
 import org.destinationsol.assets.sound.OggSoundManager;
 import org.destinationsol.assets.sound.SpecialSounds;
 import org.destinationsol.common.DebugCol;
-import org.destinationsol.common.In;
 import org.destinationsol.common.SolException;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.common.SolRandom;
@@ -89,7 +88,7 @@ public class SolGame {
     private final FarBackgroundManagerOld farBackgroundManagerOld;
     private final FactionManager factionManager;
     private final MapDrawer mapDrawer;
-    private final ShardBuilder shardBuilder;
+    private final RubbleBuilder rubbleBuilder;
     private final ItemManager itemManager;
     private final StarPort.Builder starPortBuilder;
     private final OggSoundManager soundManager;
@@ -153,8 +152,8 @@ public class SolGame {
         asteroidBuilder = new AsteroidBuilder();
         lootBuilder = new LootBuilder();
         mapDrawer = new MapDrawer();
-        shardBuilder = new ShardBuilder();
-        context.put(ShardBuilder.class, shardBuilder);
+        rubbleBuilder = new RubbleBuilder();
+        context.put(RubbleBuilder.class, rubbleBuilder);
         galaxyFiller = new GalaxyFiller(hullConfigManager);
         starPortBuilder = new StarPort.Builder();
         drawableDebugger = new DrawableDebugger();
@@ -496,8 +495,8 @@ public class SolGame {
         return mapDrawer;
     }
 
-    public ShardBuilder getShardBuilder() {
-        return shardBuilder;
+    public RubbleBuilder getRubbleBuilder() {
+        return rubbleBuilder;
     }
 
     public FarBackgroundManagerOld getFarBackgroundgManagerOld() {

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -354,7 +354,7 @@ public class SolShip implements SolObject {
     @Override
     public void onRemove(SolGame game) {
         if (myHull.life <= 0) {
-            game.getShardBuilder().buildExplosionShards(game, myHull.getPosition(), myHull.getVelocity(), myHull.config.getSize());
+            game.getRubbleBuilder().buildExplosionShards(game, myHull.getPosition(), myHull.getVelocity(), myHull.config.getSize());
             throwAllLoot(game);
         }
         myHull.onRemove(game);

--- a/engine/src/main/java/org/destinationsol/moneyDropping/components/DropsMoneyOnDestruction.java
+++ b/engine/src/main/java/org/destinationsol/moneyDropping/components/DropsMoneyOnDestruction.java
@@ -21,5 +21,5 @@ import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 /**
  * Indicates that when the entity is destroyed, one or more {@link Loot} objects should be created.
  */
-public class DropsMoneyOnDeath extends EmptyComponent<DropsMoneyOnDeath> {
+public class DropsMoneyOnDestruction extends EmptyComponent<DropsMoneyOnDestruction> {
 }

--- a/engine/src/main/java/org/destinationsol/moneyDropping/systems/MoneyDroppingSystem.java
+++ b/engine/src/main/java/org/destinationsol/moneyDropping/systems/MoneyDroppingSystem.java
@@ -28,7 +28,7 @@ import org.destinationsol.game.item.LootBuilder;
 import org.destinationsol.game.item.MoneyItem;
 import org.destinationsol.location.components.Position;
 import org.destinationsol.location.components.Velocity;
-import org.destinationsol.moneyDropping.components.DropsMoneyOnDeath;
+import org.destinationsol.moneyDropping.components.DropsMoneyOnDestruction;
 import org.destinationsol.removal.events.DeletionEvent;
 import org.destinationsol.removal.systems.DestructionSystem;
 import org.destinationsol.size.components.Size;
@@ -40,7 +40,7 @@ import org.terasology.gestalt.entitysystem.event.ReceiveEvent;
 import java.util.List;
 
 /**
- * When an entity with a {@link DropsMoneyOnDeath} component is destroyed, this system creates an amount of money based
+ * When an entity with a {@link DropsMoneyOnDestruction} component is destroyed, this system creates an amount of money based
  * on its {@link Size}.
  */
 public class MoneyDroppingSystem implements EventReceiver {
@@ -60,7 +60,7 @@ public class MoneyDroppingSystem implements EventReceiver {
     @In
     private ObjectManager objectManager;
 
-    @ReceiveEvent(components = {DropsMoneyOnDeath.class, Position.class, Velocity.class, Size.class})
+    @ReceiveEvent(components = {DropsMoneyOnDestruction.class, Position.class, Velocity.class, Size.class})
     @Before(DestructionSystem.class)
     public EventResult onDeletion(DeletionEvent event, EntityRef entity) {
 

--- a/engine/src/main/java/org/destinationsol/rubble/components/CreatesRubbleOnDestruction.java
+++ b/engine/src/main/java/org/destinationsol/rubble/components/CreatesRubbleOnDestruction.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.rubble.components;
+
+import org.destinationsol.game.Shard;
+import org.terasology.gestalt.entitysystem.component.EmptyComponent;
+
+/**
+ * Indicates that when an entity dies, {@link Shard}s should be created where the entity was.
+ */
+public class CreatesRubbleOnDestruction extends EmptyComponent<CreatesRubbleOnDestruction> {
+}

--- a/engine/src/main/java/org/destinationsol/rubble/components/CreatesRubbleOnDestruction.java
+++ b/engine/src/main/java/org/destinationsol/rubble/components/CreatesRubbleOnDestruction.java
@@ -16,10 +16,12 @@
 package org.destinationsol.rubble.components;
 
 import org.destinationsol.game.Rubble;
+import org.destinationsol.location.components.Position;
 import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
- * Indicates that when an entity dies, {@link Rubble}s should be created where the entity was.
+ * Indicates that when an entity dies, {@link Rubble} should be created where the entity was. The entity needs to have
+ * a {@link Position} component for this to function.
  */
 public class CreatesRubbleOnDestruction extends EmptyComponent<CreatesRubbleOnDestruction> {
 }

--- a/engine/src/main/java/org/destinationsol/rubble/components/CreatesRubbleOnDestruction.java
+++ b/engine/src/main/java/org/destinationsol/rubble/components/CreatesRubbleOnDestruction.java
@@ -15,11 +15,11 @@
  */
 package org.destinationsol.rubble.components;
 
-import org.destinationsol.game.Shard;
+import org.destinationsol.game.Rubble;
 import org.terasology.gestalt.entitysystem.component.EmptyComponent;
 
 /**
- * Indicates that when an entity dies, {@link Shard}s should be created where the entity was.
+ * Indicates that when an entity dies, {@link Rubble}s should be created where the entity was.
  */
 public class CreatesRubbleOnDestruction extends EmptyComponent<CreatesRubbleOnDestruction> {
 }

--- a/engine/src/main/java/org/destinationsol/rubble/systems/RubbleCreationSystem.java
+++ b/engine/src/main/java/org/destinationsol/rubble/systems/RubbleCreationSystem.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.rubble.systems;
+
+import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.common.In;
+import org.destinationsol.entitysystem.EventReceiver;
+import org.destinationsol.game.Shard;
+import org.destinationsol.game.ShardBuilder;
+import org.destinationsol.game.SolGame;
+import org.destinationsol.location.components.Position;
+import org.destinationsol.location.components.Velocity;
+import org.destinationsol.removal.events.DeletionEvent;
+import org.destinationsol.removal.systems.DestructionSystem;
+import org.destinationsol.rubble.components.CreatesRubbleOnDestruction;
+import org.destinationsol.size.components.Size;
+import org.destinationsol.stasis.components.Stasis;
+import org.terasology.gestalt.entitysystem.entity.EntityRef;
+import org.terasology.gestalt.entitysystem.event.Before;
+import org.terasology.gestalt.entitysystem.event.EventResult;
+import org.terasology.gestalt.entitysystem.event.ReceiveEvent;
+
+/**
+ * When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this system creates {@link Shard}s
+ * where the entity was.
+ */
+public class RubbleCreationSystem implements EventReceiver {
+
+    @In
+    private ShardBuilder shardBuilder;
+
+    @In
+    private SolGame solGame;
+
+    //TODO once Shards are entities, this needs to be refactored to replace ShardBuilder
+    /**
+     *When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this creates {@link Shard}s where
+     * the entity was, unless the entity is in {@link Stasis}.
+     */
+    @ReceiveEvent(components = {CreatesRubbleOnDestruction.class, Position.class, Velocity.class, Size.class})
+    @Before(DestructionSystem.class)
+    public EventResult onDeletion(DeletionEvent event, EntityRef entity) {
+        if (!entity.hasComponent(Stasis.class)) {
+            Vector2 position = entity.getComponent(Position.class).get().position;
+            Vector2 velocity = entity.getComponent(Velocity.class).get().velocity;
+            float size = entity.getComponent(Size.class).get().size;
+            shardBuilder.buildExplosionShards(solGame, position, velocity, size);
+        }
+        return EventResult.CONTINUE;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/rubble/systems/RubbleCreationSystem.java
+++ b/engine/src/main/java/org/destinationsol/rubble/systems/RubbleCreationSystem.java
@@ -46,16 +46,22 @@ public class RubbleCreationSystem implements EventReceiver {
     private SolGame solGame;
 
     //TODO once Shards are entities, this needs to be refactored to replace ShardBuilder
+
     /**
-     *When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this creates {@link Rubble}s where
+     * When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this creates {@link Rubble}s where
      * the entity was, unless the entity is in {@link Stasis}.
      */
-    @ReceiveEvent(components = {CreatesRubbleOnDestruction.class, Position.class, Velocity.class, Size.class})
+    @ReceiveEvent(components = {CreatesRubbleOnDestruction.class, Position.class, Size.class})
     @Before(DestructionSystem.class)
     public EventResult onDeletion(DeletionEvent event, EntityRef entity) {
         if (!entity.hasComponent(Stasis.class)) {
             Vector2 position = entity.getComponent(Position.class).get().position;
-            Vector2 velocity = entity.getComponent(Velocity.class).get().velocity;
+            Vector2 velocity;
+            if (entity.hasComponent(Velocity.class)) {
+                velocity = entity.getComponent(Velocity.class).get().velocity;
+            } else {
+                velocity = new Vector2();
+            }
             float size = entity.getComponent(Size.class).get().size;
             rubbleBuilder.buildExplosionShards(solGame, position, velocity, size);
         }

--- a/engine/src/main/java/org/destinationsol/rubble/systems/RubbleCreationSystem.java
+++ b/engine/src/main/java/org/destinationsol/rubble/systems/RubbleCreationSystem.java
@@ -18,8 +18,8 @@ package org.destinationsol.rubble.systems;
 import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.common.In;
 import org.destinationsol.entitysystem.EventReceiver;
-import org.destinationsol.game.Shard;
-import org.destinationsol.game.ShardBuilder;
+import org.destinationsol.game.Rubble;
+import org.destinationsol.game.RubbleBuilder;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.location.components.Position;
 import org.destinationsol.location.components.Velocity;
@@ -34,20 +34,20 @@ import org.terasology.gestalt.entitysystem.event.EventResult;
 import org.terasology.gestalt.entitysystem.event.ReceiveEvent;
 
 /**
- * When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this system creates {@link Shard}s
+ * When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this system creates {@link Rubble}s
  * where the entity was.
  */
 public class RubbleCreationSystem implements EventReceiver {
 
     @In
-    private ShardBuilder shardBuilder;
+    private RubbleBuilder rubbleBuilder;
 
     @In
     private SolGame solGame;
 
     //TODO once Shards are entities, this needs to be refactored to replace ShardBuilder
     /**
-     *When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this creates {@link Shard}s where
+     *When an entity with a {@link CreatesRubbleOnDestruction} component is destroyed, this creates {@link Rubble}s where
      * the entity was, unless the entity is in {@link Stasis}.
      */
     @ReceiveEvent(components = {CreatesRubbleOnDestruction.class, Position.class, Velocity.class, Size.class})
@@ -57,7 +57,7 @@ public class RubbleCreationSystem implements EventReceiver {
             Vector2 position = entity.getComponent(Position.class).get().position;
             Vector2 velocity = entity.getComponent(Velocity.class).get().velocity;
             float size = entity.getComponent(Size.class).get().size;
-            shardBuilder.buildExplosionShards(solGame, position, velocity, size);
+            rubbleBuilder.buildExplosionShards(solGame, position, velocity, size);
         }
         return EventResult.CONTINUE;
     }

--- a/engine/src/test/java/org/destinationsol/game/RubbleTest.java
+++ b/engine/src/test/java/org/destinationsol/game/RubbleTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ShardTest {
+public class RubbleTest {
 
     private static ArrayList<Drawable> drawables;
 
@@ -50,7 +50,7 @@ public class ShardTest {
     private static SolObject createShard() {
         drawables = new ArrayList<>(1);
         Gdx.app.postRunnable(() -> drawables.add(new RectSprite(Assets.listTexturesMatching("engine:shard_.*").get(0), 1, 1, 1, new Vector2(), DrawableLevel.PART_FG_0, 0, 0, Color.WHITE, false)));
-        return new Shard(BodyUtilities.createDummyBody(), drawables);
+        return new Rubble(BodyUtilities.createDummyBody(), drawables);
     }
 
     @Test
@@ -82,15 +82,15 @@ public class ShardTest {
     public void getSpeed() {
         Body body = BodyUtilities.createDummyBody();
         body.setLinearVelocity(1f, 2f);
-        final Shard shard = new Shard(body, drawables);
-        assertTrue(shard.getVelocity().epsilonEquals(1f, 2f, 0.01f));
+        final Rubble rubble = new Rubble(body, drawables);
+        assertTrue(rubble.getVelocity().epsilonEquals(1f, 2f, 0.01f));
         assertTrue(SHARD_CONSTANT.getVelocity().epsilonEquals(0f, 0f, 0.01f));
     }
 
     @Test
     public void handleContact() {
         // Shards are not big enough to cause damage or get damage or anything, so this just shouldn't crash
-        SHARD_CONSTANT.handleContact(new Shard(BodyUtilities.createDummyBody(), drawables), 10f, InitializationUtilities.game, new Vector2(0f, 0f));
+        SHARD_CONSTANT.handleContact(new Rubble(BodyUtilities.createDummyBody(), drawables), 10f, InitializationUtilities.game, new Vector2(0f, 0f));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class ShardTest {
     public void onRemove() {
         // TODO onRemove() should free its resources. How to test that?
         // I guess this just should not crash
-        new Shard(BodyUtilities.createDummyBody(), drawables).onRemove(InitializationUtilities.game);
+        new Rubble(BodyUtilities.createDummyBody(), drawables).onRemove(InitializationUtilities.game);
     }
 
     @Test


### PR DESCRIPTION
# Description
This PR adds rubble creation when an entity with a `CreatesRubbleOnDestruction` component is destroyed. It also refactors `Shard` to be called `Rubble`, and `DropsMoneyOnDeath` to be called `DropsMoneyOnDestruction`.

# Testing
Start the game and shoot the golden asteroid. When it is destroyed, it should explode into rubble.
