### PR TITLE
De-duplicate assets on Android

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         // HACK: Needed for NUI and gestalt entity-component reflections
         classpath group: 'org.terasology.nui', name: 'nui', version: '3.1.0-SNAPSHOT'
         classpath group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
-        classpath group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.0.6-SNAPSHOT'
+        classpath group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.2.0-SNAPSHOT'
     }
 }
 
@@ -42,10 +42,10 @@ dependencies {
     api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
     api "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
 
-    api(group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.0.6-SNAPSHOT')
-    api(group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.0.6-SNAPSHOT')
-    api(group: 'org.terasology.gestalt', name: 'gestalt-module', version: '7.0.6-SNAPSHOT')
-    api(group: 'org.terasology.gestalt', name: 'gestalt-util', version: '7.0.6-SNAPSHOT')
+    api(group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.2.0-SNAPSHOT')
+    api(group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.2.0-SNAPSHOT')
+    api(group: 'org.terasology.gestalt', name: 'gestalt-module', version: '7.2.0-SNAPSHOT')
+    api(group: 'org.terasology.gestalt', name: 'gestalt-util', version: '7.2.0-SNAPSHOT')
 
     api group: 'org.terasology.nui', name: 'nui', version: nuiVersion
     api group: 'org.terasology.nui', name: 'nui-libgdx', version: nuiVersion
@@ -82,7 +82,7 @@ task cacheReflections {
             configurations."${sourceSets.main.runtimeClasspathConfigurationName}"
 
     outputs.upToDateWhen {classes.state.upToDate}
-    outputs.file("$buildDir/classes/reflections.cache")
+    outputs.file("$buildDir/resources/main/org/destinationsol/reflections.cache")
     dependsOn classes
 
     doLast {
@@ -91,7 +91,7 @@ task cacheReflections {
                 .addUrls(inputs.files.collect { it.toURI().toURL() })
                 .filterInputsBy({ it.startsWith("org.destinationsol") || it.startsWith("org.terasology.nui") })
                 .setScanners(new TypeAnnotationsScanner(), new SubTypesScanner()))
-        reflections.save("$buildDir/classes/reflections.cache")
+        reflections.save("$buildDir/resources/main/org/destinationsol/reflections.cache")
     }
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         classpath 'dom4j:dom4j:1.6.1'
 
         // HACK: Needed for NUI and gestalt entity-component reflections
-        classpath group: 'org.terasology.nui', name: 'nui', version: '2.0.0-SNAPSHOT'
+        classpath group: 'org.terasology.nui', name: 'nui', version: '3.1.0-SNAPSHOT'
         classpath group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
         classpath group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.0.6-SNAPSHOT'
     }
@@ -89,6 +89,7 @@ task cacheReflections {
         // Without the .mkdirs() we might hit a scenario where the classes dir doesn't exist yet
         Reflections reflections = new Reflections(new ConfigurationBuilder()
                 .addUrls(inputs.files.collect { it.toURI().toURL() })
+                .filterInputsBy({ it.startsWith("org.destinationsol") || it.startsWith("org.terasology.nui") })
                 .setScanners(new TypeAnnotationsScanner(), new SubTypesScanner()))
         reflections.save("$buildDir/classes/reflections.cache")
     }

--- a/engine/src/main/java/org/destinationsol/assets/sound/AndroidOggSoundFileFormat.java
+++ b/engine/src/main/java/org/destinationsol/assets/sound/AndroidOggSoundFileFormat.java
@@ -16,13 +16,11 @@
 package org.destinationsol.assets.sound;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.files.FileHandle;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.format.AbstractAssetFileFormat;
 import org.terasology.gestalt.assets.format.AssetDataFile;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
 public class AndroidOggSoundFileFormat extends AbstractAssetFileFormat<OggSoundData> {
@@ -33,15 +31,26 @@ public class AndroidOggSoundFileFormat extends AbstractAssetFileFormat<OggSoundD
     @Override
     public OggSoundData load(ResourceUrn urn, List<AssetDataFile> inputs) throws IOException {
         // HACK: LibGDX will only accept an AndroidFileHandle (it casts to one internally). The class has a private
-        //       constructor, so we cannot use the same workaround as with AssetDataFileHandle. The only plausible way
-        //        to do this appears to be to save the data out to a file and point LibGDX at that.
+        //       constructor, so we cannot use the same workaround as with AssetDataFileHandle.
+        //       Android also doesn't seem to support playing media directly form InputStreams directly either.
+        //       The only way I've found to get around this is to bypass gestalt using the information it provides
+        //       on the source path for the asset.
+        //       Android will be forced to use directory modules exclusively because of this.
         AssetDataFile asset = inputs.get(0);
-        FileHandle outFile = Gdx.files.local("sound/" + urn.toString().replace(":", "_") + "." + inputs.get(0).getFileExtension());
-        if (!outFile.exists()) {
-            InputStream fileStream = asset.openStream();
-            outFile.write(fileStream, false);
-        }
 
-        return new OggSoundData(Gdx.audio.newSound(outFile));
+        StringBuilder pathStringBuilder = new StringBuilder();
+        if (urn.getModuleName().compareTo("engine") != 0) {
+            pathStringBuilder.append("modules/");
+        }
+        pathStringBuilder.append(urn.getModuleName());
+        pathStringBuilder.append("/");
+
+        for (int pathNo = 0; pathNo < asset.getPath().size(); pathNo++) {
+            pathStringBuilder.append(asset.getPath().get(pathNo));
+            pathStringBuilder.append('/');
+        }
+        pathStringBuilder.append(asset.getFilename());
+
+        return new OggSoundData(Gdx.audio.newSound(Gdx.files.internal(pathStringBuilder.toString())));
     }
 }

--- a/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
+++ b/engine/src/main/java/org/destinationsol/body/components/BodyLinked.java
@@ -47,7 +47,7 @@ public class BodyLinked implements Component<BodyLinked> {
     }
 
     @Override
-    public void copy(BodyLinked other) {
+    public void copyFrom(BodyLinked other) {
         this.mass = other.getMass();
     }
 }

--- a/engine/src/main/java/org/destinationsol/force/components/Durability.java
+++ b/engine/src/main/java/org/destinationsol/force/components/Durability.java
@@ -49,7 +49,7 @@ public class Durability implements Component<Durability> {
     }
 
     @Override
-    public void copy(Durability other) {
+    public void copyFrom(Durability other) {
         this.durability = other.durability;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/console/adapter/ParameterAdapter.java
+++ b/engine/src/main/java/org/destinationsol/game/console/adapter/ParameterAdapter.java
@@ -15,6 +15,9 @@
  */
 package org.destinationsol.game.console.adapter;
 
+import org.terasology.gestalt.module.sandbox.API;
+
+@API
 public interface ParameterAdapter<T> {
     T parse(String raw);
 

--- a/engine/src/main/java/org/destinationsol/game/console/adapter/ParameterAdapterManager.java
+++ b/engine/src/main/java/org/destinationsol/game/console/adapter/ParameterAdapterManager.java
@@ -20,9 +20,11 @@ import com.google.common.collect.Maps;
 import org.destinationsol.SolApplication;
 import org.destinationsol.game.console.commands.PositionCommandHandler;
 import org.destinationsol.game.ship.hulls.HullConfig;
+import org.terasology.gestalt.module.sandbox.API;
 
 import java.util.Map;
 
+@API
 public class ParameterAdapterManager {
     private final Map<Class<?>, ParameterAdapter> adapters = Maps.newHashMap();
 

--- a/engine/src/main/java/org/destinationsol/game/console/annotations/package-info.java
+++ b/engine/src/main/java/org/destinationsol/game/console/annotations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.game.console.annotations;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/game/console/suggesters/package-info.java
+++ b/engine/src/main/java/org/destinationsol/game/console/suggesters/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.game.console.suggesters;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/game/drawables/animated/AnimatedRectSprite.java
+++ b/engine/src/main/java/org/destinationsol/game/drawables/animated/AnimatedRectSprite.java
@@ -24,10 +24,12 @@ import org.destinationsol.game.SolGame;
 import org.destinationsol.game.SolObject;
 import org.destinationsol.game.drawables.DrawableLevel;
 import org.destinationsol.game.drawables.RectSprite;
+import org.terasology.gestalt.module.sandbox.API;
 
 /**
  * AnimatedRectSprites are a specialised variant of RectSprites that can play a single animation, based off a sprite-sheet texture
  */
+@API
 public class AnimatedRectSprite extends RectSprite {
     private Animation<TextureAtlas.AtlasRegion> spriteAnimation;
     private float animationTime;

--- a/engine/src/main/java/org/destinationsol/location/components/Angle.java
+++ b/engine/src/main/java/org/destinationsol/location/components/Angle.java
@@ -27,7 +27,7 @@ public class Angle implements Component<Angle> {
     private float angle;
 
     @Override
-    public void copy(Angle other) {
+    public void copyFrom(Angle other) {
         this.angle = other.angle;
     }
 

--- a/engine/src/main/java/org/destinationsol/location/components/Position.java
+++ b/engine/src/main/java/org/destinationsol/location/components/Position.java
@@ -27,7 +27,7 @@ public class Position implements Component<Position> {
     public Vector2 position = new Vector2();
 
     @Override
-    public void copy(Position other) {
+    public void copyFrom(Position other) {
         position = other.position.cpy();
     }
 }

--- a/engine/src/main/java/org/destinationsol/location/components/Velocity.java
+++ b/engine/src/main/java/org/destinationsol/location/components/Velocity.java
@@ -27,7 +27,7 @@ public class Velocity implements Component<Velocity> {
     public Vector2 velocity = new Vector2();
 
     @Override
-    public void copy(Velocity other) {
+    public void copyFrom(Velocity other) {
         velocity = other.velocity.cpy();
     }
 }

--- a/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
@@ -106,7 +106,34 @@ public class ModuleManager {
             "com.badlogic.gdx.graphics.g2d",
             // The hull config exposes a box2d body instance
             "com.badlogic.gdx.physics",
-            "com.badlogic.gdx.physics.box2d"
+            "com.badlogic.gdx.physics.box2d",
+            // NUI doesn't use gestalt's @API annotations anymore, so they are replicated here
+            "org.terasology.input",
+            "org.terasology.input.device",
+            "org.terasology.input.device.nulldevices",
+            "org.terasology.nui",
+            "org.terasology.nui.asset",
+            "org.terasology.nui.asset.font",
+            "org.terasology.nui.canvas",
+            "org.terasology.nui.databinding",
+            "org.terasology.nui.events",
+            "org.terasology.nui.itemRendering",
+            "org.terasology.nui.layouts",
+            "org.terasology.nui.layouts.miglayout",
+            "org.terasology.nui.layouts.relative",
+            "org.terasology.nui.properties",
+            "org.terasology.nui.reflection",
+            "org.terasology.nui.skin",
+            "org.terasology.nui.translate",
+            "org.terasology.nui.util",
+            "org.terasology.nui.widgets",
+            "org.terasology.nui.widgets.treeView",
+            "org.terasology.nui.widgets.types",
+            "org.terasology.nui.widgets.types.builtin",
+            "org.terasology.nui.widgets.types.builtin.object",
+            "org.terasology.nui.widgets.types.builtin.util",
+            "org.terasology.nui.widgets.types.math",
+            "org.terasology.reflection.metadata"
     };
     protected static final Class<?>[] CLASS_WHITELIST = new Class<?>[]{
             InvocationTargetException.class,
@@ -162,7 +189,14 @@ public class ModuleManager {
             org.terasology.gestalt.entitysystem.entity.EntityManager.class,
             org.terasology.gestalt.entitysystem.event.EventResult.class,
             org.terasology.gestalt.entitysystem.event.ReceiveEvent.class,
-            org.terasology.gestalt.entitysystem.prefab.GeneratedFromRecipeComponent.class
+            org.terasology.gestalt.entitysystem.prefab.Prefab.class,
+            org.terasology.gestalt.entitysystem.prefab.GeneratedFromRecipeComponent.class,
+            /* NUI classes */
+            org.terasology.input.device.InputDevice.class,
+            org.terasology.input.device.KeyboardDevice.class,
+            org.terasology.input.device.MouseDevice.class,
+            org.terasology.reflection.MappedContainer.class,
+            org.terasology.reflection.TypeInfo.class
     };
 
     protected static ModuleEnvironment environment;
@@ -229,7 +263,7 @@ public class ModuleManager {
         scanner.scan(reflections);
         Policy.setPolicy(new ModuleSecurityPolicy());
         System.setSecurityManager(new ModuleSecurityManager());
-        environment = new ModuleEnvironment(modules,permissionFactory);
+        environment = new ModuleEnvironment(modules, permissionFactory);
     }
 
     public ModuleEnvironment getEnvironment() {

--- a/engine/src/main/java/org/destinationsol/rendering/components/Renderable.java
+++ b/engine/src/main/java/org/destinationsol/rendering/components/Renderable.java
@@ -30,7 +30,7 @@ public final class Renderable implements Component<Renderable> {
     public boolean isInvisible;
 
     @Override
-    public void copy(Renderable other) {
+    public void copyFrom(Renderable other) {
         ArrayList<RenderableElement> newElements = new ArrayList<>();
         for (int index = 0; index < other.elements.size(); index++) {
             RenderableElement data = new RenderableElement();

--- a/engine/src/main/java/org/destinationsol/size/components/Size.java
+++ b/engine/src/main/java/org/destinationsol/size/components/Size.java
@@ -25,7 +25,7 @@ public class Size implements Component<Size> {
     public float size;
 
     @Override
-    public void copy(Size other) {
+    public void copyFrom(Size other) {
         this.size = other.size;
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/nui/package-info.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.ui.nui;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/package-info.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.ui.nui.screens;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/ui/nui/widgets/package-info.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/widgets/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.ui.nui.widgets;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/world/generators/package-info.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.world.generators;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/engine/src/main/java/org/destinationsol/world/package-info.java
+++ b/engine/src/main/java/org/destinationsol/world/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Terasology Foundation
+ * Copyright 2021 The Terasology Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.destinationsol.health.components;
+@API package org.destinationsol.world;
 
-import org.terasology.gestalt.entitysystem.component.Component;
-
-/**
- * Contains information about the health of an entity.
- */
-public final class Health implements Component<Health> {
-
-    public float maxHealth = 30;
-    public float currentHealth = 30;
-
-    @Override
-    public void copyFrom(Health other) {
-        this.maxHealth = other.maxHealth;
-        this.currentHealth = other.currentHealth;
-    }
-}
+import org.terasology.gestalt.module.sandbox.API;

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -183,9 +183,7 @@ task createSkeleton() {
 
 task cacheReflections {
     description = 'Caches reflection output to make regular startup faster. May go stale and need cleanup at times.'
-    inputs.files sourceSets.main.output.classesDirs,
-            // getClassesDir from all sourceSets (for any jvm (seems) language)
-            configurations."${sourceSets.main.runtimeClasspathConfigurationName}"
+    inputs.files sourceSets.main.output.classesDirs
 
     outputs.upToDateWhen {classes.state.upToDate}
     outputs.file("$buildDir/classes/reflections.cache")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request contains the corresponding engine changes for the Android pull request MovingBlocks/DestSolAndroid#22. See that pull request for a description of the build system changes.

The engine changes are as follows:
 - Changed the output path for the engine module reflections cache to make it easier to symlink
 - Reduced the classes included in reflection caches in general, leading to an overall module size reduction
 - Updated gestalt to the latest release.
 - Updated `AndroidOggMusicFileFormat` and `AndroidOggSoundFormat` to use a new method for reading files that eliminates the need to copy them onto the filesystem on Android. This method requires the music and sound files to be present in a directory module directly in the Android `assets` directory instead of in a jar, which the Android build scripts 

# Testing
- Android should still work the same as before with these changes. The APK file sizes should be considerably smaller though.
- As a comparison, the v2.0.0 APK (with duplicated assets) is approximately 121MB. This is for the base game only, with no additional modules.
- With these changes, the APK size is approximately 107MB (base game only).

# Notes
- This depends on MovingBlocks/DestSolAndroid#22
- Breaking changes in the latest gestalt (7.x) release mean that this will likely break existing ECS pull requests. The `Component#copy` method has been renamed to `Component#copyFrom`.
- With these changes, it is no longer possible to use archive modules (jar/zip modules) on Android. For a from-source workspace though, there should be no functional difference.