### PR TITLE
Fixed gradle `distZipBundleJREs` and `distZipUnbundledJRE` tasks (game distribution)

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -56,7 +56,7 @@ jar {
     archiveName = "solDesktop.jar"
 
     manifest {
-        def manifestClasspath = configurations.runtime.collect { it.getName() }.join(" ")
+        def manifestClasspath = configurations.runtimeClasspath.collect { it.getName() }.join(" ")
         attributes 'Main-Class': project.mainClassName
         attributes("Class-Path": manifestClasspath)
         attributes "SplashScreen-Image": "mainMenuLogo.png"
@@ -88,7 +88,7 @@ task libsDist(type: Copy) {
     dependsOn jar
 
     from jar
-    from configurations.runtime
+    from configurations.runtimeClasspath
     into("$distsDir/app/libs")
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request fixes distribution creation by using the proper configuration to copy dependency jars from. I would guess that this was missed when updating the project to gradle 6 in #581. Gradle 6 specifies the runtime dependencies in `configurations.runtimeClasspath` instead of `configurations.runtime` (https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations). Before this change, only the `solDesktop` jar was copied into the built distribution. All the other libraries and dependencies were missing, including the actual game code (`sol.jar`).

# Testing
Run the command `gradlew distZipBundleJREs` to create a zipped distribution. Unzip the file `desktop/build/distributions/DestinationSol.zip` and run the game (either using `sol.exe` , any of the `sol[OS].sh` scripts, or `java -jar libs/solDesktop.jar`). The game should run the same as usual.

Run the command `distZipUnbundledJRE`. Unzip the file `desktop/build/distributions/DestinationSol.zip` and run the game (using `java -jar libs/solDesktop.jar`). The game should run the same as usual.