### PR TITLE
Prevent collisions between projectiles from the same ship

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
@@ -320,6 +320,10 @@ public class Projectile implements SolObject {
                 return shield != null && shield.canAbsorb(config.dmgType);
             }
             return true;
+        } else if (object instanceof Projectile) {
+            // Projectiles from the same sources are allowed to overlap
+            Projectile projectile = (Projectile) object;
+            return projectile.ship != this.ship;
         }
 
         return true;


### PR DESCRIPTION
# Description
This pull request adds a check to allow projectiles from the same ship to intersect. Projectiles from another ship should still be destroyed upon collision though.

The ships from the `warp` module seem to rely on this behaviour, whilst the built-in ones can do without it.
# Testing
This issue is most noticable with the warp super-weapon, which can be used with the `quasar` ship. It is noticable to a lesser extent with all warp weapons though, as the projectiles have a large radius.
- Fetch the warp module with `groovy module get warp`
### Warp super-weapon
- Start a new game with the ship `Warp Quasar`
- Wait until the super-weapon has re-charged
- Hold down the left mouse button (Gun 1) to use the super-weapon
- Projectiles should come out of the ship from all directions
### Warp standard projectiles
- Start a new game with the ship `Warp Endeavour`
- Try shooting the left gun followed by the right
- When the projectiles overlap, they should not interact with each other