### PR TITLE
Removed jcenter repository

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -1,6 +1,6 @@
 import groovy.json.JsonSlurper
 
-@GrabResolver(name = 'jcenter', root = 'http://jcenter.bintray.com/')
+@GrabResolver(name = 'grgit-backup', root = 'https://ajoberstar.github.io/bintray-backup/')
 @Grab(group = 'org.ajoberstar', module = 'grgit', version = '1.9.3')
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Remote

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -12,7 +12,6 @@ import org.reflections.util.ClasspathHelper;
 buildscript {
     repositories {
         // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-        jcenter()
         mavenCentral()
 
         // HACK: Needed for NUI and gestalt entity-component reflections

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -14,9 +14,17 @@ import org.reflections.util.ConfigurationBuilder;
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
-        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-        jcenter()
+        // External libs
         mavenCentral()
+
+        // Gradle plugin portal - Used for Artifactory plugin
+        gradlePluginPortal() {
+            content {
+                // Only fetch org.jfrog.buildinfo packages,
+                // as the gradle plugin portal forwards to jcenter for any unknown dependencies
+                includeGroup("org.jfrog.buildinfo")
+            }
+        }
     }
 
     dependencies {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This removes all references to the jcenter repository from the project and its sub-projects. Jcenter is still used in the android facade though due to the issues mentioned in https://github.com/MovingBlocks/DestSolAndroid/pull/17#discussion_r583947201.

# Testing
If it compiles, then it should work, assuming that no dependencies have changed. In terms of compilation:
 - Ensure that compiling everything succeeds (`gradlew buildDebug`)
 - Ensure the engine project compiles (`gradlew :engine:build`)
 - Ensure modules compile (especially code modules like warp)
 - Ensure that the desktop facade compiles (`gradlew :desktop:build`)
 - Test the `groovyw` utility to ensure that it still functions. `groovyw module get syndicate` should probably work.

# Notes
- The groovy scripts `grgit` dependency is now fetched from a read-only mirror recommended by its creator, as shown in the [README](https://github.com/ajoberstar/grgit/blob/main/README.md) for the `grgit` project.
- I am not sure where the artifactory plugin is used anywhere in the module build scripts, however since it is present on gradle plugin portal repository as well, I have replaced the jcenter dependency with that.

Adds to https://github.com/MovingBlocks/Terasology/issues/4582