### PR TITLE
Initial PlanetGenerator Setup

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -334,7 +334,7 @@ public class SolApplication implements ApplicationListener {
 
         solGame.createUpdateSystems(context);
 
-        solGame.startGame(shipName, isNewGame, worldConfig, new SolNames(), entitySystemManager);
+        solGame.startGame(shipName, isNewGame, worldConfig, entitySystemManager);
 
         // Big, fat, ugly HACK to get a working classloader
         // Serialisation and thus a classloader is not needed when there are no components

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -76,7 +76,7 @@ public class GalaxyFiller {
         float stationDist = planet.getDistance() + planet.getFullHeight() + FeatureGenerator.ORBITAL_FEATURE_BUFFER;
         Vector2 stationPos = new Vector2();
         SolMath.fromAl(stationPos, angleToSun, stationDist);
-        stationPos.add(planet.getSystem().getPosition());
+        stationPos.add(planet.getSolarSystemPosition());
         return stationPos;
     }
 
@@ -139,7 +139,7 @@ public class GalaxyFiller {
             return;
         }
         createStarPorts(game);
-        ArrayList<SolarSystem> systems = game.getPlanetManager().getSystems();
+        ArrayList<SolarSystem> systems = game.getWorldBuilder().getBuiltSolarSystems();
 
         JSONObject rootNode = Validator.getValidatedJSON(moduleName + ":startingStation", "engine:schemaStartingStation");
 
@@ -172,10 +172,9 @@ public class GalaxyFiller {
     }
 
     private void createStarPorts(SolGame game) {
-        PlanetManager planetManager = game.getPlanetManager();
         ArrayList<Planet> biggest = new ArrayList<>();
 
-        for (SolarSystem system : planetManager.getSystems()) {
+        for (SolarSystem system : game.getWorldBuilder().getBuiltSolarSystems()) {
             float minHeight = 0;
             Planet biggestPlanet = null;
             int biggestPlanetIndex = -1;

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -33,6 +33,7 @@ public class ShipConfig {
     public final HullConfig hull;
     public final String items;
     public final int money;
+    //TODO: Consider refactoring 'density' to some other name, as it more accurately reflects a probability of ship spawning
     public float density;
     public final ShipConfig guard;
     public final float dps;

--- a/engine/src/main/java/org/destinationsol/game/ShipConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/ShipConfig.java
@@ -33,7 +33,7 @@ public class ShipConfig {
     public final HullConfig hull;
     public final String items;
     public final int money;
-    public final float density;
+    public float density;
     public final ShipConfig guard;
     public final float dps;
     public Vector2 spawnPos;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -182,7 +182,7 @@ public class SolGame {
         beaconHandler = new BeaconHandler();
         solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
         context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
-        planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors,itemManager);
+        planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors, itemManager);
         context.put(PlanetConfigs.class, planetConfigManager);
         worldBuilder = new WorldBuilder(context, worldConfig.getNumberOfSystems());
         context.put(WorldBuilder.class, worldBuilder);
@@ -239,16 +239,18 @@ public class SolGame {
         }
     }
 
-    public void startGame(String shipName, boolean isNewGame, WorldConfig worldConfig, SolNames solNames, EntitySystemManager entitySystemManager) {
+    public void startGame(String shipName, boolean isNewGame, WorldConfig worldConfig, EntitySystemManager entitySystemManager) {
         this.entitySystemManager = entitySystemManager;
 
         respawnState = new RespawnState();
         SolRandom.setSeed(worldConfig.getSeed());
+
         //World Generation will be initiated from here
         worldBuilder.buildWithRandomSolarSystemGenerators();
-        //TODO: Remove the next two lines and associated classes when new world-gen system is running
-        solarSystemConfigManager.loadDefaultSolarSystemConfigs();
-        planetManager.fill(solNames, worldConfig.getNumberOfSystems());
+
+        //Add all the Planets in the game to the PlanetManager TODO: Add mazes, belts, etc. once the are implemented
+        addObjectsToPlanetManager();
+
         createGame(shipName, isNewGame);
 
         if (!isNewGame) {
@@ -265,6 +267,15 @@ public class SolGame {
             }
         }, 0, 30);
         gameScreens.consoleScreen.init(this);
+    }
+
+    private void addObjectsToPlanetManager() {
+        planetManager.getSystems().addAll(worldBuilder.getBuiltSolarSystems());
+        for (SolarSystem system : planetManager.getSystems()) {
+            for (Planet planet : system.getPlanets()) {
+                planetManager.getPlanets().add(planet);
+            }
+        }
     }
 
     public Context getContext() {
@@ -611,6 +622,10 @@ public class SolGame {
 
     public HullConfigManager getHullConfigManager() {
         return hullConfigManager;
+    }
+
+    public WorldBuilder getWorldBuilder() {
+        return worldBuilder;
     }
 
 }

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -161,7 +161,7 @@ public class SolGame {
         itemManager = new ItemManager(soundManager, effectTypes, gameColors);
         AbilityCommonConfigs abilityCommonConfigs = new AbilityCommonConfigs(effectTypes, gameColors, soundManager);
         hullConfigManager = new HullConfigManager(itemManager, abilityCommonConfigs);
-        planetManager = new PlanetManager(hullConfigManager, gameColors, itemManager);
+        planetManager = new PlanetManager();
 
         contactListener = new SolContactListener(this);
         factionManager = new FactionManager();
@@ -183,6 +183,7 @@ public class SolGame {
         solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
         context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
         planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors, itemManager);
+        planetConfigManager.loadDefaultPlanetConfigs();
         context.put(PlanetConfigs.class, planetConfigManager);
         worldBuilder = new WorldBuilder(context, worldConfig.getNumberOfSystems());
         context.put(WorldBuilder.class, worldBuilder);

--- a/engine/src/main/java/org/destinationsol/game/chunk/ChunkFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/chunk/ChunkFiller.java
@@ -151,6 +151,8 @@ public class ChunkFiller {
             }
             return Optional.of(system.getConfig().envConfig);
         }
+        //TODO: Uncomment this section when there are mazes added to the SolarSystem
+        /*
         Maze maze = planetManager.getNearestMaze(chunkCenter);
         float distanceToMaze = maze.getPos().dst(chunkCenter);
         float zoneRadius = maze.getRadius() + MAZE_ZONE_BORDER;
@@ -158,6 +160,8 @@ public class ChunkFiller {
             densityMultiplier[0] = 1 - distanceToMaze / zoneRadius;
             return Optional.of(maze.getConfig().envConfig);
         }
+        */
+
         return Optional.empty();
     }
 

--- a/engine/src/main/java/org/destinationsol/game/input/BigObjAvoider.java
+++ b/engine/src/main/java/org/destinationsol/game/input/BigObjAvoider.java
@@ -52,7 +52,7 @@ public class BigObjAvoider {
                 result = angleToDestination + 45 * SolMath.toInt(myProj.y < 0);
             }
         }
-        Vector2 sunPos = planet.getSystem().getPosition();
+        Vector2 sunPos = planet.getSolarSystemPosition();
         float sunRad = SunGenerator.SUN_RADIUS;
         myProj.set(sunPos);
         myProj.sub(from);

--- a/engine/src/main/java/org/destinationsol/game/planet/CloudBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/CloudBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.planet;
+
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class keeps track of the variables which are taken into account when placing clouds (or other floating decorations
+ * onto a Planet. These values are used by {@link PlanetObjectsBuilder} to create the actual objects that decorate
+ * a Planet.
+ */
+public class CloudBuilder {
+    private final List<TextureAtlas.AtlasRegion> cloudTextures = new ArrayList<>();
+    //Frequency at which clouds will generate
+    private float cloudDensity;
+    //The lowest point (in terms of percentage of the atmosphere) that clouds will generate at
+    private float atmosphereStartingPercentage;
+    //The highest point (in terms of percentage of the atmosphere) that clouds will generate at
+    private float atmosphereEndingPercentage;
+    //The smallest width (in terms of percentage of the default width) that a cloud will generate with
+    private float cloudWidthStartingPercentage;
+    //The largest width (in terms of percentage of the default width) that a cloud will generate with
+    private float cloudWidthEndingPercentage;
+
+    public CloudBuilder(List<TextureAtlas.AtlasRegion> cloudTextures, float cloudDensity,
+                        float atmosphereStartingPercentage, float atmosphereEndingPercentage,
+                        float cloudWidthStartingPercentage, float cloudWidthEndingPercentage) {
+        this.cloudTextures.addAll(cloudTextures);
+        this.cloudDensity = cloudDensity;
+        this.atmosphereStartingPercentage = atmosphereStartingPercentage;
+        this.atmosphereEndingPercentage = atmosphereEndingPercentage;
+        this.cloudWidthStartingPercentage = cloudWidthStartingPercentage;
+        this.cloudWidthEndingPercentage = cloudWidthEndingPercentage;
+    }
+
+    public float getAtmosphereStartingPercentage() {
+        return atmosphereStartingPercentage;
+    }
+
+    public void setAtmosphereStartingPercentage(float atmosphereStartingPercentage) {
+        this.atmosphereStartingPercentage = atmosphereStartingPercentage;
+    }
+
+    public float getAtmosphereEndingPercentage() {
+        return atmosphereEndingPercentage;
+    }
+
+    public void setAtmosphereEndingPercentage(float atmosphereEndingPercentage) {
+        this.atmosphereEndingPercentage = atmosphereEndingPercentage;
+    }
+
+    public float getCloudWidthStartingPercentage() {
+        return cloudWidthStartingPercentage;
+    }
+
+    public void setCloudWidthStartingPercentage(float cloudWidthStartingPercentage) {
+        this.cloudWidthStartingPercentage = cloudWidthStartingPercentage;
+    }
+
+    public float getCloudWidthEndingPercentage() {
+        return cloudWidthEndingPercentage;
+    }
+
+    public void setCloudWidthEndingPercentage(float cloudWidthEndingPercentage) {
+        this.cloudWidthEndingPercentage = cloudWidthEndingPercentage;
+    }
+
+    public float getCloudDensity() {
+        return cloudDensity;
+    }
+
+    public void setCloudDensity(float cloudDensity) {
+        this.cloudDensity = cloudDensity;
+    }
+
+    public List<TextureAtlas.AtlasRegion> getCloudTextures() {
+        return cloudTextures;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/planet/CloudBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/CloudBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,15 +27,20 @@ import java.util.List;
  */
 public class CloudBuilder {
     private final List<TextureAtlas.AtlasRegion> cloudTextures = new ArrayList<>();
-    //Frequency at which clouds will generate
+
+    /** Frequency at which clouds will generate */
     private float cloudDensity;
-    //The lowest point (in terms of percentage of the atmosphere) that clouds will generate at
+
+    /** The lowest point (in terms of percentage of the atmosphere) that clouds will generate at */
     private float atmosphereStartingPercentage;
-    //The highest point (in terms of percentage of the atmosphere) that clouds will generate at
+
+    /** The highest point (in terms of percentage of the atmosphere) that clouds will generate at */
     private float atmosphereEndingPercentage;
-    //The smallest width (in terms of percentage of the default width) that a cloud will generate with
+
+    /** The smallest width (in terms of percentage of the default width) that a cloud will generate with */
     private float cloudWidthStartingPercentage;
-    //The largest width (in terms of percentage of the default width) that a cloud will generate with
+
+    /**The largest width (in terms of percentage of the default width) that a cloud will generate with */
     private float cloudWidthEndingPercentage;
 
     public CloudBuilder(List<TextureAtlas.AtlasRegion> cloudTextures, float cloudDensity,

--- a/engine/src/main/java/org/destinationsol/game/planet/OrbitEnemiesBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/OrbitEnemiesBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.planet;
+
+import org.destinationsol.game.ShipConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class keeps track of the variables which are taken into account when placing various types of ships within the
+ * orbit of a Planet. These values are used by {@link PlanetObjectsBuilder} to create the actual ships that are on
+ * a Planet. This class keeps track specifically of variables which affect the entire category of Orbit Enemies. Other
+ * variables, such ship density (how many of the ships are places), are dependent on the specific ShipConfig,
+ * and so are held within the list of ShipConfigs.
+ */
+public class OrbitEnemiesBuilder {
+    private ArrayList<ShipConfig> orbitEnemies = new ArrayList<>();
+    //Offset Percentage represents how far apart enemies should be made, in terms of circumference of the planet
+    float offsetPercentage;
+    float atmospherePercentage;
+    float detectionDist;
+
+    public OrbitEnemiesBuilder(List<ShipConfig> orbitEnemies, float offsetPercentage, float atmospherePercentage, float detectionDistance) {
+        this.orbitEnemies.addAll(orbitEnemies);
+        this.offsetPercentage = offsetPercentage;
+        this.atmospherePercentage = atmospherePercentage;
+        this.detectionDist = detectionDistance;
+    }
+
+    public ArrayList<ShipConfig> getOrbitEnemies() {
+        return orbitEnemies;
+    }
+
+    public float getOffsetPercentage() {
+        return offsetPercentage;
+    }
+
+    public void setOffsetPercentage(float offsetPercentage) {
+        this.offsetPercentage = offsetPercentage;
+    }
+
+    public float getAtmospherePercentage() {
+        return atmospherePercentage;
+    }
+
+    public void setAtmospherePercentage(float atmospherePercentage) {
+        this.atmospherePercentage = atmospherePercentage;
+    }
+
+    public float getDetectionDist() {
+        return detectionDist;
+    }
+
+    public void setDetectionDist(float detectionDist) {
+        this.detectionDist = detectionDist;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/planet/OrbitalEnemiesBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/OrbitalEnemiesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,26 +23,27 @@ import java.util.List;
 /**
  * This class keeps track of the variables which are taken into account when placing various types of ships within the
  * orbit of a Planet. These values are used by {@link PlanetObjectsBuilder} to create the actual ships that are on
- * a Planet. This class keeps track specifically of variables which affect the entire category of Orbit Enemies. Other
+ * a Planet. This class keeps track specifically of variables which affect the entire category of Orbital Enemies. Other
  * variables, such ship density (how many of the ships are places), are dependent on the specific ShipConfig,
  * and so are held within the list of ShipConfigs.
  */
-public class OrbitEnemiesBuilder {
-    private ArrayList<ShipConfig> orbitEnemies = new ArrayList<>();
+public class OrbitalEnemiesBuilder {
+    private ArrayList<ShipConfig> orbitalEnemies = new ArrayList<>();
     //Offset Percentage represents how far apart enemies should be made, in terms of circumference of the planet
-    float offsetPercentage;
-    float atmospherePercentage;
-    float detectionDist;
+    private float offsetPercentage;
+    //TODO: Change atmosphere percentage to something more understandable, like height
+    private float atmospherePercentage;
+    private float detectionDistance;
 
-    public OrbitEnemiesBuilder(List<ShipConfig> orbitEnemies, float offsetPercentage, float atmospherePercentage, float detectionDistance) {
-        this.orbitEnemies.addAll(orbitEnemies);
+    public OrbitalEnemiesBuilder(List<ShipConfig> orbitalEnemies, float offsetPercentage, float atmospherePercentage, float detectionDistance) {
+        this.orbitalEnemies.addAll(orbitalEnemies);
         this.offsetPercentage = offsetPercentage;
         this.atmospherePercentage = atmospherePercentage;
-        this.detectionDist = detectionDistance;
+        this.detectionDistance = detectionDistance;
     }
 
-    public ArrayList<ShipConfig> getOrbitEnemies() {
-        return orbitEnemies;
+    public ArrayList<ShipConfig> getOrbitalEnemies() {
+        return orbitalEnemies;
     }
 
     public float getOffsetPercentage() {
@@ -61,11 +62,11 @@ public class OrbitEnemiesBuilder {
         this.atmospherePercentage = atmospherePercentage;
     }
 
-    public float getDetectionDist() {
-        return detectionDist;
+    public float getDetectionDistance() {
+        return detectionDistance;
     }
 
-    public void setDetectionDist(float detectionDist) {
-        this.detectionDist = detectionDist;
+    public void setDetectionDistance(float detectionDistance) {
+        this.detectionDistance = detectionDistance;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/planet/Planet.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/Planet.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Planet {
-    private final SolarSystem system;
+    private final Vector2 solarSystemPosition;
     private final Vector2 position;
     private final float distance;
     private final float rotationSpeedInSystem;
@@ -46,9 +46,9 @@ public class Planet {
     private float minGroundHeight;
     private Vector2 velocity;
 
-    public Planet(SolarSystem sys, float angleToSys, float dist, float angle, float toSysRotationSpeed, float rotationSpeed,
+    public Planet(Vector2 solarSystemPosition, float angleToSys, float dist, float angle, float toSysRotationSpeed, float rotationSpeed,
                   float groundHeight, boolean objsCreated, PlanetConfig config, String name) {
-        system = sys;
+        this.solarSystemPosition = solarSystemPosition;
         angleInSystem = angleToSys;
         distance = dist;
         this.angle = angle;
@@ -84,7 +84,7 @@ public class Planet {
 
     private void setSecondaryParams() {
         SolMath.fromAl(position, angleInSystem, distance);
-        position.add(system.getPosition());
+        position.add(solarSystemPosition);
         float speed = SolMath.angleToArc(rotationSpeedInSystem, distance);
         float velocityAngle = angleInSystem + 90;
         SolMath.fromAl(velocity, velocityAngle, speed);
@@ -113,8 +113,8 @@ public class Planet {
         return groundHeight;
     }
 
-    public SolarSystem getSystem() {
-        return system;
+    public Vector2 getSolarSystemPosition() {
+        return solarSystemPosition;
     }
 
     @Bound

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetConfig.java
@@ -16,6 +16,7 @@
 package org.destinationsol.game.planet;
 
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import org.destinationsol.Const;
 import org.destinationsol.assets.Assets;
 import org.destinationsol.files.HullConfigManager;
 import org.destinationsol.game.GameColors;
@@ -44,6 +45,10 @@ public class PlanetConfig {
     public final TradeConfig tradeConfig;
     public final boolean hardOnly;
     public final boolean easyOnly;
+    //These 'builder' classes allow custom World Generators to modify values used when placing objects on the planet
+    public final OrbitEnemiesBuilder lowOrbitEnemiesBuilder;
+    public final OrbitEnemiesBuilder highOrbitEnemiesBuilder;
+    public final CloudBuilder cloudBuilder;
 
     public PlanetConfig(String configName, float minGrav, float maxGrav, List<DecoConfig> deco, List<ShipConfig> groundEnemies,
                         List<ShipConfig> highOrbitEnemies, List<ShipConfig> lowOrbitEnemies, List<TextureAtlas.AtlasRegion> cloudTextures,
@@ -66,6 +71,9 @@ public class PlanetConfig {
         this.hardOnly = hardOnly;
         this.easyOnly = easyOnly;
         this.moduleName = moduleName;
+        this.cloudBuilder = new CloudBuilder(cloudTextures, .2f, 0f, 1f, .2f, 1f);
+        this.lowOrbitEnemiesBuilder = new OrbitEnemiesBuilder(lowOrbitEnemies, 0, .1f, Const.AUTO_SHOOT_SPACE);
+        this.highOrbitEnemiesBuilder = new OrbitEnemiesBuilder(highOrbitEnemies, .1f, .6f, Const.AI_DET_DIST);
     }
 
     static PlanetConfig load(String name, JSONObject rootNode, HullConfigManager hullConfigs, GameColors cols, ItemManager itemManager, String moduleName) {

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetConfig.java
@@ -46,8 +46,8 @@ public class PlanetConfig {
     public final boolean hardOnly;
     public final boolean easyOnly;
     //These 'builder' classes allow custom World Generators to modify values used when placing objects on the planet
-    public final OrbitEnemiesBuilder lowOrbitEnemiesBuilder;
-    public final OrbitEnemiesBuilder highOrbitEnemiesBuilder;
+    public final OrbitalEnemiesBuilder lowOrbitalEnemiesBuilder;
+    public final OrbitalEnemiesBuilder highOrbitalEnemiesBuilder;
     public final CloudBuilder cloudBuilder;
 
     public PlanetConfig(String configName, float minGrav, float maxGrav, List<DecoConfig> deco, List<ShipConfig> groundEnemies,
@@ -72,8 +72,8 @@ public class PlanetConfig {
         this.easyOnly = easyOnly;
         this.moduleName = moduleName;
         this.cloudBuilder = new CloudBuilder(cloudTextures, .2f, 0f, 1f, .2f, 1f);
-        this.lowOrbitEnemiesBuilder = new OrbitEnemiesBuilder(lowOrbitEnemies, 0, .1f, Const.AUTO_SHOOT_SPACE);
-        this.highOrbitEnemiesBuilder = new OrbitEnemiesBuilder(highOrbitEnemies, .1f, .6f, Const.AI_DET_DIST);
+        this.lowOrbitalEnemiesBuilder = new OrbitalEnemiesBuilder(lowOrbitEnemies, 0, .1f, Const.AUTO_SHOOT_SPACE);
+        this.highOrbitalEnemiesBuilder = new OrbitalEnemiesBuilder(highOrbitEnemies, .1f, .6f, Const.AI_DET_DIST);
     }
 
     static PlanetConfig load(String name, JSONObject rootNode, HullConfigManager hullConfigs, GameColors cols, ItemManager itemManager, String moduleName) {

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetConfigs.java
@@ -68,6 +68,11 @@ public class PlanetConfigs {
         return allConfigs.get(name);
     }
 
+    /**
+     * This determines whether the planet gets an easy, hard, or medium config. If easy is true, it will be an easy planet.
+     * If easy is false but hard is true, it will be a hard planet. Else, it will be a medium planet. If both are true,
+     * it will be easy
+     */
     public PlanetConfig getRandom(boolean easy, boolean hard) {
         List<PlanetConfig> cfg = easy ? this.easy : hard ? this.hard : medium;
         return SolRandom.seededRandomElement(cfg);

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetManager.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetManager.java
@@ -43,7 +43,7 @@ import java.util.List;
 
 public class PlanetManager implements UpdateAwareSystem {
     private final ArrayList<SolarSystem> systems;
-    private final ArrayList<Planet> planets;
+    private ArrayList<Planet> planets;
     private final ArrayList<SystemBelt> belts;
     private final FlatPlaceFinder flatPlaceFinder;
     private final PlanetConfigs planetConfigs;
@@ -266,4 +266,5 @@ public class PlanetManager implements UpdateAwareSystem {
     public void drawPlanetCoreHack(SolGame game, GameDrawer drawer, Context context) {
         planetCoreSingleton.draw(game, drawer, context);
     }
+
 }

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetManager.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetManager.java
@@ -43,25 +43,15 @@ import java.util.List;
 
 public class PlanetManager implements UpdateAwareSystem {
     private final ArrayList<SolarSystem> systems;
-    private ArrayList<Planet> planets;
+    private final ArrayList<Planet> planets;
     private final ArrayList<SystemBelt> belts;
     private final FlatPlaceFinder flatPlaceFinder;
-    private final PlanetConfigs planetConfigs;
-    private final MazeConfigs mazeConfigs;
     private final ArrayList<Maze> mazes;
     private final SunSingleton sunSingleton;
-    private final SolarSystemConfigManager solarSystemConfigManager;
-    private final BeltConfigManager beltConfigManager;
     private final PlanetCoreSingleton planetCoreSingleton;
     private Planet nearestPlanet;
 
-    public PlanetManager(HullConfigManager hullConfigs, GameColors cols,
-                            ItemManager itemManager) {
-        planetConfigs = new PlanetConfigs(hullConfigs, cols, itemManager);
-        solarSystemConfigManager = new SolarSystemConfigManager(hullConfigs, itemManager);
-        beltConfigManager = new BeltConfigManager(hullConfigs, itemManager);
-        mazeConfigs = new MazeConfigs(hullConfigs, itemManager);
-
+    public PlanetManager() {
         systems = new ArrayList<>();
         mazes = new ArrayList<>();
         planets = new ArrayList<>();
@@ -69,11 +59,6 @@ public class PlanetManager implements UpdateAwareSystem {
         flatPlaceFinder = new FlatPlaceFinder();
         sunSingleton = new SunSingleton();
         planetCoreSingleton = new PlanetCoreSingleton();
-    }
-
-    public void fill(SolNames names, int numberOfSystems) {
-        new SystemsBuilder().build(systems, planets, belts, planetConfigs, mazeConfigs, mazes, solarSystemConfigManager,
-                beltConfigManager, names, numberOfSystems);
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/planet/Sky.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/Sky.java
@@ -84,7 +84,7 @@ public class Sky implements SolObject {
             distPercentage = 1;
         }
 
-        Vector2 sysPos = planet.getSystem().getPosition();
+        Vector2 sysPos = planet.getSolarSystemPosition();
         float angleToCam = SolMath.angle(planetPos, camPos);
         float angleToSun = SolMath.angle(planetPos, sysPos);
         float dayPercentage = 1 - SolMath.angleDiff(angleToCam, angleToSun) / 180;

--- a/engine/src/main/java/org/destinationsol/game/planet/SystemsBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/SystemsBuilder.java
@@ -188,6 +188,6 @@ public class SystemsBuilder {
         float toSysRotationSpeed = SolMath.arcToAngle(PLANET_SPD, planetDist) * SolMath.toInt(SolRandom.seededTest(.5f));
         float rotationSpeed = SolMath.arcToAngle(GROUND_SPD, groundHeight) * SolMath.toInt(SolRandom.seededTest(.5f));
         String name = SolRandom.seededRandomElement(names.planets.get(planetConfig.moduleName));
-        return new Planet(s, SolRandom.seededRandomFloat(180), planetDist, SolRandom.seededRandomFloat(180), toSysRotationSpeed, rotationSpeed, groundHeight, false, planetConfig, name);
+        return new Planet(s.getPosition(), SolRandom.seededRandomFloat(180), planetDist, SolRandom.seededRandomFloat(180), toSysRotationSpeed, rotationSpeed, groundHeight, false, planetConfig, name);
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/Orbital.java
+++ b/engine/src/main/java/org/destinationsol/world/Orbital.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/world/WorldBuilder.java
+++ b/engine/src/main/java/org/destinationsol/world/WorldBuilder.java
@@ -39,6 +39,7 @@ import java.util.List;
  */
 public class WorldBuilder {
     private static final Logger logger = LoggerFactory.getLogger(WorldBuilder.class);
+    private static final float MAX_WORLD_RADIUS = 1_000_000_000f;
     //These ArrayLists hold class types of any class which extends SolarSystemGenerator or FeatureGenerator, respectively
     private ArrayList<Class<? extends SolarSystemGenerator>> solarSystemGeneratorTypes = new ArrayList<>();
     private ArrayList<Class<? extends FeatureGenerator>> featureGeneratorTypes = new ArrayList<>();
@@ -54,6 +55,7 @@ public class WorldBuilder {
         this.context = context;
         this.moduleManager = context.get(ModuleManager.class);
         this.solarSystemConfigManager = context.get(SolarSystemConfigManager.class);
+        solarSystemConfigManager.loadDefaultSolarSystemConfigs();
         numberOfSystems = numSystems;
         populateSolarSystemGeneratorList();
         populateFeatureGeneratorList();
@@ -108,6 +110,7 @@ public class WorldBuilder {
             Class<? extends SolarSystemGenerator> solarSystemGenerator = solarSystemGeneratorTypes.get(SolRandom.seededRandomInt(solarSystemGeneratorTypes.size()));
             try {
                 SolarSystemGenerator generator = solarSystemGenerator.newInstance();
+                generator.setContext(context);
                 generator.setFeatureGeneratorTypes(featureGeneratorTypes);
                 generator.setSolarSystemConfigManager(solarSystemConfigManager);
                 generator.setSolarSystemNumber(i);
@@ -125,7 +128,12 @@ public class WorldBuilder {
      */
     private void positionSolarSystems() {
         for (SolarSystemGenerator generator : activeSolarSystemGenerators) {
-            calculateSolarSystemPosition(activeSolarSystemGenerators, generator, generator.getRadius());
+            try {
+                calculateSolarSystemPosition(activeSolarSystemGenerators, generator, generator.getRadius());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
             //Printout of generator position for testing (as these positions don't have a representation in the game yet)
             logger.info(generator + " position: " + generator.getPosition().x + ", " + generator.getPosition().y);
         }
@@ -146,12 +154,12 @@ public class WorldBuilder {
      * a SolarSystem there will not cause it to overlap with any others.
      * TODO Implement logic to allow system to be positioned within a particular annulus
      */
-    private void calculateSolarSystemPosition(List<SolarSystemGenerator> systems, SolarSystemGenerator solarSystemGenerator, float bodyRadius) {
+    private void calculateSolarSystemPosition(List<SolarSystemGenerator> systems, SolarSystemGenerator solarSystemGenerator, float bodyRadius) throws Exception {
         Vector2 result = SolMath.getVec();
         float distance = 0;
-        int counter = 0;
-        //This loop should find a position for the SolarSystem well before the counter reaches 400
-        while (counter < 400) {
+        float counter = 0;
+        //This loop should find a position for the SolarSystem well before the counter reaches 1,000,000,000
+        while (counter < MAX_WORLD_RADIUS) {
             //test 20 spots at each radius
             for (int i = 0; i < 20; i++) {
                 calculateRandomWorldPositionAtDistance(result, distance);
@@ -167,6 +175,7 @@ public class WorldBuilder {
             counter++;
         }
         SolMath.free(result);
+        throw new RuntimeException("Could not find position for SolarSystem");
     }
 
     private boolean isPositionAvailable(List<SolarSystemGenerator> systems, float bodyRadius, Vector2 result) {

--- a/engine/src/main/java/org/destinationsol/world/generators/LargeSolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/LargeSolarSystemGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/world/generators/LargeSolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/LargeSolarSystemGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Terasology Foundation
+ * Copyright 2020 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,8 @@ import org.destinationsol.game.planet.SolarSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * This class is a concrete implementation of a SolarSystemGenerator and handles creation of elements
- * specific to this type of SolarSystem (such as how many Planets to generate, how large to make
- * the SolarSystem, etc).
- * <p>
- * This class also has access to the featureGenerators list from {@link SolarSystemGenerator}.
- * This allows it to choose which FeatureGenerators to use in populating the SolarSystem.
- * TODO: Define the behavior of default SolarSystems in this class (As it is implemented in the game currently)
- */
-public class SolarSystemGeneratorImpl extends SolarSystemGenerator {
-    private static final Logger logger = LoggerFactory.getLogger(SolarSystemGeneratorImpl.class);
-
-    @Override
-    public SolarSystemSize getSolarSystemSize() {
-        return SolarSystemSize.MEDIUM;
-    }
-
-    @Override
-    public int getCustomFeaturesCount() {
-        return 0;
-    }
+public class LargeSolarSystemGenerator extends SolarSystemGenerator {
+    private static final Logger logger = LoggerFactory.getLogger(LargeSolarSystemGenerator.class);
 
     @Override
     public SolarSystem build() {
@@ -60,5 +41,15 @@ public class SolarSystemGeneratorImpl extends SolarSystemGenerator {
         }
 
         return createBuiltSolarSystem();
+    }
+
+    @Override
+    public SolarSystemSize getSolarSystemSize() {
+        return SolarSystemSize.LARGE;
+    }
+
+    @Override
+    public int getCustomFeaturesCount() {
+        return 0;
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/PlanetGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/PlanetGenerator.java
@@ -16,22 +16,30 @@
 package org.destinationsol.world.generators;
 
 import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.common.SolMath;
+import org.destinationsol.common.SolRandom;
+import org.destinationsol.game.ShipConfig;
 import org.destinationsol.game.SolNames;
+import org.destinationsol.game.planet.DecoConfig;
 import org.destinationsol.game.planet.Planet;
 import org.destinationsol.game.planet.PlanetConfig;
 import org.destinationsol.game.planet.PlanetConfigs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * This class defines the general behavior for Planet generators (such as ground, sky, gravity, etc). Any Planet will be
  * created from a concrete implementation of this class, with behavior specific to that Planet defined there.
- * TODO: Implement behavior common to all Planets as concrete methods in this class
  */
 public abstract class PlanetGenerator extends FeatureGenerator {
     public static final float PLANET_MAX_DIAMETER = 78f;
-    protected static final float DEFAULT_MAX_GROUND_HEIGHT = 25f;
-    protected static final float DEFAULT_ATMOSPHERE_HEIGHT = 14f;
     public static final float PLANET_SPEED = .2f;
     public static final float PLANET_GROUND_SPEED = .2f;
+    protected static final float DEFAULT_MAX_GROUND_HEIGHT = 25f;
+    protected static final float DEFAULT_ATMOSPHERE_HEIGHT = 14f;
+    private static final Logger logger = LoggerFactory.getLogger(PlanetGenerator.class);
     protected SolNames solNames = new SolNames();
     private Planet planet;
     private Vector2 solarSystemPosition = new Vector2();
@@ -45,7 +53,6 @@ public abstract class PlanetGenerator extends FeatureGenerator {
     private float angleInSolarSystem;
     private float distanceFromSolarSystemCenter;
     private float initialPlanetAngle;
-
     //This is the speed the Planet orbits around the SolarSystem at
     private float orbitSolarSystemSpeed;
     //This is the speed the Planet spins around it's axis at
@@ -73,6 +80,178 @@ public abstract class PlanetGenerator extends FeatureGenerator {
     protected PlanetConfig getPlanetConfigDefaultSettings() {
         return getPlanetConfigManager().getRandom(!getIsInnerPlanet() && getIsInFirstSolarSystem(),
                 getIsInnerPlanet() && !getIsInFirstSolarSystem());
+    }
+
+    /**
+     * This calculates the proper speed for a planet to orbit around the center of the SolarSystem. It is randomized
+     * slightly, so not all planets orbit at the same speed.
+     * @return float representing orbit speed
+     */
+    protected float calculateDefaultPlanetOrbitSpeed() {
+        return SolMath.arcToAngle(PLANET_SPEED, getDistanceFromSolarSystemCenter()) * SolMath.toInt(SolRandom.seededTest(.5f));
+    }
+
+    /**
+     * This calculates the proper speed for a planet to rotate around its axis. It is randomized slightly, so not all
+     * planets rotate at the same speed.
+     * @return float representing rotation speed
+     */
+    protected float calculateDefaultPlanetRotationSpeed() {
+        return SolMath.arcToAngle(PLANET_GROUND_SPEED, getGroundHeight()) * SolMath.toInt(SolRandom.seededTest(.5f));
+    }
+
+    /**
+     * This method modifies the density of low orbit ships that generate on the Planet. The density represents how
+     * frequently the ships spawn
+     * @param densityMultiplier amount by which the current density should be multiplied. Must be at least 0
+     */
+    protected void modifyLowOrbitShipsDensity(float densityMultiplier) {
+        if (densityMultiplier >= 0) {
+            for (ShipConfig shipConfig : getPlanetConfig().lowOrbitEnemies) {
+                shipConfig.density *= densityMultiplier;
+            }
+        } else {
+            logger.error("Ship density multiplier must be at least 0");
+        }
+    }
+
+    /**
+     * This method modifies the density of high orbit ships that generate on the Planet. The density represents how
+     * frequently the ships spawn
+     * @param densityMultiplier amount by which the current density should be multiplied. Must be at least 0
+     */
+    protected void modifyHighOrbitShipsDensity(float densityMultiplier) {
+        if (densityMultiplier >= 0) {
+            for (ShipConfig shipConfig : getPlanetConfig().highOrbitEnemies) {
+                shipConfig.density *= densityMultiplier;
+            }
+        } else {
+            logger.error("Ship density multiplier must be at least 0");
+        }
+    }
+
+    /**
+     * This method modifies the density of ground enemies (turrets) that generate on the Planet. The density represents how
+     * frequently the turrets spawn
+     * @param densityMultiplier amount by which the current density should be multiplied. Must be at least 0
+     */
+    protected void modifyGroundEnemiesDensity(float densityMultiplier) {
+        if (densityMultiplier >= 0) {
+            for (ShipConfig shipConfig : getPlanetConfig().groundEnemies) {
+                shipConfig.density *= densityMultiplier;
+            }
+        } else {
+            logger.error("Ship density multiplier must be at least 0");
+        }
+    }
+
+    /**
+     * This method modifies the percentage of the atmosphere at which low orbit ships start spawning.
+     * @param atmospherePercentageMultiplier amount by which the current atmosphere percentage should be multiplied
+     */
+    protected void modifyLowOrbitShipsAtmospherePercentage(float atmospherePercentageMultiplier) {
+        getPlanetConfig().lowOrbitEnemiesBuilder.setAtmospherePercentage(
+                getPlanetConfig().lowOrbitEnemiesBuilder.getAtmospherePercentage() * atmospherePercentageMultiplier);
+    }
+
+    /**
+     * This method modifies the percentage of the atmosphere at which high orbit ships start spawning.
+     * @param atmospherePercentageMultiplier amount by which the current atmosphere percentage should be multiplied
+     */
+    protected void modifyHighOrbitShipsAtmospherePercentage(float atmospherePercentageMultiplier) {
+        getPlanetConfig().highOrbitEnemiesBuilder.setAtmospherePercentage(
+                getPlanetConfig().highOrbitEnemiesBuilder.getAtmospherePercentage() * atmospherePercentageMultiplier);
+    }
+
+    /**
+     * This method modifies the distance from which low orbit ships will detect a player
+     * @param detectionDistanceMultiplier amount by which the current detection distance should be multiplied
+     */
+    protected void modifyLowOrbitShipsDetectionDistance(float detectionDistanceMultiplier) {
+        getPlanetConfig().lowOrbitEnemiesBuilder.setDetectionDist(
+                getPlanetConfig().lowOrbitEnemiesBuilder.getDetectionDist() * detectionDistanceMultiplier);
+    }
+
+    /**
+     * This method modifies the distance from which high orbit ships will detect a player
+     * @param detectionDistanceMultiplier amount by which the current detection distance should be multiplied
+     */
+    protected void modifyHighOrbitShipsDetectionDistance(float detectionDistanceMultiplier) {
+        getPlanetConfig().highOrbitEnemiesBuilder.setDetectionDist(
+                getPlanetConfig().highOrbitEnemiesBuilder.getDetectionDist() * detectionDistanceMultiplier);
+    }
+
+    /**
+     * This method modifies the density of clouds that generate above the Planet. The density represents how
+     * frequently the clouds spawn
+     * @param cloudDensityMultiplier amount by which the current density should be multiplied. Must be at least 0
+     */
+    protected void modifyCloudDensity(float cloudDensityMultiplier) {
+        if (cloudDensityMultiplier >= 0) {
+            getPlanetConfig().cloudBuilder.setCloudDensity(
+                    getPlanetConfig().cloudBuilder.getCloudDensity() * cloudDensityMultiplier);
+        } else {
+            logger.error("Cloud density multiplier must be at least 0");
+        }
+    }
+
+    /**
+     * This method modifies the percentage of the atmosphere at which clouds start spawning.
+     * @param startingAtmospherePercentage the height at which clouds should start spawning
+     */
+    protected void setCloudsStartingAtmospherePercentage(float startingAtmospherePercentage) {
+        if (startingAtmospherePercentage >= 0 && startingAtmospherePercentage < 1) {
+            getPlanetConfig().cloudBuilder.setAtmosphereStartingPercentage(startingAtmospherePercentage);
+        } else {
+            logger.error("Starting atmosphere percentage for clouds must be at least 0 and less than 1");
+        }
+    }
+
+    /**
+     * This method modifies the percentage of the atmosphere at which clouds stop spawning.
+     * @param endingAtmospherePercentage the height at which clouds should stop spawning
+     */
+    protected void setCloudsEndingAtmospherePercentage(float endingAtmospherePercentage) {
+        if (endingAtmospherePercentage >= 0 && endingAtmospherePercentage < 1) {
+            getPlanetConfig().cloudBuilder.setAtmosphereEndingPercentage(endingAtmospherePercentage);
+        } else {
+            logger.error("Ending atmosphere percentage for clouds must be at least 0 and less than 1");
+        }
+    }
+
+    /**
+     * This method sets the smallest width that a cloud should spawn with, in terms of percentage of the
+     * default width.
+     * @param startingWidthPercentage the lowest percentage width a cloud will spawn with
+     */
+    protected void setCloudsWidthStartingPercentage(float startingWidthPercentage) {
+        if (startingWidthPercentage >= 0) {
+            getPlanetConfig().cloudBuilder.setCloudWidthStartingPercentage(startingWidthPercentage);
+        } else {
+            logger.error("Starting width percentage for clouds must be at least 0");
+        }
+    }
+
+    /**
+     * This method sets the largest width that a cloud should spawn with, in terms of percentage of the
+     * default width.
+     * @param endingWidthPercentage the largest percentage width a cloud will spawn with
+     */
+    protected void setCloudsWidthEndingPercentage(float endingWidthPercentage) {
+        if (endingWidthPercentage >= 0) {
+            getPlanetConfig().cloudBuilder.setCloudWidthEndingPercentage(endingWidthPercentage);
+        } else {
+            logger.error("Ending width percentage for clouds must be at least 0");
+        }
+    }
+
+    /**
+     * This allows access to the decoration config files of the Planet. Modifying these allows for changing the look
+     * of decorations without making an entire new Planet config
+     * @return the Planet's decoration config list
+     */
+    protected List<DecoConfig> getDecorationConfigs() {
+        return planetConfig.deco;
     }
 
     public void setAtmosphereHeight(float atmosphereHeight) {
@@ -159,8 +338,10 @@ public abstract class PlanetGenerator extends FeatureGenerator {
         this.solarSystemPosition.set(solarSystemPosition);
     }
 
-
-
+    /**
+     * Sets the speed the planet will rotate around its axis.
+     * @param planetRotationSpeed rotation speed
+     */
     public void setPlanetRotationSpeed(float planetRotationSpeed) {
         this.planetRotationSpeed = planetRotationSpeed;
     }
@@ -169,6 +350,10 @@ public abstract class PlanetGenerator extends FeatureGenerator {
         return planetRotationSpeed;
     }
 
+    /**
+     * Sets the speed the planet will orbit around the center of the SolarSystem.
+     * @param orbitSolarSystemSpeed orbit speed
+     */
     public void setOrbitSolarSystemSpeed(float orbitSolarSystemSpeed) {
         this.orbitSolarSystemSpeed = orbitSolarSystemSpeed;
     }

--- a/engine/src/main/java/org/destinationsol/world/generators/PlanetGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/PlanetGenerator.java
@@ -61,20 +61,17 @@ public abstract class PlanetGenerator extends FeatureGenerator {
     private PlanetConfigs planetConfigManager;
 
     /**
-     * This method sets the planet variable for the PlanetGenerator. It should be called at the end of the build() method,
-     * after the settings of the planet have been set.
+     * This method sets the Planet variable for the PlanetGenerator. It should be called at the end of the build() method,
+     * after the settings of the planet have been set. This Planet be used after the world-gen phase in the runtime code.
      */
-    protected void createPlanet() {
+    protected void instantiatePlanet() {
         planet = new Planet(getSolarSystemPosition(), getAngleInSolarSystem(), getDistanceFromSolarSystemCenter(),
                 getInitialPlanetAngle(), orbitSolarSystemSpeed, planetRotationSpeed, getGroundHeight(),
                 false, getPlanetConfig(), name);
     }
 
     /**
-     * The gets a planet config with the difficulty set in the way it is by default. If a planet is not an inner planet
-     * (less than half the SolarSystem radius from the center of the system), and not in the starting system, is in
-     * the starting system, it will be easy. If the Planet is in the inner part of its system, and it is not the first
-     * system, it will be a hard planet. Otherwise, it will be a medium planet.
+     * This returns a PlanetConfig using logic to determine Planet difficulty.
      * @return the PlanetConfig with the correct difficulty
      */
     protected PlanetConfig getPlanetConfigDefaultSettings() {
@@ -150,8 +147,8 @@ public abstract class PlanetGenerator extends FeatureGenerator {
      * @param atmospherePercentageMultiplier amount by which the current atmosphere percentage should be multiplied
      */
     protected void modifyLowOrbitShipsAtmospherePercentage(float atmospherePercentageMultiplier) {
-        getPlanetConfig().lowOrbitEnemiesBuilder.setAtmospherePercentage(
-                getPlanetConfig().lowOrbitEnemiesBuilder.getAtmospherePercentage() * atmospherePercentageMultiplier);
+        getPlanetConfig().lowOrbitalEnemiesBuilder.setAtmospherePercentage(
+                getPlanetConfig().lowOrbitalEnemiesBuilder.getAtmospherePercentage() * atmospherePercentageMultiplier);
     }
 
     /**
@@ -159,8 +156,8 @@ public abstract class PlanetGenerator extends FeatureGenerator {
      * @param atmospherePercentageMultiplier amount by which the current atmosphere percentage should be multiplied
      */
     protected void modifyHighOrbitShipsAtmospherePercentage(float atmospherePercentageMultiplier) {
-        getPlanetConfig().highOrbitEnemiesBuilder.setAtmospherePercentage(
-                getPlanetConfig().highOrbitEnemiesBuilder.getAtmospherePercentage() * atmospherePercentageMultiplier);
+        getPlanetConfig().highOrbitalEnemiesBuilder.setAtmospherePercentage(
+                getPlanetConfig().highOrbitalEnemiesBuilder.getAtmospherePercentage() * atmospherePercentageMultiplier);
     }
 
     /**
@@ -168,8 +165,8 @@ public abstract class PlanetGenerator extends FeatureGenerator {
      * @param detectionDistanceMultiplier amount by which the current detection distance should be multiplied
      */
     protected void modifyLowOrbitShipsDetectionDistance(float detectionDistanceMultiplier) {
-        getPlanetConfig().lowOrbitEnemiesBuilder.setDetectionDist(
-                getPlanetConfig().lowOrbitEnemiesBuilder.getDetectionDist() * detectionDistanceMultiplier);
+        getPlanetConfig().lowOrbitalEnemiesBuilder.setDetectionDistance(
+                getPlanetConfig().lowOrbitalEnemiesBuilder.getDetectionDistance() * detectionDistanceMultiplier);
     }
 
     /**
@@ -177,8 +174,8 @@ public abstract class PlanetGenerator extends FeatureGenerator {
      * @param detectionDistanceMultiplier amount by which the current detection distance should be multiplied
      */
     protected void modifyHighOrbitShipsDetectionDistance(float detectionDistanceMultiplier) {
-        getPlanetConfig().highOrbitEnemiesBuilder.setDetectionDist(
-                getPlanetConfig().highOrbitEnemiesBuilder.getDetectionDist() * detectionDistanceMultiplier);
+        getPlanetConfig().highOrbitalEnemiesBuilder.setDetectionDistance(
+                getPlanetConfig().highOrbitalEnemiesBuilder.getDetectionDistance() * detectionDistanceMultiplier);
     }
 
     /**

--- a/engine/src/main/java/org/destinationsol/world/generators/PlanetGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/PlanetGenerator.java
@@ -15,6 +15,9 @@
  */
 package org.destinationsol.world.generators;
 
+import com.badlogic.gdx.math.Vector2;
+import org.destinationsol.game.SolNames;
+import org.destinationsol.game.planet.Planet;
 import org.destinationsol.game.planet.PlanetConfig;
 import org.destinationsol.game.planet.PlanetConfigs;
 
@@ -27,13 +30,51 @@ public abstract class PlanetGenerator extends FeatureGenerator {
     public static final float PLANET_MAX_DIAMETER = 78f;
     protected static final float DEFAULT_MAX_GROUND_HEIGHT = 25f;
     protected static final float DEFAULT_ATMOSPHERE_HEIGHT = 14f;
-    PlanetConfigs planetConfigManager;
-    PlanetConfig planetConfig;
-    float groundHeight;
+    public static final float PLANET_SPEED = .2f;
+    public static final float PLANET_GROUND_SPEED = .2f;
+    protected SolNames solNames = new SolNames();
+    private Planet planet;
+    private Vector2 solarSystemPosition = new Vector2();
+    private String name;
+    private boolean isInFirstSolarSystem;
+    private boolean isInnerPlanet;
+    private PlanetConfig planetConfig;
+    private float groundHeight;
     //distance from ground of planet to atmosphere
-    float atmosphereHeight;
-    float angleInSolarSystem;
-    float distanceFromSolarSystemCenter;
+    private float atmosphereHeight;
+    private float angleInSolarSystem;
+    private float distanceFromSolarSystemCenter;
+    private float initialPlanetAngle;
+
+    //This is the speed the Planet orbits around the SolarSystem at
+    private float orbitSolarSystemSpeed;
+    //This is the speed the Planet spins around it's axis at
+    private float planetRotationSpeed;
+
+    private PlanetConfigs planetConfigManager;
+
+    /**
+     * This method sets the planet variable for the PlanetGenerator. It should be called at the end of the build() method,
+     * after the settings of the planet have been set.
+     */
+    protected void createPlanet() {
+        planet = new Planet(getSolarSystemPosition(), getAngleInSolarSystem(), getDistanceFromSolarSystemCenter(),
+                getInitialPlanetAngle(), orbitSolarSystemSpeed, planetRotationSpeed, getGroundHeight(),
+                false, getPlanetConfig(), name);
+    }
+
+    /**
+     * The gets a planet config with the difficulty set in the way it is by default. If a planet is not an inner planet
+     * (less than half the SolarSystem radius from the center of the system), and not in the starting system, is in
+     * the starting system, it will be easy. If the Planet is in the inner part of its system, and it is not the first
+     * system, it will be a hard planet. Otherwise, it will be a medium planet.
+     *
+     * @return the PlanetConfig with the correct difficulty
+     */
+    protected PlanetConfig getPlanetConfigDefaultSettings() {
+        return getPlanetConfigManager().getRandom(!getIsInnerPlanet() && getIsInFirstSolarSystem(),
+                getIsInnerPlanet() && !getIsInFirstSolarSystem());
+    }
 
     public void setAtmosphereHeight(float atmosphereHeight) {
         this.atmosphereHeight = atmosphereHeight;
@@ -51,12 +92,16 @@ public abstract class PlanetGenerator extends FeatureGenerator {
         return groundHeight;
     }
 
-    void setRadius() {
+    void calculateRadius() {
         setRadius(getGroundHeight() + getAtmosphereHeight());
     }
 
     public void setAngleInSolarSystem(float angleInSolarSystem) {
         this.angleInSolarSystem = angleInSolarSystem;
+    }
+
+    public float getAngleInSolarSystem() {
+        return angleInSolarSystem;
     }
 
     public void setDistanceFromSolarSystemCenter(float distanceFromSolarSystemCenter) {
@@ -73,5 +118,73 @@ public abstract class PlanetGenerator extends FeatureGenerator {
 
     public PlanetConfig getPlanetConfig() {
         return planetConfig;
+    }
+
+    public PlanetConfigs getPlanetConfigManager() {
+        return planetConfigManager;
+    }
+
+    public void setPlanetConfigManager(PlanetConfigs planetConfigManager) {
+        this.planetConfigManager = planetConfigManager;
+    }
+
+    public void setIsInFirstSolarSystem(boolean isInfirstSolarSystem) {
+        this.isInFirstSolarSystem = isInfirstSolarSystem;
+    }
+
+    public boolean getIsInFirstSolarSystem() {
+        return isInFirstSolarSystem;
+    }
+
+    public void setIsInnerPlanet(boolean isInnerPlanet) {
+        this.isInnerPlanet = isInnerPlanet;
+    }
+
+    public boolean getIsInnerPlanet() {
+        return isInnerPlanet;
+    }
+
+    public void setInitialPlanetAngle(float initialPlanetAngle) {
+        this.initialPlanetAngle = initialPlanetAngle;
+    }
+
+    public float getInitialPlanetAngle() {
+        return initialPlanetAngle;
+    }
+
+    public Vector2 getSolarSystemPosition() {
+        return solarSystemPosition;
+    }
+
+    public void setSolarSystemPosition(Vector2 solarSystemPosition) {
+        this.solarSystemPosition.set(solarSystemPosition);
+    }
+
+    public void setPlanetRotationSpeed(float planetRotationSpeed) {
+        this.planetRotationSpeed = planetRotationSpeed;
+    }
+
+    public float getPlanetRotationSpeed() {
+        return planetRotationSpeed;
+    }
+
+    public void setOrbitSolarSystemSpeed(float orbitSolarSystemSpeed) {
+        this.orbitSolarSystemSpeed = orbitSolarSystemSpeed;
+    }
+
+    public float getOrbitSolarSystemSpeed() {
+        return orbitSolarSystemSpeed;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Planet getPlanet() {
+        return planet;
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/PlanetGeneratorImpl.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/PlanetGeneratorImpl.java
@@ -15,6 +15,7 @@
  */
 package org.destinationsol.world.generators;
 
+import org.destinationsol.common.SolMath;
 import org.destinationsol.common.SolRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,10 +30,18 @@ public class PlanetGeneratorImpl extends PlanetGenerator {
 
     @Override
     public void build() {
-        logger.info("Building a planet now!");
+        //sets the PlanetConfig for either an easy, medium, or hard planet.
+        setPlanetConfig(getPlanetConfigDefaultSettings());
+
         setGroundHeight(SolRandom.seededRandomFloat(.5f, 1) * DEFAULT_MAX_GROUND_HEIGHT);
         setAtmosphereHeight(DEFAULT_ATMOSPHERE_HEIGHT);
-        setRadius();
-        setAngleInSolarSystem(SolRandom.seededRandomFloat(180));
+        calculateRadius();
+
+        setOrbitSolarSystemSpeed(SolMath.arcToAngle(PLANET_SPEED, getDistanceFromSolarSystemCenter()) * SolMath.toInt(SolRandom.seededTest(.5f)));
+        setPlanetRotationSpeed(SolMath.arcToAngle(PLANET_GROUND_SPEED, getGroundHeight()) * SolMath.toInt(SolRandom.seededTest(.5f)));
+        setName(SolRandom.seededRandomElement(solNames.planets.get(getPlanetConfig().moduleName)));
+        logger.info("Building a planet now. Planet name: " + getName() + ". Planet position: " + getPosition() + ". Planet Type: " + getPlanetConfig().configName);
+
+        createPlanet();
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/PlanetGeneratorImpl.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/PlanetGeneratorImpl.java
@@ -15,7 +15,6 @@
  */
 package org.destinationsol.world.generators;
 
-import org.destinationsol.common.SolMath;
 import org.destinationsol.common.SolRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +40,6 @@ public class PlanetGeneratorImpl extends PlanetGenerator {
         setName(SolRandom.seededRandomElement(solNames.planets.get(getPlanetConfig().moduleName)));
         logger.info("Building a planet now. Planet name: " + getName() + ". Planet position: " + getPosition() + ". Planet Type: " + getPlanetConfig().configName);
 
-        createPlanet();
+        instantiatePlanet();
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/SmallPlanetGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SmallPlanetGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is a concrete implementation of a PlanetGenerator and handles its creation. This class creates planets
- * that are similar to the default Planets of Destination: Sol, but smaller, with different clouds, turrets,
- * and more high orbit enemies.
+ * This class is a concrete implementation of a PlanetGenerator and handles preparing a Planet to be built.
+ * This class creates planets that are similar to the default Planets of Destination: Sol, but smaller,
+ * with different clouds, turrets, and more high orbit enemies.
  */
 public class SmallPlanetGenerator extends PlanetGenerator {
     private static final Logger logger = LoggerFactory.getLogger(PlanetGeneratorImpl.class);
@@ -47,6 +47,6 @@ public class SmallPlanetGenerator extends PlanetGenerator {
         setCloudsEndingAtmospherePercentage(0.6f);
         setCloudsWidthEndingPercentage(5f);
         modifyGroundEnemiesDensity(1.3f);
-        createPlanet();
+        instantiatePlanet();
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/SmallPlanetGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SmallPlanetGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Terasology Foundation
+ * Copyright 2020 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package org.destinationsol.world.generators;
 
-import org.destinationsol.common.SolMath;
 import org.destinationsol.common.SolRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is a concrete implementation of a PlanetGenerator and handles its creation. This class defines the
- * behavior specific to the default Planets of Destination: Sol.
+ * This class is a concrete implementation of a PlanetGenerator and handles its creation. This class creates planets
+ * that are similar to the default Planets of Destination: Sol, but smaller, with different clouds, turrets,
+ * and more high orbit enemies.
  */
-public class PlanetGeneratorImpl extends PlanetGenerator {
+public class SmallPlanetGenerator extends PlanetGenerator {
     private static final Logger logger = LoggerFactory.getLogger(PlanetGeneratorImpl.class);
 
     @Override
@@ -32,7 +32,7 @@ public class PlanetGeneratorImpl extends PlanetGenerator {
         //sets the PlanetConfig for either an easy, medium, or hard planet.
         setPlanetConfig(getPlanetConfigDefaultSettings());
 
-        setGroundHeight(SolRandom.seededRandomFloat(.5f, 1) * DEFAULT_MAX_GROUND_HEIGHT);
+        setGroundHeight(SolRandom.seededRandomFloat(.5f, 1) * DEFAULT_MAX_GROUND_HEIGHT * .6f);
         setAtmosphereHeight(DEFAULT_ATMOSPHERE_HEIGHT);
         calculateRadius();
 
@@ -41,6 +41,12 @@ public class PlanetGeneratorImpl extends PlanetGenerator {
         setName(SolRandom.seededRandomElement(solNames.planets.get(getPlanetConfig().moduleName)));
         logger.info("Building a planet now. Planet name: " + getName() + ". Planet position: " + getPosition() + ". Planet Type: " + getPlanetConfig().configName);
 
+        modifyCloudDensity(1.7f);
+        modifyHighOrbitShipsDensity(1.35f);
+        setCloudsStartingAtmospherePercentage(0.25f);
+        setCloudsEndingAtmospherePercentage(0.6f);
+        setCloudsWidthEndingPercentage(5f);
+        modifyGroundEnemiesDensity(1.3f);
         createPlanet();
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
@@ -41,6 +41,7 @@ import static org.destinationsol.world.generators.SunGenerator.SUN_RADIUS;
  * Particular implementations can decide which of those FeatureGenerators will be used to populate the SolarSystem.
  */
 public abstract class SolarSystemGenerator {
+    public static final float MAX_ANGLE_IN_SYSTEM = 180;
     private static final Logger logger = LoggerFactory.getLogger(SolarSystemGenerator.class);
 
     /**
@@ -181,7 +182,7 @@ public abstract class SolarSystemGenerator {
             if (generator.getClass().getSuperclass().equals(MazeGenerator.class)) {
                 //set the outermost orbital to have a MazeGenerator
                 solarSystemOrbitals.get(solarSystemOrbitals.size() - 1).setFeatureGenerator(generator);
-                float angle = SolRandom.seededRandomFloat(180);
+                float angle = SolRandom.seededRandomFloat(MAX_ANGLE_IN_SYSTEM);
                 SolMath.fromAl(result, angle, solarSystemOrbitals.get(solarSystemOrbitals.size() - 1).calculateDistanceFromCenterOfSystemForFeature());
                 if (isGoodAngle(angle, usedAnglesInSolarSystem, 15)) {
                     result = result.add(position);
@@ -208,8 +209,8 @@ public abstract class SolarSystemGenerator {
                 Orbital orbital = solarSystemOrbitals.get(orbitalPosition);
                 orbital.setFeatureGenerator(generator);
 
-                generator.setAngleInSolarSystem(SolRandom.seededRandomFloat(180));
-                generator.setInitialPlanetAngle(SolRandom.seededRandomFloat(180));
+                generator.setAngleInSolarSystem(SolRandom.seededRandomFloat(MAX_ANGLE_IN_SYSTEM));
+                generator.setInitialPlanetAngle(SolRandom.seededRandomFloat(MAX_ANGLE_IN_SYSTEM));
                 generator.setDistanceFromSolarSystemCenter(orbital.calculateDistanceFromCenterOfSystemForFeature());
 
                 SolMath.fromAl(result, generator.getAngleInSolarSystem(), generator.getDistanceFromSolarSystemCenter());
@@ -394,11 +395,11 @@ public abstract class SolarSystemGenerator {
     }
 
     /**
-     * This method returns the Planet objects built by the PlanetGenerators of this SolarSystem. It is most useful
-     * after the build method is called
+     * This method returns the Planet objects instantiated by the PlanetGenerators of this SolarSystem. It is most useful
+     * after the build() method is called on each PlanetGenerator
      * @return List of Planets
      */
-    ArrayList<Planet> getBuiltPlanets() {
+    ArrayList<Planet> getInstantiatedPlanets() {
         ArrayList<Planet> planets = new ArrayList<>();
         for (FeatureGenerator featureGenerator : activeFeatureGenerators) {
             if (featureGenerator.getClass().getSuperclass().equals(PlanetGenerator.class)) {
@@ -489,7 +490,7 @@ public abstract class SolarSystemGenerator {
      */
     public SolarSystem createBuiltSolarSystem() {
         SolarSystem solarSystem = new SolarSystem(getPosition(), getSolarSystemConfig(), getName(), getRadius());
-        solarSystem.getPlanets().addAll(getBuiltPlanets());
+        solarSystem.getPlanets().addAll(getInstantiatedPlanets());
         return solarSystem;
     }
 

--- a/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
@@ -19,6 +19,9 @@ import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.common.SolRandom;
 import org.destinationsol.game.SolNames;
+import org.destinationsol.game.context.Context;
+import org.destinationsol.game.planet.Planet;
+import org.destinationsol.game.planet.PlanetConfigs;
 import org.destinationsol.game.planet.SolarSystem;
 import org.destinationsol.game.planet.SolarSystemConfig;
 import org.destinationsol.game.planet.SolarSystemConfigManager;
@@ -61,6 +64,7 @@ public abstract class SolarSystemGenerator {
     protected ArrayList<Class<? extends FeatureGenerator>> featureGeneratorTypes = new ArrayList<>();
     ArrayList<FeatureGenerator> activeFeatureGenerators = new ArrayList<>();
     ArrayList<Orbital> solarSystemOrbitals = new ArrayList<>();
+    Context context;
     //This class is included to give access to the game's default names if desired
     protected SolNames solNames = new SolNames();
     private SolarSystemConfigManager solarSystemConfigManager;
@@ -204,12 +208,18 @@ public abstract class SolarSystemGenerator {
                 Orbital orbital = solarSystemOrbitals.get(orbitalPosition);
                 orbital.setFeatureGenerator(generator);
 
+                generator.setAngleInSolarSystem(SolRandom.seededRandomFloat(180));
+                generator.setInitialPlanetAngle(SolRandom.seededRandomFloat(180));
                 generator.setDistanceFromSolarSystemCenter(orbital.calculateDistanceFromCenterOfSystemForFeature());
-                SolMath.fromAl(result, generator.angleInSolarSystem, generator.getDistanceFromSolarSystemCenter());
+
+                SolMath.fromAl(result, generator.getAngleInSolarSystem(), generator.getDistanceFromSolarSystemCenter());
                 result.add(position);
                 generator.setPosition(result);
+                generator.setSolarSystemPosition(this.getPosition());
+                generator.setIsInnerPlanet(generator.getDistanceFromSolarSystemCenter() < this.radius / 2);
+                generator.setIsInFirstSolarSystem(getSolarSystemNumber() == 0);
 
-                logger.info(generator + " distance from center: " + generator.distanceFromSolarSystemCenter);
+                logger.info(generator + " distance from center: " + generator.getDistanceFromSolarSystemCenter());
                 orbitalPosition++;
             }
             SolMath.free(result);
@@ -289,6 +299,7 @@ public abstract class SolarSystemGenerator {
                 Class<? extends FeatureGenerator> newFeatureGeneratorType = featureGeneratorTypes.get(index);
                 try {
                     FeatureGenerator newFeatureGenerator = newFeatureGeneratorType.newInstance();
+                    ((PlanetGenerator) newFeatureGenerator).setPlanetConfigManager(context.get(PlanetConfigs.class));
                     activeFeatureGenerators.add(newFeatureGenerator);
                     planetsLeft--;
                 } catch (Exception e) {
@@ -383,6 +394,22 @@ public abstract class SolarSystemGenerator {
     }
 
     /**
+     * This method returns the Planet objects built by the PlanetGenerators of this SolarSystem. It is most useful
+     * after the build method is called
+     *
+     * @return List of Planets
+     */
+    ArrayList<Planet> getBuiltPlanets() {
+        ArrayList<Planet> planets = new ArrayList<>();
+        for (FeatureGenerator featureGenerator : activeFeatureGenerators) {
+            if (featureGenerator.getClass().getSuperclass().equals(PlanetGenerator.class)) {
+                planets.add(((PlanetGenerator) featureGenerator).getPlanet());
+            }
+        }
+        return planets;
+    }
+
+    /**
      * This method is used to choose a valid position to insert a belt into. It chooses a position that is between two planets
      * (not on the edge of the system and not previously used for a belt)
      *
@@ -403,8 +430,8 @@ public abstract class SolarSystemGenerator {
     /**
      * This method checks if an angle is not within a certain amount of degrees to any other angle in the passed in list
      *
-     * @param anglesToCheckAgainst  angles to compare to
-     * @param  angleToCheck angle to check
+     * @param anglesToCheckAgainst angles to compare to
+     * @param angleToCheck angle to check
      * @param degrees how many degrees apart to ensure angles are between
      * @return whether angles are within specified amount of degrees or not
      */
@@ -457,8 +484,15 @@ public abstract class SolarSystemGenerator {
         return solarSystemConfig;
     }
 
-    public SolarSystem getBuiltSolarSystem() {
-        return new SolarSystem(getPosition(), getSolarSystemConfig(), getName(), getRadius());
+    /**
+     * This method creates a built SolarSystem object from the details set by the Generator.
+     *
+     * @return The SolarSystem object
+     */
+    public SolarSystem createBuiltSolarSystem() {
+        SolarSystem solarSystem = new SolarSystem(getPosition(), getSolarSystemConfig(), getName(), getRadius());
+        solarSystem.getPlanets().addAll(getBuiltPlanets());
+        return solarSystem;
     }
 
     public Vector2 getPosition() {
@@ -487,18 +521,6 @@ public abstract class SolarSystemGenerator {
 
     public ArrayList<FeatureGenerator> getActiveFeatureGenerators() {
         return activeFeatureGenerators;
-    }
-
-    public void setPlanetCount(int planetCount) {
-        this.planetCount = planetCount;
-    }
-
-    public void setPossibleBeltCount(int possibleBeltCount) {
-        this.possibleBeltCount = possibleBeltCount;
-    }
-
-    public void setMazeCount(int mazeCount) {
-        this.mazeCount = mazeCount;
     }
 
     public void setName(String name) {
@@ -531,5 +553,13 @@ public abstract class SolarSystemGenerator {
 
     public ArrayList<String> getDefaultSolarSystemNames() {
         return solNames.systems;
+    }
+
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    public Context getContext() {
+        return context;
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/SunGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SunGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/destinationsol/world/generators/SunGeneratorImpl.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SunGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/test/java/org/destinationsol/world/WorldBuilderTest.java
+++ b/engine/src/test/java/org/destinationsol/world/WorldBuilderTest.java
@@ -17,6 +17,7 @@ package org.destinationsol.world;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.physics.box2d.Box2D;
 import org.destinationsol.assets.sound.OggSoundManager;
 import org.destinationsol.files.HullConfigManager;
 import org.destinationsol.game.AbilityCommonConfigs;
@@ -25,6 +26,7 @@ import org.destinationsol.game.context.Context;
 import org.destinationsol.game.context.internal.ContextImpl;
 import org.destinationsol.game.item.ItemManager;
 import org.destinationsol.game.particle.EffectTypes;
+import org.destinationsol.game.planet.PlanetConfigs;
 import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.testingUtilities.MockGL;
@@ -44,7 +46,6 @@ public class WorldBuilderTest implements AssetsHelperInitializer {
     private EffectTypes effectTypes;
     private OggSoundManager soundManager;
     private AbilityCommonConfigs abilityCommonConfigs;
-    SolarSystemConfigManager solarSystemConfigManager;
 
 
     @BeforeEach
@@ -56,20 +57,26 @@ public class WorldBuilderTest implements AssetsHelperInitializer {
 
         setupMockGL();
 
-        solarSystemConfigManager = setupSolarSystemConfigManager();
-        context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
+        setupConfigManagers();
     }
 
     private void setupMockGL() {
         GL20 mockGL = new MockGL();
         Gdx.gl = mockGL;
         Gdx.gl20 = mockGL;
+        Box2D.init();
     }
 
-    private SolarSystemConfigManager setupSolarSystemConfigManager() {
+    private void setupConfigManagers() {
         ItemManager itemManager = setupItemManager();
         HullConfigManager hullConfigManager = setupHullConfigManager(itemManager);
-        return new SolarSystemConfigManager(hullConfigManager, itemManager);
+
+        PlanetConfigs planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors,itemManager);
+        planetConfigManager.loadDefaultPlanetConfigs();
+        context.put(PlanetConfigs.class, planetConfigManager);
+
+        SolarSystemConfigManager solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
+        context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
     }
 
     private ItemManager setupItemManager() {

--- a/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.world.generators;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import org.destinationsol.assets.sound.OggSoundManager;
+import org.destinationsol.files.HullConfigManager;
+import org.destinationsol.game.AbilityCommonConfigs;
+import org.destinationsol.game.GameColors;
+import org.destinationsol.game.context.Context;
+import org.destinationsol.game.context.internal.ContextImpl;
+import org.destinationsol.game.item.ItemManager;
+import org.destinationsol.game.particle.EffectTypes;
+import org.destinationsol.game.planet.PlanetConfigs;
+import org.destinationsol.game.planet.SolarSystemConfigManager;
+import org.destinationsol.modules.ModuleManager;
+import org.destinationsol.testingUtilities.MockGL;
+import org.destinationsol.testsupport.AssetsHelperInitializer;
+import org.destinationsol.world.WorldBuilder;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlanetGeneratorTest implements AssetsHelperInitializer {
+    private Context context;
+    private ModuleManager moduleManager;
+    private WorldBuilder worldBuilder;
+    private GameColors gameColors;
+    private EffectTypes effectTypes;
+    private OggSoundManager soundManager;
+    private AbilityCommonConfigs abilityCommonConfigs;
+    private SolarSystemGenerator solarSystemGenerator;
+    private PlanetGenerator planetGenerator;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        context = new ContextImpl();
+        moduleManager = getModuleManager();
+        moduleManager.init();
+        context.put(ModuleManager.class, moduleManager);
+
+        setupMockGL();
+
+        //TODO: Determine how to load in PlanetConfigs class without CollisionMeshLoader error
+        setupConfigManagers();
+
+        worldBuilder = new WorldBuilder(context, 1);
+
+        ArrayList<SolarSystemGenerator> solarSystemGenerators = worldBuilder.initializeRandomSolarSystemGenerators();
+        solarSystemGenerator = solarSystemGenerators.get(0);
+        setupSolarSystemGenerator();
+        planetGenerator = (PlanetGeneratorImpl) solarSystemGenerators.get(0).getActiveFeatureGenerators().get(1);
+    }
+
+    private void setupMockGL() {
+        GL20 mockGL = new MockGL();
+        Gdx.gl = mockGL;
+        Gdx.gl20 = mockGL;
+    }
+
+    private void setupConfigManagers() {
+        ItemManager itemManager = setupItemManager();
+        HullConfigManager hullConfigManager = setupHullConfigManager(itemManager);
+
+        PlanetConfigs planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors,itemManager);
+        context.put(PlanetConfigs.class, planetConfigManager);
+
+        SolarSystemConfigManager solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
+        context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
+    }
+
+    private ItemManager setupItemManager() {
+        gameColors = new GameColors();
+        effectTypes = new EffectTypes();
+        soundManager = new OggSoundManager(context);
+        return new ItemManager(soundManager, effectTypes, gameColors);
+    }
+
+    private HullConfigManager setupHullConfigManager(ItemManager itemManager) {
+        abilityCommonConfigs = new AbilityCommonConfigs(effectTypes, gameColors, soundManager);
+        return new HullConfigManager(itemManager, abilityCommonConfigs);
+    }
+
+    private void setupSolarSystemGenerator() {
+        solarSystemGenerator.initializeRandomDefaultFeatureGenerators(1f);
+        solarSystemGenerator.calculateFeaturePositions();
+        solarSystemGenerator.buildFeatureGenerators();
+        solarSystemGenerator.getBuiltPlanets().get(0);
+    }
+
+}

--- a/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
@@ -17,6 +17,8 @@ package org.destinationsol.world.generators;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.physics.box2d.Box2D;
+import com.badlogic.gdx.physics.box2d.PolygonShape;
 import org.destinationsol.assets.sound.OggSoundManager;
 import org.destinationsol.files.HullConfigManager;
 import org.destinationsol.game.AbilityCommonConfigs;
@@ -32,10 +34,13 @@ import org.destinationsol.testingUtilities.MockGL;
 import org.destinationsol.testsupport.AssetsHelperInitializer;
 import org.destinationsol.world.WorldBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PlanetGeneratorTest implements AssetsHelperInitializer {
     private Context context;
@@ -57,7 +62,6 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
 
         setupMockGL();
 
-        //TODO: Determine how to load in PlanetConfigs class without CollisionMeshLoader error
         setupConfigManagers();
 
         worldBuilder = new WorldBuilder(context, 1);
@@ -65,13 +69,14 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
         ArrayList<SolarSystemGenerator> solarSystemGenerators = worldBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);
         setupSolarSystemGenerator();
-        planetGenerator = (PlanetGeneratorImpl) solarSystemGenerators.get(0).getActiveFeatureGenerators().get(1);
+        planetGenerator = (PlanetGenerator) solarSystemGenerators.get(0).getActiveFeatureGenerators().get(1);
     }
 
     private void setupMockGL() {
         GL20 mockGL = new MockGL();
         Gdx.gl = mockGL;
         Gdx.gl20 = mockGL;
+        Box2D.init();
     }
 
     private void setupConfigManagers() {
@@ -79,6 +84,7 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
         HullConfigManager hullConfigManager = setupHullConfigManager(itemManager);
 
         PlanetConfigs planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors,itemManager);
+        planetConfigManager.loadDefaultPlanetConfigs();
         context.put(PlanetConfigs.class, planetConfigManager);
 
         SolarSystemConfigManager solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
@@ -104,4 +110,33 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
         solarSystemGenerator.getBuiltPlanets().get(0);
     }
 
+    @Test
+    void planetDiameterIsWithinRange() {
+        assertTrue(planetGenerator.getDiameter() < PlanetGenerator.PLANET_MAX_DIAMETER && planetGenerator.getDiameter() > 0);
+    }
+
+    @Test
+    void planetRadiusIsGroundHeightPlusAtmosphereHeight() {
+        assertEquals(planetGenerator.getRadius(), planetGenerator.getGroundHeight() + planetGenerator.getAtmosphereHeight());
+    }
+
+    @Test
+    void planetHasConfig() {
+        assertNotNull(planetGenerator.getPlanetConfig());
+    }
+
+    @Test
+    void planetHasName() {
+        assertTrue(planetGenerator.getName().length() > 0);
+    }
+
+    @Test
+    void planetHasPositiveRotationSpeed() {
+        assertTrue(planetGenerator.getPlanetRotationSpeed() > 0);
+    }
+
+    @Test
+    void planetHasPositiveOrbitSpeed() {
+        assertTrue(planetGenerator.getPlanetRotationSpeed() > 0);
+    }
 }

--- a/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
@@ -18,7 +18,6 @@ package org.destinationsol.world.generators;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.physics.box2d.Box2D;
-import com.badlogic.gdx.physics.box2d.PolygonShape;
 import org.destinationsol.assets.sound.OggSoundManager;
 import org.destinationsol.files.HullConfigManager;
 import org.destinationsol.game.AbilityCommonConfigs;
@@ -107,7 +106,7 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
         solarSystemGenerator.initializeRandomDefaultFeatureGenerators(1f);
         solarSystemGenerator.calculateFeaturePositions();
         solarSystemGenerator.buildFeatureGenerators();
-        solarSystemGenerator.getBuiltPlanets().get(0);
+        solarSystemGenerator.getInstantiatedPlanets().get(0);
     }
 
     @Test

--- a/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
 
     private void setupSolarSystemGenerator() {
         solarSystemGenerator.initializeRandomDefaultFeatureGenerators(1f);
-        //solarSystemGenerator.buildFeatureGenerators();
+        solarSystemGenerator.buildFeatureGenerators();
         solarSystemGenerator.calculateFeaturePositions();
     }
 

--- a/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
@@ -17,6 +17,8 @@ package org.destinationsol.world.generators;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.physics.box2d.Box2D;
+import com.badlogic.gdx.physics.box2d.PolygonShape;
 import org.destinationsol.files.HullConfigManager;
 import org.destinationsol.game.AbilityCommonConfigs;
 import org.destinationsol.game.GameColors;
@@ -25,6 +27,7 @@ import org.destinationsol.game.context.internal.ContextImpl;
 import org.destinationsol.game.item.ItemManager;
 import org.destinationsol.game.particle.EffectTypes;
 import org.destinationsol.assets.sound.OggSoundManager;
+import org.destinationsol.game.planet.PlanetConfigs;
 import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.testingUtilities.MockGL;
@@ -59,8 +62,7 @@ public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
 
         setupMockGL();
 
-        SolarSystemConfigManager solarSystemConfigManager = setupSolarSystemConfigManager();
-        context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
+        setupConfigManagers();
 
         worldBuilder = new WorldBuilder(context, 1);
 
@@ -73,12 +75,19 @@ public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
         GL20 mockGL = new MockGL();
         Gdx.gl = mockGL;
         Gdx.gl20 = mockGL;
+        Box2D.init();
     }
 
-    private SolarSystemConfigManager setupSolarSystemConfigManager() {
+    private void setupConfigManagers() {
         ItemManager itemManager = setupItemManager();
         HullConfigManager hullConfigManager = setupHullConfigManager(itemManager);
-        return new SolarSystemConfigManager(hullConfigManager, itemManager);
+
+        PlanetConfigs planetConfigManager = new PlanetConfigs(hullConfigManager, gameColors,itemManager);
+        planetConfigManager.loadDefaultPlanetConfigs();
+        context.put(PlanetConfigs.class, planetConfigManager);
+
+        SolarSystemConfigManager solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
+        context.put(SolarSystemConfigManager.class, solarSystemConfigManager);
     }
 
     private ItemManager setupItemManager() {
@@ -95,7 +104,7 @@ public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
 
     private void setupSolarSystemGenerator() {
         solarSystemGenerator.initializeRandomDefaultFeatureGenerators(1f);
-        solarSystemGenerator.buildFeatureGenerators();
+        //solarSystemGenerator.buildFeatureGenerators();
         solarSystemGenerator.calculateFeaturePositions();
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This PR adds the default implementation of Planets to the new modular world-gen system. It also sets up the game so that SolarSystems and Planets generated by Generator classes show up in the game.

In this implementation, many options are available to the Planet via getting the config in your particular implementation, and then changing various values

# Testing
Run the game, and you should see SolarSystems running with Planets in them, but no belts and no mazes. There are two types of SolarSystems that will generate, the default systems and large SolarSystems. Generate a world with a good amount of systems (at least 4) to make sure you see the different types.

# Outstanding Work
Two features still need to be added for Planets. One is the ability to place custom objects/ modify terrain, which will involve modularizing the PlanetObjectsBuilder class to accept types of objects, instead of specific objects. The other is the ability to load custom PlanetConfig files. Additionally, tests need to be written still. There is an issue with testing PlanetGenerators as the require the PlanetConfigs class to be loaded, and this seems to be dependent on the class CollisionMeshLoader, which is throwing an error when running tests
