### PR TITLE
Updated NUI to version 3.0.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ allprojects {
         appName = 'DestinationSol'
         gdxVersion = '1.9.8'
         roboVMVersion = '2.3.3'
+        nuiVersion = '3.0.0-SNAPSHOT'
     }
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -49,8 +49,9 @@ dependencies {
     api(group: 'org.terasology.gestalt', name: 'gestalt-module', version: '7.0.6-SNAPSHOT')
     api(group: 'org.terasology.gestalt', name: 'gestalt-util', version: '7.0.6-SNAPSHOT')
 
-    api group: 'org.terasology.nui', name: 'nui', version: '2.0.0'
-    api group: 'org.terasology.nui', name: 'nui-libgdx', version: '2.0.0'
+    api group: 'org.terasology.nui', name: 'nui', version: nuiVersion
+    api group: 'org.terasology.nui', name: 'nui-libgdx', version: nuiVersion
+    api group: 'org.terasology.nui', name: 'nui-gestalt7', version: nuiVersion
 
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.4.0'
 

--- a/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
@@ -42,6 +42,7 @@ import org.terasology.nui.UIWidget;
 import org.terasology.nui.asset.UIElement;
 import org.terasology.nui.reflection.WidgetLibrary;
 import org.terasology.nui.skin.UISkin;
+import org.terasology.nui.skin.UISkinAsset;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
@@ -81,8 +82,8 @@ public class AssetHelper {
             widgetLibrary.register(new ResourceUrn(moduleName, new Name(widgetClass.getSimpleName())), widgetClass);
         }
 
-        assetTypeManager.createAssetType(UISkin.class, UISkin::new, "skins");
-        ((AssetFileDataProducer)assetTypeManager.getAssetType(UISkin.class).get().getProducers().get(0)).addAssetFormat(new UISkinFormat(widgetLibrary));
+        assetTypeManager.createAssetType(UISkinAsset.class, UISkinAsset::new, "skins");
+        ((AssetFileDataProducer)assetTypeManager.getAssetType(UISkinAsset.class).get().getProducers().get(0)).addAssetFormat(new UISkinFormat(widgetLibrary));
 
         assetTypeManager.createAssetType(UIElement.class, UIElement::new, "ui");
         ((AssetFileDataProducer)assetTypeManager.getAssetType(UIElement.class).get().getProducers().get(0)).addAssetFormat(new UIFormat(widgetLibrary));

--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.entitysystem.prefab.Prefab;
+import org.terasology.nui.skin.UISkin;
+import org.terasology.nui.skin.UISkinAsset;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -123,6 +125,16 @@ public abstract class Assets {
         }
 
         throw new RuntimeException("Font " + path + " not found!");
+    }
+
+    public static UISkin getSkin(String path) {
+        Optional<UISkinAsset> skinOptional = assetHelper.get(new ResourceUrn(path), UISkinAsset.class);
+
+        if (skinOptional.isPresent()) {
+            return skinOptional.get().getSkin();
+        }
+
+        throw new RuntimeException("UISkin " + path + " not found!");
     }
 
     /**

--- a/engine/src/main/java/org/destinationsol/assets/ui/UIFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/ui/UIFormat.java
@@ -45,6 +45,7 @@ import org.terasology.nui.asset.UIData;
 import org.terasology.nui.asset.font.Font;
 import org.terasology.nui.reflection.WidgetLibrary;
 import org.terasology.nui.skin.UISkin;
+import org.terasology.nui.skin.UISkinAsset;
 import org.terasology.nui.widgets.UILabel;
 import org.terasology.reflection.ReflectionUtil;
 import org.terasology.reflection.metadata.ClassMetadata;
@@ -103,7 +104,7 @@ public class UIFormat extends AbstractAssetFileFormat<UIData> {
                 .registerTypeAdapter(UISkin.class, new JsonDeserializer<UISkin>() {
                     @Override
                     public UISkin deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        return Assets.getAssetHelper().get(new ResourceUrn(json.getAsString()), UISkin.class).get();
+                        return Assets.getAssetHelper().get(new ResourceUrn(json.getAsString()), UISkinAsset.class).get().getSkin();
                     }
                 })
                 .registerTypeAdapter(UITextureRegion.class, new UISkinFormat.TextureRegionTypeAdapter())

--- a/engine/src/main/java/org/destinationsol/assets/ui/UISkinFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/ui/UISkinFormat.java
@@ -24,6 +24,7 @@ import org.terasology.nui.UITextureRegion;
 import org.terasology.nui.UIWidget;
 import org.terasology.nui.asset.font.Font;
 import org.terasology.nui.skin.UISkin;
+import org.terasology.nui.skin.UISkinAsset;
 import org.terasology.nui.skin.UISkinBuilder;
 import org.terasology.nui.skin.UISkinData;
 import org.terasology.nui.skin.UIStyleFragment;
@@ -96,7 +97,7 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
                 DefaultInfo defaultInfo = null;
                 defaultInfo = context.deserialize(json, DefaultInfo.class);
                 defaultInfo.apply(builder);
-                return builder.build();
+                return new UISkinData(builder.build());
             }
             return null;
         }
@@ -110,9 +111,9 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
         public void apply(UISkinBuilder builder) {
             super.apply(builder);
             if (inherit != null) {
-                Optional<? extends UISkin> skin = Assets.getAssetHelper().get(new ResourceUrn(inherit), UISkin.class);
+                Optional<? extends UISkinAsset> skin = Assets.getAssetHelper().get(new ResourceUrn(inherit), UISkinAsset.class);
                 if (skin.isPresent()) {
-                    builder.setBaseSkin(skin.get());
+                    builder.setBaseSkin(skin.get().getSkin());
                 }
             }
             if (families != null) {

--- a/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
@@ -27,7 +27,8 @@ import org.destinationsol.util.InjectionHelper;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.input.InputType;
 import org.terasology.input.MouseInput;
-import org.terasology.input.device.KeyboardAction;
+import org.terasology.input.device.CharKeyboardAction;
+import org.terasology.input.device.RawKeyboardAction;
 import org.terasology.input.device.KeyboardDevice;
 import org.terasology.input.device.MouseAction;
 import org.terasology.input.device.MouseDevice;
@@ -40,6 +41,7 @@ import org.terasology.nui.backends.libgdx.LibGDXKeyboardDevice;
 import org.terasology.nui.backends.libgdx.LibGDXMouseDevice;
 import org.terasology.nui.backends.libgdx.NUIInputProcessor;
 import org.terasology.nui.canvas.CanvasImpl;
+import org.terasology.nui.events.NUICharEvent;
 import org.terasology.nui.events.NUIKeyEvent;
 import org.terasology.nui.events.NUIMouseButtonEvent;
 import org.terasology.nui.events.NUIMouseWheelEvent;
@@ -122,7 +124,7 @@ public class NUIManager {
                 commonDrawer.getSpriteBatch(), new ShapeRenderer(), false, true);
         focusManager = new FocusManagerImpl();
         whiteTexture = Assets.getDSTexture(WHITE_TEXTURE_URN).getUiTexture();
-        skin = Assets.getAssetHelper().get(new ResourceUrn(DEFAULT_SKIN_URN), UISkin.class).get();
+        skin = Assets.getSkin(DEFAULT_SKIN_URN);
 
         canvas = new CanvasImpl(canvasRenderer, focusManager, keyboard, mouse, whiteTexture, skin, 100);
         TabbingManager.setFocusManager(focusManager);
@@ -145,11 +147,11 @@ public class NUIManager {
      * @param solApplication the application to use
      */
     public void update(SolApplication solApplication) {
-        canvas.processMousePosition(mouse.getMousePosition());
+        canvas.processMousePosition(mouse.getPosition());
         canvas.setGameTime(System.currentTimeMillis());
 
-        for (KeyboardAction action : keyboard.getInputQueue()) {
-            NUIKeyEvent event = new NUIKeyEvent(mouse, keyboard, action.getInput(), action.getInputChar(), action.getState());
+        for (RawKeyboardAction action : keyboard.getInputQueue()) {
+            NUIKeyEvent event = new NUIKeyEvent(mouse, keyboard, action.getInput(), action.getState());
 
             if (focusManager.getFocus() != null) {
                 focusManager.getFocus().onKeyEvent(event);
@@ -157,6 +159,20 @@ public class NUIManager {
 
             for (NUIScreenLayer uiScreen : uiScreens) {
                 if (uiScreen.onKeyEvent(event) || uiScreen.isBlockingInput() || event.isConsumed()) {
+                    break;
+                }
+            }
+        }
+
+        for (CharKeyboardAction action : keyboard.getCharInputQueue()) {
+            NUICharEvent event = new NUICharEvent(mouse, keyboard, action.getCharacter());
+
+            if (focusManager.getFocus() != null) {
+                focusManager.getFocus().onCharEvent(event);
+            }
+
+            for (NUIScreenLayer uiScreen : uiScreens) {
+                if (uiScreen.onCharEvent(event) || uiScreen.isBlockingInput() || event.isConsumed()) {
                     break;
                 }
             }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request updates the version of NUI used to `3.0.0-SNAPSHOT`. It brings the project back up-to-date with the most recent NUI bugfixes and feature additions. This is the first release of NUI that can operate independently of gestalt (MovingBlocks/TeraNUI#47).

# Testing
The testing for this is mostly the same as that for the initial NUI integration (see #536), apart from that you should not need to clone and locally publish a new version of NUI.

# Notes
- Keyboard input and character input are now separate things in NUI.
- `UISkin` is no longer an asset type and the asset equivalent is `UISkinAsset`. A `UISkinAsset` is not an instance of `UISkin`, however it provides access to one.
