### PR TITLE
Attempt to exclude LGTM processing of now-deleted embedded JRE files (and update from develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center"><img src="readMeLogo.png" alt="Destination Sol"/></p>
 
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/MovingBlocks/DestinationSol)
+[![Discord](https://img.shields.io/discord/270264625419911192.svg?label=discord)](http://discord.gg/Terasology)
 
 This is the official open source home for the arcade space shooter Destination Sol, originally started by Milosh Petrov and a small team on [Steam](http://store.steampowered.com/app/342980/) and [SourceForge](http://sourceforge.net/projects/destinationsol)
 
@@ -12,7 +13,7 @@ Milosh accepted our offer and supported us in moving the game onwards to its new
 
 Destination Sol is now officially licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) (except soundtrack, see its section below) and available in source code form at [GitHub](https://github.com/MovingBlocks/DestinationSol).
 
-You can download the game on [Steam](http://store.steampowered.com/app/342980/), get it in the [Google Play Store](https://play.google.com/store/apps/details?id=com.miloshpetrov.sol2.android&hl=en), or download the [very latest version from our build server](http://jenkins.terasology.org/job/DestinationSol/lastSuccessfulBuild/artifact/desktop/build/distributions/DestinationSol.zip) (warning: latest build may be unstable)
+You can download the game on [Steam](http://store.steampowered.com/app/342980/), get it in the [Google Play Store](https://play.google.com/store/apps/details?id=com.miloshpetrov.sol2.android&hl=en), or download the [very latest version from our build server](http://jenkins.terasology.io/teraorg/job/DestinationSol/job/engine/job/develop/lastSuccessfulBuild/artifact/desktop/build/distributions/DestinationSol.zip) (warning: latest build may be unstable)
 
 Feel free to fork the project and contribute pull requests! You can visit a [Destination Sol forum](http://forum.terasology.org/forum/destination-sol.57/) on the Terasology site if you have any questions or would like to discuss the game or contributing.
 
@@ -67,33 +68,16 @@ Note: You can select either pure keyboard, keyboard + mouse, or controller (in t
 Building and running from source
 --------
 
-You only need Java installed to run Destination Sol from source. Use Java 7 or 8, the newer the better.
+You only need Java 8 installed to run Destination Sol from source.
 
 Run any commands in the project root directory (where you cloned / extracted the project to, using a command prompt / terminal).
 
 * Download / clone the [source from GitHub](https://github.com/MovingBlocks/DestinationSol)
 * To run from the command line: `gradlew run` (on Linux you might need to use `./gradlew run`)
 * To prepare for IntelliJ run: `gradlew idea` then load the generated project via `DestinationSol.ipr`
-* Distributions (Windows, Linux, Mac) should be obtained from the [Jenkins build server](http://jenkins.terasology.org/view/DestSol/job/DestinationSol/), but you can also create a distribution locally by running: `gradlew distZipBundleJREs`
+* Distributions (Windows, Linux, Mac) can be created locally by running: `gradlew distZipBundleJREs`
 
-For Android a little extra setup is needed
-
-* Add in the Android code: `gradlew fetchAndroid` and then rerun Gradle once - for instance `gradlew idea` again
-* Install the official Android SDK from Google - exact version info is still TODO
-* Make a local.properties in the project root with the path to your SDK. Example: sdk.dir=C\:/Dev/Android/SDK
-* To prepare in IntelliJ go to Project Structure and under Modules click the android "folder" icon and set the SDK
-* In the same window go to Artifacts and add a new Android Application, created from the android module
-* Supply a code signing keystore or supply other debug configuration
-* To run in IntelliJ make sure you have an Android emulator (or USB connection) working then create a run configuration
-* We use `gradlew assembleRelease` to build the APK for Google Play (with the right keystore etc)
-
-You can also run the Android version via Gradle: `gradlew android` - but need your device setup. TODO more instructions.
-
-GWT / HTML
-
-LibGDX supports an HTML based facade based on the Google Web Toolkit. Its use isn't all the way implemented yet.
-
-* Add in the code like with Android: `gradlew fetchGwt` then rerun Gradle
+For Android a little extra setup is needed. See instructions [here](https://github.com/MovingBlocks/DestSolAndroid).
 
 [Steam Release Process](steam/SteamRelease.md)
 ------------
@@ -101,64 +85,12 @@ LibGDX supports an HTML based facade based on the Google Web Toolkit. Its use is
 Contributors
 ------------
 [GitHub contribution stats](https://github.com/MovingBlocks/DestinationSol/graphs/contributors)
+[Contribution Leaderboard](http://destinationsol.org/contribute)
 
-*Original creators:*
+* Original creators: [Milosh Petrov](https://github.com/miloshpetrov), [Nika Burimenko](https://github.com/NoiseDoll), Kent C. Jensen, Julia Nikolaeva
 
-* [Milosh Petrov](https://github.com/miloshpetrov)
-* [Nika Burimenko](https://github.com/NoiseDoll)
-* Kent C. Jensen
-* Julia Nikolaeva
-
-*Contributors on GitHub:*
-
-* [Cervator](https://github.com/Cervator)
-* [Rulasmur](https://github.com/Rulasmur) (PrivateAlpha)
-* [theotherjay](https://github.com/theotherjay)
-* [LinusVanElswijk](https://github.com/LinusVanElswijk)
-* [SimonC4](https://github.com/SimonC4)
-* [grauerkoala](https://github.com/grauerkoala)
-* [rzats](https://github.com/rzats)
-* [LadySerenaKitty](https://github.com/LadySerenaKitty)
-* [askneller](https://github.com/askneller)
-* [JGelfand](https://github.com/JGelfand)
-* [AvaLanCS](https://github.com/Avalancs)
-* [scirelli](https://github.com/scirelli)
-* [Sigma-One](https://github.com/Sigma-One)
-* [vampcat](https://github.com/vampcat)
-* [Malanius](https://github.com/Malanius)
-* [AonoZan](https://github.com/AonoZan)
-* [ererbe](https://github.com/ererbe)
-* [SurajDutta](https://github.com/SurajDuta)
-* [jasyohuang](https://github.com/jasyohuang)
-* [Steampunkery](https://github.com/Steampunkery)
-* [Graviton48](https://github.com/Graviton48)
-* [Adrijaned](https://github.com/Adrijaned)
-* [MaxBorsch](https://github.com/MaxBorsch)
-* [sohil123](https://github.com/sohil123)
-* [FieryPheonix909](https://github.com/FieryPheonix909)
-* [digitalripperynr](https://github.com/digitalripperynr)
-* [NicholasBatesNZ](https://github.com/NicholasBatesNZ)
-* [Pendi](https://github.com/ZPendi)
-* [Torpedo99](https://github.com/Torpedo99)
-* [AndyTechGuy](https://github.com/AndyTechGuy)
-* [BenjaminAmos](https://github.com/BenjaminAmos)
-* [dannykelemen](https://github.com/dannykelemen)
-* [msteiger](https://github.com/msteiger)
-* [oniatus](https://github.com/oniatus)
-* [arpitkamboj](https://github.com/arpitkamboj)
-* [manas96](https://github.com/manas96)
-* [IsaacLic](https://github.com/IsaacLic)
-* [Mpcs](https://github.com/Mpcs)
-* [ZPendi](https://github.com/ZPendi)
-* [nailorcngci](https://github.com/nailorcngci)
-* [FearlessTobi](https://github.com/FearlessTobi)
-* [ujjman](https://github.com/ujjman)
-* [ThisIsPIRI](https://github.com/ThisIsPIRI)
-* [Esnardo](https://github.com/Esnardo)
-
+* Contributors on GitHub: [Cervator](https://github.com/Cervator), [Rulasmur (PrivateAlpha)](https://github.com/Rulasmur), [theotherjay](https://github.com/theotherjay), [LinusVanElswijk](https://github.com/LinusVanElswijk), [SimonC4](https://github.com/SimonC4), [grauerkoala](https://github.com/grauerkoala), [rzats](https://github.com/rzats), [LadySerenaKitty](https://github.com/LadySerenaKitty), [askneller](https://github.com/askneller), [JGelfand](https://github.com/JGelfand), [AvaLanCS](https://github.com/Avalancs), [scirelli](https://github.com/scirelli), [Sigma-One](https://github.com/Sigma-One), [vampcat](https://github.com/vampcat), [Malanius](https://github.com/Malanius), [AonoZan](https://github.com/AonoZan), [ererbe](https://github.com/ererbe), [SurajDutta](https://github.com/SurajDuta), [jasyohuang](https://github.com/jasyohuang), [Steampunkery](https://github.com/Steampunkery), [Graviton48](https://github.com/Graviton48), [Adrijaned](https://github.com/Adrijaned), [MaxBorsch](https://github.com/MaxBorsch), [sohil123](https://github.com/sohil123), [FieryPheonix909](https://github.com/FieryPheonix909), [digitalripperynr](https://github.com/digitalripperynr), [NicholasBatesNZ](https://github.com/NicholasBatesNZ), [Pendi](https://github.com/ZPendi), [Torpedo99](https://github.com/Torpedo99), [AndyTechGuy](https://github.com/AndyTechGuy), [BenjaminAmos](https://github.com/BenjaminAmos), [dannykelemen](https://github.com/dannykelemen), [msteiger](https://github.com/msteiger), [oniatus](https://github.com/oniatus), [arpitkamboj](https://github.com/arpitkamboj), [manas96](https://github.com/manas96), [IsaacLic](https://github.com/IsaacLic), [Mpcs](https://github.com/Mpcs), [ZPendi](https://github.com/ZPendi), [nailorcngci](https://github.com/nailorcngci), [FearlessTobi](https://github.com/FearlessTobi), [ujjman](https://github.com/ujjman), [ThisIsPIRI](https://github.com/ThisIsPIRI), [Esnardo](https://github.com/Esnardo) 
 ... and your name here? :-) More coming!
-
-*Additional credits:*
 
 * Soundtrack - Provided by [NeonInsect](https://github.com/NeonInsect) ([Soundcloud](https://soundcloud.com/neon-insect)) and copyrighted by him [CC-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/), free for our use with Destination Sol.
 * All sprites from MillionthVector are licensed under a Creative Commons Attribution 4.0 International License - originally reachable at millionthvector.blogspot.id

--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -175,6 +175,10 @@ public class SolApplication implements ApplicationListener {
 
     @Override
     public void resize(int newWidth, int newHeight) {
+        //To prevent application crashing, dont resize the height and width to 0 s, this condition checks it
+        if (newWidth == 0 && newHeight == 0) {
+            return;
+        }
         displayDimensions.set(newWidth, newHeight);
 
         for (ResizeSubscriber resizeSubscriber : resizeSubscribers) {
@@ -292,7 +296,7 @@ public class SolApplication implements ApplicationListener {
 
                 EntityRef entityRef = entitySystemManager.getEntityManager().createEntity(graphicsComponent, position, size,
                         new Angle(), new Velocity(), new AsteroidMesh(), health, new DropsMoneyOnDestruction(), new CreatesRubbleOnDestruction());
-                
+
                 entityRef.setComponent(new BodyLinked());
                 entityCreated = true;
             }
@@ -416,7 +420,7 @@ public class SolApplication implements ApplicationListener {
     public Context getContext() {
         return context;
     }
-  
+
     public NUIManager getNuiManager() {
         return nuiManager;
     }

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  ignore:
+    - exclude: launcher


### PR DESCRIPTION
The GSOC branch for some reason trips up LGTM into thinking Javascript files have changed, which it then promptly fails to build, as we don't have any. Once upon a time we did, when we had LWJGL/JRE files embedded in the repo, but those have long since been deleted. Seemingly every PR since just thought the JS hadn't changed and thus didn't try to rerun it and left the check green. The GSOC one retriggered the JS build earning it a red x - this attempts to entirely get rid of JS as a considered language by excluding the directory they used to live in. Lets see what happens!

This also updates the gsoc branch from develop as I'm missing the handy little button that lets us do that via the UI - not sure if maybe that's only available if branch protection is on in some fashion but not really worried about figuring that out right now.