### PR TITLE
Maze Layout System

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -119,4 +119,5 @@ test {
     useJUnitPlatform()
     // showStandardStreams: makes the standard streams (err and out) visible at console when running tests
     testLogging.showStandardStreams = true
+    workingDir = rootProject.projectDir
 }

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -139,7 +139,7 @@ public class GalaxyFiller {
             return;
         }
         createStarPorts(game);
-        ArrayList<SolarSystem> systems = game.getWorldBuilder().getBuiltSolarSystems();
+        ArrayList<SolarSystem> systems = game.getGalaxyBuilder().getBuiltSolarSystems();
 
         JSONObject rootNode = Validator.getValidatedJSON(moduleName + ":startingStation", "engine:schemaStartingStation");
 
@@ -174,7 +174,7 @@ public class GalaxyFiller {
     private void createStarPorts(SolGame game) {
         ArrayList<Planet> biggest = new ArrayList<>();
 
-        for (SolarSystem system : game.getWorldBuilder().getBuiltSolarSystems()) {
+        for (SolarSystem system : game.getGalaxyBuilder().getBuiltSolarSystems()) {
             float minHeight = 0;
             Planet biggestPlanet = null;
             int biggestPlanetIndex = -1;

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -68,7 +68,7 @@ import org.destinationsol.ui.TutorialManager;
 import org.destinationsol.ui.UiDrawer;
 import org.destinationsol.ui.Waypoint;
 import org.destinationsol.util.InjectionHelper;
-import org.destinationsol.world.WorldBuilder;
+import org.destinationsol.world.GalaxyBuilder;
 import org.terasology.gestalt.entitysystem.entity.EntityRef;
 
 import java.util.ArrayList;
@@ -105,7 +105,7 @@ public class SolGame {
     private final TutorialManager tutorialManager;
     private final GalaxyFiller galaxyFiller;
     private final SolContactListener contactListener;
-    private final WorldBuilder worldBuilder;
+    private final GalaxyBuilder galaxyBuilder;
     private final SolarSystemConfigManager solarSystemConfigManager;
     private final PlanetConfigManager planetConfigManager;
     private final MazeConfigManager mazeConfigManager;
@@ -198,8 +198,8 @@ public class SolGame {
         beltConfigManager = new BeltConfigManager(hullConfigManager, itemManager);
         beltConfigManager.loadDefaultBeltConfigs();
         context.put(BeltConfigManager.class, beltConfigManager);
-        worldBuilder = new WorldBuilder(context, worldConfig.getNumberOfSystems());
-        context.put(WorldBuilder.class, worldBuilder);
+        galaxyBuilder = new GalaxyBuilder(context, worldConfig.getNumberOfSystems());
+        context.put(GalaxyBuilder.class, galaxyBuilder);
 
         timeFactor = 1;
     }
@@ -260,7 +260,7 @@ public class SolGame {
         SolRandom.setSeed(worldConfig.getSeed());
 
         //World Generation will be initiated from here
-        worldBuilder.buildWithRandomSolarSystemGenerators();
+        galaxyBuilder.buildWithRandomSolarSystemGenerators();
 
         //Add all the Planets in the game to the PlanetManager TODO: Add mazes, belts, etc. once the are implemented
         addObjectsToPlanetManager();
@@ -284,7 +284,7 @@ public class SolGame {
     }
 
     private void addObjectsToPlanetManager() {
-        planetManager.getSystems().addAll(worldBuilder.getBuiltSolarSystems());
+        planetManager.getSystems().addAll(galaxyBuilder.getBuiltSolarSystems());
         for (SolarSystem system : planetManager.getSystems()) {
             for (Planet planet : system.getPlanets()) {
                 planetManager.getPlanets().add(planet);
@@ -644,8 +644,8 @@ public class SolGame {
         return hullConfigManager;
     }
 
-    public WorldBuilder getWorldBuilder() {
-        return worldBuilder;
+    public GalaxyBuilder getGalaxyBuilder() {
+        return galaxyBuilder;
     }
 
 }

--- a/engine/src/main/java/org/destinationsol/game/maze/Maze.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/Maze.java
@@ -28,11 +28,22 @@ public class Maze {
     private final float radius;
     private final float damagePerSecond;
     private boolean areObjectsCreated;
+    private MazeLayout mazeLayout;
+    private boolean hasLayout;
 
     public Maze(MazeConfig config, Vector2 position, float radius) {
         this.config = config;
         this.position = position;
         this.radius = radius;
+        damagePerSecond = HardnessCalc.getMazeDps(config);
+    }
+
+    public Maze(MazeConfig config, Vector2 position, float radius, MazeLayout mazeLayout) {
+        this.config = config;
+        this.position = position;
+        this.radius = radius;
+        this.mazeLayout = mazeLayout;
+        hasLayout = true;
         damagePerSecond = HardnessCalc.getMazeDps(config);
     }
 
@@ -62,5 +73,18 @@ public class Maze {
 
     public float getDps() {
         return damagePerSecond;
+    }
+
+    public void setMazeLayout(MazeLayout mazeLayout) {
+        this.mazeLayout = mazeLayout;
+        hasLayout = true;
+    }
+
+    public boolean hasLayoutSet() {
+        return hasLayout;
+    }
+
+    public MazeLayout getMazeLayout() {
+        return mazeLayout;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeBuilder.java
@@ -39,19 +39,25 @@ public class MazeBuilder {
     private Vector2 mazePosition;
     private float mazeAngle;
     private float innerRadius;
+    MazeLayout mazeLayout;
 
     public void build(SolGame game, Maze maze) {
         innerRadius = maze.getRadius() - BORDER;
         size = (int) (innerRadius * 2 / TILE_SZ);
         mazePosition = maze.getPos();
         mazeAngle = SolRandom.seededRandomFloat(180);
-
-        MazeLayout layout = buildMaze(game, maze);
-        buildEnemies(game, maze, layout);
+        mazeLayout = buildMaze(game, maze);
+        buildEnemies(game, maze, mazeLayout);
     }
 
     private MazeLayout buildMaze(SolGame game, Maze maze) {
-        MazeLayout layout = new MazeLayoutBuilder(size).build();
+        MazeLayout layout;
+        if (maze.hasLayoutSet()) {
+            layout = new MazeLayoutBuilder(size).build(maze.getMazeLayout().inners);
+        } else {
+            layout = new MazeLayoutBuilder(size).build();
+        }
+
         new MazeTileObject.Builder();
         MazeConfig config = maze.getConfig();
         for (int col = 0; col < size; col++) {

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeConfigManager.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeConfigManager.java
@@ -31,6 +31,7 @@ import java.util.Set;
  * This class manages loading config files in for Mazes. It also allows for getting a random Maze config or a
  * specific Maze config by name. It can either load the default Maze configs, or specified custom configs
  */
+
 public class MazeConfigManager {
     public final List<MazeConfig> configs;
     HullConfigManager hullConfigManager;

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeLayout.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeLayout.java
@@ -17,10 +17,13 @@
 package org.destinationsol.game.maze;
 
 public class MazeLayout {
+    /** This 2D array determines where MazeTiles will or will not be placed. The other arrays are created based off of
+     * inners*/
     public final boolean[][] inners;
     public final boolean[][] holes;
     public final boolean[][] right;
     public final boolean[][] down;
+    public String name = "";
 
     public MazeLayout(boolean[][] inners, boolean[][] holes, boolean[][] right, boolean[][] down) {
         this.inners = inners;
@@ -29,4 +32,15 @@ public class MazeLayout {
         this.down = down;
     }
 
+    public MazeLayout(boolean[][] inners, boolean[][] holes, boolean[][] right, boolean[][] down, String name) {
+        this.inners = inners;
+        this.holes = holes;
+        this.right = right;
+        this.down = down;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeLayoutBuilder.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeLayoutBuilder.java
@@ -23,7 +23,7 @@ public class MazeLayoutBuilder {
     private static final float HOLE_PERCENTAGE = 0.2f;
     private static final float WALL_PERCENTAGE = 0.5f;
     private final int size;
-    private final boolean[][] inners;
+    private boolean[][] inners;
     private final boolean[][] holes;
     private final boolean[][] right;
     private final boolean[][] down;
@@ -38,6 +38,21 @@ public class MazeLayoutBuilder {
 
     public MazeLayout build() {
         setInners();
+        for (int col = 0; col < size; col++) {
+            for (int row = 0; row < size; row++) {
+                boolean inner = inners[col][row];
+                boolean rInner = col < size - 1 && inners[col + 1][row];
+                boolean dInner = row < size - 1 && inners[col][row + 1];
+                right[col][row] = (inner || rInner) && SolRandom.test(WALL_PERCENTAGE);
+                down[col][row] = (inner || dInner) && SolRandom.test(WALL_PERCENTAGE);
+            }
+        }
+        makeAllAccessible();
+        return new MazeLayout(inners, holes, right, down);
+    }
+
+    public MazeLayout build(boolean[][] innerPreset) {
+        inners = innerPreset;
         for (int col = 0; col < size; col++) {
             for (int row = 0; row < size; row++) {
                 boolean inner = inners[col][row];

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeLayoutManager.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeLayoutManager.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.destinationsol.game.maze;
+
+import org.destinationsol.assets.Assets;
+import org.destinationsol.assets.json.Json;
+import org.destinationsol.assets.json.Validator;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.terasology.gestalt.assets.ResourceUrn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class is used to load MazeLayouts from JSON files into MazeGenerators. This allows Mazes to have custom layouts.
+ * A JSON maze layout has two properties: "name" which is a string and "inner", which is a 2D array of booleans which
+ * represents where the maze should have tiles and should not have tiles. See spiralMazeLayout.json in the core module
+ * for an example.
+ */
+public class MazeLayoutManager {
+    public final List<MazeLayout> mazeLayouts;
+
+    public MazeLayoutManager() {
+        this.mazeLayouts = new ArrayList<>();
+    }
+
+    /**
+     * This loads in the specified JSON asset. The assetName parameter should be the name of the JSON file you created.
+     * The layout is added to the mazeLayouts list.
+     * @param assetName JSON asset name
+     */
+    public void load(String assetName) {
+        final Set<ResourceUrn> configUrns = Assets.getAssetHelper().listAssets(Json.class, assetName);
+        for (ResourceUrn configUrn : configUrns) {
+            JSONObject rootNode = Validator.getValidatedJSON(configUrn.toString(), "engine:schemaMazeLayouts");
+            String layoutName = "";
+            ArrayList<ArrayList<Boolean>> inners = new ArrayList<>();
+            for (String s : rootNode.keySet()) {
+                if (!(rootNode.get(s) instanceof JSONArray)) {
+                    layoutName = rootNode.getString(s);
+                    continue;
+                }
+                JSONArray mazeNode = rootNode.getJSONArray(s);
+                ArrayList<Object> arrayList = new ArrayList<>(mazeNode.toList());
+                if (s.equals("inner")) {
+                    for (int i = 0; i < arrayList.size(); i++) {
+                        inners.add((ArrayList<Boolean>) arrayList.get(i));
+                    }
+                }
+            }
+            boolean[][] innersArray = new boolean[inners.size()][];
+            for (int i = 0; i < inners.size(); i++) {
+                ArrayList<Boolean> row = inners.get(i);
+                Boolean[] rowObj = row.toArray(new Boolean[row.size()]);
+                boolean[] rowPrim = new boolean[rowObj.length];
+                for (int j = 0; j < rowObj.length; j++) {
+                    rowPrim[j] = rowObj[j];
+                }
+                innersArray[i] = rowPrim;
+            }
+            mazeLayouts. add(new MazeLayout(innersArray, new boolean[0][], new boolean[0][], new boolean[0][], layoutName));
+        }
+    }
+
+    public List<MazeLayout> getMazeLayouts() {
+        return mazeLayouts;
+    }
+
+    /**
+     * Return layout with the specified name
+     * @param name name of the layout. Specified by the name property in JSON
+     * @return the MazeLayout
+     */
+    public MazeLayout getLayout(String name) {
+        for (MazeLayout layout : mazeLayouts) {
+            if (layout.getName().equals(name)) {
+                return layout;
+            }
+        }
+        return null;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/world/GalaxyBuilder.java
+++ b/engine/src/main/java/org/destinationsol/world/GalaxyBuilder.java
@@ -37,10 +37,10 @@ import java.util.List;
  * all Generator classes and then initiates each SolarSystem's build process. Two types of world generation classes are
  * retrieved: those that subclass SolarSystemGenerator and those that subclass FeatureGenerator.
  */
-public class WorldBuilder {
+public class GalaxyBuilder {
     public static final float MAX_ANGLE_WITHIN_WORLD = 180;
     public static final float MAX_WORLD_RADIUS = 100_000;
-    private static final Logger logger = LoggerFactory.getLogger(WorldBuilder.class);
+    private static final Logger logger = LoggerFactory.getLogger(GalaxyBuilder.class);
     //These ArrayLists hold class types of any class which extends SolarSystemGenerator or FeatureGenerator, respectively
     private ArrayList<Class<? extends SolarSystemGenerator>> solarSystemGeneratorTypes = new ArrayList<>();
     private ArrayList<Class<? extends FeatureGenerator>> featureGeneratorTypes = new ArrayList<>();
@@ -52,7 +52,7 @@ public class WorldBuilder {
     private SolarSystemConfigManager solarSystemConfigManager;
     private final int numberOfSystems;
 
-    public WorldBuilder(Context context, int numSystems) {
+    public GalaxyBuilder(Context context, int numSystems) {
         this.context = context;
         this.moduleManager = context.get(ModuleManager.class);
         this.solarSystemConfigManager = context.get(SolarSystemConfigManager.class);

--- a/engine/src/main/java/org/destinationsol/world/generators/LargeSolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/LargeSolarSystemGenerator.java
@@ -24,7 +24,7 @@ public class LargeSolarSystemGenerator extends SolarSystemGenerator {
     @Override
     public SolarSystem build() {
         getSolarSystemConfigManager().loadDefaultSolarSystemConfigs();
-        setSolarSystemConfig(getSolarSystemConfigManager().getRandomSolarSystemConfig(getSolarSystemNumber() > 0));
+        setSolarSystemConfigUsingDefault();
         setName(SolRandom.seededRandomElement(getDefaultSolarSystemNames()));
         initializeRandomDefaultFeatureGenerators(.8f);
         calculateFeaturePositions();

--- a/engine/src/main/java/org/destinationsol/world/generators/MazeGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/MazeGenerator.java
@@ -20,6 +20,8 @@ import org.destinationsol.game.ShipConfig;
 import org.destinationsol.game.maze.Maze;
 import org.destinationsol.game.maze.MazeConfig;
 import org.destinationsol.game.maze.MazeConfigManager;
+import org.destinationsol.game.maze.MazeLayout;
+import org.destinationsol.game.maze.MazeLayoutManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +37,9 @@ public abstract class MazeGenerator extends FeatureGenerator {
     private MazeConfigManager mazeConfigManager;
     private MazeConfig mazeConfig;
     private Maze maze;
+    private MazeLayoutManager mazeLayoutManager = new MazeLayoutManager();
+    private MazeLayout mazeLayout;
+    private boolean hasSetLayout;
 
     /**
      * This method modifies how often inner maze enemies will spawn.
@@ -95,7 +100,11 @@ public abstract class MazeGenerator extends FeatureGenerator {
      * at the end of the build() method in any MazeGenerator implementation.
      */
     protected void instantiateMaze() {
-        maze = new Maze(getMazeConfig(), getPosition(), getRadius());
+        if (layoutIsSet()) {
+            maze = new Maze(getMazeConfig(), getPosition(), getRadius(), getMazeLayout());
+        } else {
+            maze = new Maze(getMazeConfig(), getPosition(), getRadius());
+        }
     }
 
     public void setMazeConfigManager(MazeConfigManager mazeConfigManager) {
@@ -106,7 +115,24 @@ public abstract class MazeGenerator extends FeatureGenerator {
         return maze;
     }
 
+    protected MazeLayoutManager getMazeLayoutManager() {
+        return mazeLayoutManager;
+    }
+
     protected float calculateDefaultMazeSize() {
         return SolRandom.seededRandomFloat(.7f, 1) * MAX_MAZE_RADIUS;
+    }
+
+    protected void setMazeLayout(MazeLayout mazeLayout) {
+        this.mazeLayout = mazeLayout;
+        hasSetLayout = true;
+    }
+
+    public MazeLayout getMazeLayout() {
+        return mazeLayout;
+    }
+
+    protected boolean layoutIsSet() {
+        return hasSetLayout;
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
@@ -145,7 +145,7 @@ public abstract class SolarSystemGenerator {
     public abstract SolarSystemSize getSolarSystemSize();
 
     /**
-     * Override this method to tell the WorldBuilder how many non-default Features you want your SolarSystem to generate.
+     * Override this method to tell the GalaxyBuilder how many non-default Features you want your SolarSystem to generate.
      *
      * @return number of custom features
      */

--- a/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
@@ -509,6 +509,9 @@ public abstract class SolarSystemGenerator {
         return solarSystem;
     }
 
+    /**
+     * Sets the SolarSystemConfig to a Config using default difficulty settings
+     */
     public void setSolarSystemConfigUsingDefault() {
         setSolarSystemConfig(getSolarSystemConfigManager().getRandomSolarSystemConfig(getSolarSystemNumber() > 0));
     }

--- a/engine/src/main/java/org/destinationsol/world/generators/SpiralMazeGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SpiralMazeGenerator.java
@@ -15,14 +15,15 @@
  */
 package org.destinationsol.world.generators;
 
-public class SmallMazeGenerator extends MazeGenerator {
+public class SpiralMazeGenerator extends MazeGenerator {
 
     @Override
     public void build() {
-        setRadius(calculateDefaultMazeSize() * 0.6f);
+        setRadius(20f);
+        getMazeLayoutManager().load("spiralMazeLayout");
+        setMazeLayout(getMazeLayoutManager().getLayout("spiral"));
         setMazeConfig(getRandomMazeConfig());
 
-        modifyOuterEnemiesFrequency(1.21f);
         instantiateMaze();
     }
 }

--- a/engine/src/main/resources/org/destinationsol/assets/schemas/schemaMazeLayouts.json
+++ b/engine/src/main/resources/org/destinationsol/assets/schemas/schemaMazeLayouts.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "description": "A maze layout defines the structure a maze will be built with",
+  "required": [
+    "name",
+    "inner"
+  ],
+  "properties": {
+    "name" : {
+      "type": "string"
+    },
+    "inner" : {
+      "type": "array"
+    }
+  }
+}

--- a/engine/src/test/java/org/destinationsol/world/GalaxyBuilderTest.java
+++ b/engine/src/test/java/org/destinationsol/world/GalaxyBuilderTest.java
@@ -38,10 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class WorldBuilderTest implements AssetsHelperInitializer {
+public class GalaxyBuilderTest implements AssetsHelperInitializer {
     private Context context;
     private ModuleManager moduleManager;
-    WorldBuilder worldBuilder;
+    GalaxyBuilder galaxyBuilder;
     private GameColors gameColors;
     private EffectTypes effectTypes;
     private OggSoundManager soundManager;
@@ -94,41 +94,41 @@ public class WorldBuilderTest implements AssetsHelperInitializer {
     @Test
     void populatesSolarSystemsList() {
         int testNumberSystems = 2;
-        worldBuilder = new WorldBuilder(context, testNumberSystems);
-        worldBuilder.buildWithRandomSolarSystemGenerators();
-        assertTrue(worldBuilder.getSolarSystemGeneratorTypes().size() > 0);
+        galaxyBuilder = new GalaxyBuilder(context, testNumberSystems);
+        galaxyBuilder.buildWithRandomSolarSystemGenerators();
+        assertTrue(galaxyBuilder.getSolarSystemGeneratorTypes().size() > 0);
 
     }
 
     @Test
     void populatesFeatureGeneratorsList() {
         int testNumberSystems = 2;
-        worldBuilder = new WorldBuilder(context, testNumberSystems);
-        worldBuilder.buildWithRandomSolarSystemGenerators();
-        assertTrue(worldBuilder.getFeatureGeneratorTypes().size() > 0);
+        galaxyBuilder = new GalaxyBuilder(context, testNumberSystems);
+        galaxyBuilder.buildWithRandomSolarSystemGenerators();
+        assertTrue(galaxyBuilder.getFeatureGeneratorTypes().size() > 0);
     }
 
     @Test
     void createsCorrectNumberOfSolarSystemGenerators() {
         int testNumberSystems = 2;
-        worldBuilder = new WorldBuilder(context, testNumberSystems);
-        worldBuilder.buildWithRandomSolarSystemGenerators();
-        assertEquals(worldBuilder.getActiveSolarSystemGenerators().size(), 2);
+        galaxyBuilder = new GalaxyBuilder(context, testNumberSystems);
+        galaxyBuilder.buildWithRandomSolarSystemGenerators();
+        assertEquals(galaxyBuilder.getActiveSolarSystemGenerators().size(), 2);
     }
 
     @Test
     void createsCorrectNumberOfSolarSystems() {
         int testNumberSystems = 2;
-        worldBuilder = new WorldBuilder(context, testNumberSystems);
-        worldBuilder.buildWithRandomSolarSystemGenerators();
-        assertEquals(worldBuilder.getBuiltSolarSystems().size(), 2);
+        galaxyBuilder = new GalaxyBuilder(context, testNumberSystems);
+        galaxyBuilder.buildWithRandomSolarSystemGenerators();
+        assertEquals(galaxyBuilder.getBuiltSolarSystems().size(), 2);
     }
 
     @Test
     void setsContext() {
         int testNumberSystems = 2;
-        worldBuilder = new WorldBuilder(context, testNumberSystems);
-        assertNotNull(worldBuilder.getContext());
+        galaxyBuilder = new GalaxyBuilder(context, testNumberSystems);
+        assertNotNull(galaxyBuilder.getContext());
     }
 
 }

--- a/engine/src/test/java/org/destinationsol/world/GalaxyBuilderTest.java
+++ b/engine/src/test/java/org/destinationsol/world/GalaxyBuilderTest.java
@@ -25,7 +25,9 @@ import org.destinationsol.game.GameColors;
 import org.destinationsol.game.context.Context;
 import org.destinationsol.game.context.internal.ContextImpl;
 import org.destinationsol.game.item.ItemManager;
+import org.destinationsol.game.maze.MazeConfigManager;
 import org.destinationsol.game.particle.EffectTypes;
+import org.destinationsol.game.planet.BeltConfigManager;
 import org.destinationsol.game.planet.PlanetConfigManager;
 import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
@@ -74,6 +76,14 @@ public class GalaxyBuilderTest implements AssetsHelperInitializer {
         PlanetConfigManager planetConfigManager = new PlanetConfigManager(hullConfigManager, gameColors,itemManager);
         planetConfigManager.loadDefaultPlanetConfigs();
         context.put(PlanetConfigManager.class, planetConfigManager);
+
+        MazeConfigManager mazeConfigManager = new MazeConfigManager(hullConfigManager, itemManager);
+        mazeConfigManager.loadDefaultMazeConfigs();
+        context.put(MazeConfigManager.class, mazeConfigManager);
+
+        BeltConfigManager beltConfigManager = new BeltConfigManager(hullConfigManager, itemManager);
+        beltConfigManager.loadDefaultBeltConfigs();
+        context.put(BeltConfigManager.class, beltConfigManager);
 
         SolarSystemConfigManager solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
         context.put(SolarSystemConfigManager.class, solarSystemConfigManager);

--- a/engine/src/test/java/org/destinationsol/world/generators/BeltGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/BeltGeneratorTest.java
@@ -33,7 +33,7 @@ import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.testingUtilities.MockGL;
 import org.destinationsol.testsupport.AssetsHelperInitializer;
-import org.destinationsol.world.WorldBuilder;
+import org.destinationsol.world.GalaxyBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BeltGeneratorTest implements AssetsHelperInitializer {
     private Context context;
     private ModuleManager moduleManager;
-    private WorldBuilder worldBuilder;
+    private GalaxyBuilder galaxyBuilder;
     private GameColors gameColors;
     private EffectTypes effectTypes;
     private OggSoundManager soundManager;
@@ -63,9 +63,9 @@ public class BeltGeneratorTest implements AssetsHelperInitializer {
 
         setupConfigManagers();
 
-        worldBuilder = new WorldBuilder(context, 1);
+        galaxyBuilder = new GalaxyBuilder(context, 1);
 
-        ArrayList<SolarSystemGenerator> solarSystemGenerators = worldBuilder.initializeRandomSolarSystemGenerators();
+        ArrayList<SolarSystemGenerator> solarSystemGenerators = galaxyBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);
         setupSolarSystemGenerator();
         ArrayList<FeatureGenerator> activeFeatureGenerators = solarSystemGenerators.get(0).getActiveFeatureGenerators();

--- a/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
@@ -33,7 +33,7 @@ import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.testingUtilities.MockGL;
 import org.destinationsol.testsupport.AssetsHelperInitializer;
-import org.destinationsol.world.WorldBuilder;
+import org.destinationsol.world.GalaxyBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MazeGeneratorTest implements AssetsHelperInitializer {
     private Context context;
     private ModuleManager moduleManager;
-    private WorldBuilder worldBuilder;
+    private GalaxyBuilder galaxyBuilder;
     private GameColors gameColors;
     private EffectTypes effectTypes;
     private OggSoundManager soundManager;
@@ -63,9 +63,9 @@ public class MazeGeneratorTest implements AssetsHelperInitializer {
 
         setupConfigManagers();
 
-        worldBuilder = new WorldBuilder(context, 1);
+        galaxyBuilder = new GalaxyBuilder(context, 1);
 
-        ArrayList<SolarSystemGenerator> solarSystemGenerators = worldBuilder.initializeRandomSolarSystemGenerators();
+        ArrayList<SolarSystemGenerator> solarSystemGenerators = galaxyBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);
         setupSolarSystemGenerator();
         ArrayList<FeatureGenerator> activeFeatureGenerators = solarSystemGenerators.get(0).getActiveFeatureGenerators();

--- a/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
@@ -69,7 +69,11 @@ public class MazeGeneratorTest implements AssetsHelperInitializer {
         solarSystemGenerator = solarSystemGenerators.get(0);
         setupSolarSystemGenerator();
         ArrayList<FeatureGenerator> activeFeatureGenerators = solarSystemGenerators.get(0).getActiveFeatureGenerators();
-        mazeGenerator = (MazeGenerator) activeFeatureGenerators.get(activeFeatureGenerators.size() - 2);
+        for (FeatureGenerator featureGenerator : activeFeatureGenerators) {
+            if (MazeGenerator.class.isAssignableFrom(featureGenerator.getClass())) {
+                mazeGenerator = (MazeGenerator) featureGenerator;
+            }
+        }
     }
 
     private void setupMockGL() {

--- a/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
@@ -33,7 +33,7 @@ import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.testingUtilities.MockGL;
 import org.destinationsol.testsupport.AssetsHelperInitializer;
-import org.destinationsol.world.WorldBuilder;
+import org.destinationsol.world.GalaxyBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PlanetGeneratorTest implements AssetsHelperInitializer {
     private Context context;
     private ModuleManager moduleManager;
-    private WorldBuilder worldBuilder;
+    private GalaxyBuilder galaxyBuilder;
     private GameColors gameColors;
     private EffectTypes effectTypes;
     private OggSoundManager soundManager;
@@ -65,9 +65,9 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
 
         setupConfigManagers();
 
-        worldBuilder = new WorldBuilder(context, 1);
+        galaxyBuilder = new GalaxyBuilder(context, 1);
 
-        ArrayList<SolarSystemGenerator> solarSystemGenerators = worldBuilder.initializeRandomSolarSystemGenerators();
+        ArrayList<SolarSystemGenerator> solarSystemGenerators = galaxyBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);
         setupSolarSystemGenerator();
         planetGenerator = (PlanetGenerator) solarSystemGenerators.get(0).getActiveFeatureGenerators().get(1);

--- a/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/PlanetGeneratorTest.java
@@ -139,12 +139,12 @@ public class PlanetGeneratorTest implements AssetsHelperInitializer {
     }
 
     @Test
-    void planetHasPositiveRotationSpeed() {
-        assertTrue(planetGenerator.getPlanetRotationSpeed() > 0);
+    void planetHasNonzeroRotationSpeed() {
+        assertTrue(planetGenerator.getPlanetRotationSpeed() != 0);
     }
 
     @Test
-    void planetHasPositiveOrbitSpeed() {
-        assertTrue(planetGenerator.getPlanetRotationSpeed() > 0);
+    void planetHasNonzeroOrbitSpeed() {
+        assertTrue(planetGenerator.getPlanetRotationSpeed() != 0);
     }
 }

--- a/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
@@ -24,8 +24,10 @@ import org.destinationsol.game.GameColors;
 import org.destinationsol.game.context.Context;
 import org.destinationsol.game.context.internal.ContextImpl;
 import org.destinationsol.game.item.ItemManager;
+import org.destinationsol.game.maze.MazeConfigManager;
 import org.destinationsol.game.particle.EffectTypes;
 import org.destinationsol.assets.sound.OggSoundManager;
+import org.destinationsol.game.planet.BeltConfigManager;
 import org.destinationsol.game.planet.PlanetConfigManager;
 import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
@@ -84,6 +86,14 @@ public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
         PlanetConfigManager planetConfigManager = new PlanetConfigManager(hullConfigManager, gameColors,itemManager);
         planetConfigManager.loadDefaultPlanetConfigs();
         context.put(PlanetConfigManager.class, planetConfigManager);
+
+        MazeConfigManager mazeConfigManager = new MazeConfigManager(hullConfigManager, itemManager);
+        mazeConfigManager.loadDefaultMazeConfigs();
+        context.put(MazeConfigManager.class, mazeConfigManager);
+
+        BeltConfigManager beltConfigManager = new BeltConfigManager(hullConfigManager, itemManager);
+        beltConfigManager.loadDefaultBeltConfigs();
+        context.put(BeltConfigManager.class, beltConfigManager);
 
         SolarSystemConfigManager solarSystemConfigManager = new SolarSystemConfigManager(hullConfigManager, itemManager);
         context.put(SolarSystemConfigManager.class, solarSystemConfigManager);

--- a/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/SolarSystemGeneratorTest.java
@@ -31,7 +31,7 @@ import org.destinationsol.game.planet.SolarSystemConfigManager;
 import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.testingUtilities.MockGL;
 import org.destinationsol.testsupport.AssetsHelperInitializer;
-import org.destinationsol.world.WorldBuilder;
+import org.destinationsol.world.GalaxyBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
     private Context context;
     private ModuleManager moduleManager;
-    private WorldBuilder worldBuilder;
+    private GalaxyBuilder galaxyBuilder;
     private GameColors gameColors;
     private EffectTypes effectTypes;
     private OggSoundManager soundManager;
@@ -63,9 +63,9 @@ public class SolarSystemGeneratorTest implements AssetsHelperInitializer {
 
         setupConfigManagers();
 
-        worldBuilder = new WorldBuilder(context, 1);
+        galaxyBuilder = new GalaxyBuilder(context, 1);
 
-        ArrayList<SolarSystemGenerator> solarSystemGenerators = worldBuilder.initializeRandomSolarSystemGenerators();
+        ArrayList<SolarSystemGenerator> solarSystemGenerators = galaxyBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);
         setupSolarSystemGenerator();
     }

--- a/modules/core/assets/mazes/spiralMazeLayout.json
+++ b/modules/core/assets/mazes/spiralMazeLayout.json
@@ -1,0 +1,15 @@
+{
+  "name" : "spiral",
+  "inner": [
+    [true, true, true, true, true, true, true, true, true, true],
+    [true, false, false, false, false, false, false, false, false, false],
+    [true, false, true, true, true, true, true, true, true, true],
+    [true, false, true, false, false, false, false, false, false, true],
+    [true, false, true, false, true, true, true, true, false, true],
+    [true, false, true, false, true, false, false, true, false, true],
+    [true, false, true, false, false, false, false, true, false, true],
+    [true, false, true, true, true, true, true, true, false, true],
+    [true, false, false, false, false, false, false, false, false, true],
+    [true, true, true, true, true, true, true, true, true, true]
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This PR adds a system for users to add their own custom maze layouts. These are represented in JSON by 2D arrays, and in the game as areas where mazes tiles do or do not generate. Also in this PR, WorldBuilder is renamed to GalaxyBuilder.

# Testing
Fly around until you find a smaller Maze. If you are lucky, it will by a SpiralMaze. You'll be able to tell by the spiral shape the maze forms (it is a bit too big to see at once, fly around the maze a bit to tell).

# Outstanding Work
This one involves loading in JSON so I wasn't sure how to write unit tests for it, but that still need to be done. 
