### PR TITLE
Fixed black screen when starting game on Android

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -15,20 +15,23 @@ buildscript {
         jcenter()
         mavenCentral()
 
-        // HACK: Needed for NUI reflections
+        // HACK: Needed for NUI and gestalt entity-component reflections
         mavenLocal()
         google()
         maven { url "http://artifactory.terasology.org/artifactory/virtual-repo-live" }
+        // Needed for Jsemver, which is a gestalt dependency
+        maven { url = 'https://heisluft.de/maven/' }
     }
 
     dependencies {
         // Needed for caching reflected data during builds
-        classpath 'org.reflections:reflections:0.9.10'
+        classpath 'org.reflections:reflections:0.9.12'
         classpath 'dom4j:dom4j:1.6.1'
 
-        // HACK: Needed for NUI reflections
+        // HACK: Needed for NUI and gestalt entity-component reflections
         classpath group: 'org.terasology.nui', name: 'nui', version: '2.0.0-SNAPSHOT'
         classpath group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
+        classpath group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.0.6-SNAPSHOT'
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request fixes the issue where only a black screen is shown after starting a new game or continuing an existing one. This only occurs when running the Android build.

# Testing
- Start Destination Sol on Android
- The main menu should be displayed correctly
- Start a new game (or continue an existing one)
- The game should work as-normal

# Notes
<details>
<summary>Problem Details</summary>
The issue is caused by the application throwing the following exception:

```stacktrace
java.lang.NullPointerException: Attempt to invoke interface method 'boolean org.terasology.gestalt.entitysystem.component.store.ComponentStore.set(int, org.terasology.gestalt.entitysystem.component.Component)' on a null object reference
	at org.terasology.gestalt.entitysystem.entity.manager.ManagedEntityRef.setComponent(ManagedEntityRef.java:90)
	at org.terasology.gestalt.entitysystem.entity.EntityRef.setComponents(EntityRef.java:115)
	at org.terasology.gestalt.entitysystem.entity.manager.CoreEntityManager.createEntity(CoreEntityManager.java:165)
	at org.terasology.gestalt.entitysystem.entity.EntityManager.createEntity(EntityManager.java:47)
	at org.destinationsol.SolApplication.draw(SolApplication.java:289)
	at org.destinationsol.SolApplication.render(SolApplication.java:192)
	at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:495)
	at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1571)
	at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1270)
```

The cause appears to be due to a component type being requested that is not avaliable. In this case, the component type that throws the exception is `AsteroidMesh`, however any sub-classes of `EmptyComponent` seemed to be the same. This seems to be because the types were not recorded as component types in the reflections cache.

By including the gestalt library in the reflections cache though, the link between `EmptyComponent` and `Component` is recorded, causing all sub-classes of `EmptyComponent` to be considered component classes. Before this change, only classes directly implementing `Component` were detected as components.

Before the change, the descendants of `Component` were recorded as the following (in `reflections.cache`).
```xml
<entry>
  <key>org.terasology.gestalt.entitysystem.component.Component</key>
  <values>
    <value>org.destinationsol.rendering.components.Renderable</value>
    <value>org.destinationsol.location.components.Position</value>
    <value>org.destinationsol.location.components.Velocity</value>
    <value>org.destinationsol.health.components.Health</value>
    <value>org.destinationsol.force.components.Durability</value>
    <value>org.destinationsol.size.components.Size</value>
    <value>org.destinationsol.location.components.Angle</value>
    <value>org.destinationsol.body.components.BodyLinked</value>
  </values>
</entry>
```
After the change, this changes to:
```xml
<entry>
  <key>org.terasology.gestalt.entitysystem.component.Component</key>
  <values>
    <value>org.destinationsol.body.components.BodyLinked</value>
    <value>org.destinationsol.force.components.Durability</value>
    <value>org.destinationsol.health.components.Health</value>
    <value>org.destinationsol.location.components.Angle</value>
    <value>org.destinationsol.location.components.Position</value>
    <value>org.destinationsol.location.components.Velocity</value>
    <value>org.destinationsol.rendering.components.Renderable</value>
    <value>org.destinationsol.size.components.Size</value>
    <value>org.terasology.gestalt.entitysystem.component.EmptyComponent</value>
  </values>
</entry>
```

The newly detected `EmptyComponent` sub-class allows sub-classes of `EmptyComponent` to be detected as implementing the `Component` interface. This change may increase the size of `reflections.cache` though, however the size after this change was 64KB when I checked, which is still fairly small.
</details>

This problem only occurs on Android because the desktop build performs reflections on start-up, allowing it to detect all classes on the classpath. On Android, I do not believe that any reflections are perfomed on start-up and so the reflections cache is used exclusively instead.  This fix only worked with version 0.9.12 of the reflections library, so I increased the version used by the build script.

### Known Issues
 - ClassNotFound exceptions are shown in the output when running a gradle build. This does not cause the build to fail though.
<!--
### Pre Pull Request Checklist:
When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones. 
If the code looks good to you and you have already at least some experience writing java, you can even completely skip 
this step
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
-->