### PR TITLE
fix: fix Android textures bug

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -38,6 +38,7 @@ import org.destinationsol.game.SolGame;
 import org.destinationsol.game.SolNames;
 import org.destinationsol.game.WorldConfig;
 import org.destinationsol.game.drawables.DrawableLevel;
+import org.destinationsol.game.drawables.SpriteManager;
 import org.destinationsol.health.components.Health;
 import org.destinationsol.location.components.Angle;
 import org.destinationsol.location.components.Velocity;
@@ -377,6 +378,12 @@ public class SolApplication implements ApplicationListener {
         }
 
         inputManager.dispose();
+
+        SpriteManager.clearCache();
+
+        Assets.getAssetHelper().dispose();
+
+        moduleManager.dispose();
     }
 
     public SolGame getGame() {

--- a/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
@@ -23,6 +23,8 @@ import org.destinationsol.assets.music.OggMusic;
 import org.destinationsol.assets.sound.OggSound;
 import org.destinationsol.assets.ui.UIFormat;
 import org.destinationsol.assets.ui.UISkinFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetData;
 import org.terasology.gestalt.assets.AssetType;
@@ -47,10 +49,12 @@ import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 
 public class AssetHelper {
+    private static final Logger logger = LoggerFactory.getLogger(AssetHelper.class);
     private ModuleAwareAssetTypeManager assetTypeManager;
 
     public AssetHelper() {
@@ -114,5 +118,14 @@ public class AssetHelper {
             return false;
         });
         return list;
+    }
+
+    public void dispose() {
+        try {
+            assetTypeManager.unloadEnvironment();
+            assetTypeManager.close();
+        } catch (IOException e) {
+            logger.error("Error closing assetTypeManager", e);
+        }
     }
 }

--- a/engine/src/main/java/org/destinationsol/assets/textures/DSTexture.java
+++ b/engine/src/main/java/org/destinationsol/assets/textures/DSTexture.java
@@ -18,22 +18,30 @@ package org.destinationsol.assets.textures;
 import com.badlogic.gdx.graphics.Texture;
 import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetType;
+import org.terasology.gestalt.assets.DisposableResource;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.module.annotations.RegisterAssetType;
 import org.terasology.nui.UITextureRegion;
 
 @RegisterAssetType(folderName = {"textures", "ships", "items", "grounds", "mazes", "asteroids", "fonts"}, factoryClass = DSTextureFactory.class)
 public class DSTexture extends Asset<DSTextureData> {
+    private final TextureResources resources;
     private DSTextureData dsTextureData;
 
-    public DSTexture(ResourceUrn urn, AssetType<?, DSTextureData> assetType, DSTextureData data) {
-        super(urn, assetType);
+    public DSTexture(ResourceUrn urn, AssetType<?, DSTextureData> assetType, DSTextureData data, TextureResources resources) {
+        super(urn, assetType, resources);
+        this.resources = resources;
         reload(data);
+    }
+
+    public static DSTexture create(ResourceUrn urn, AssetType<?, DSTextureData> assetType, DSTextureData data) {
+        return new DSTexture(urn, assetType, data, new TextureResources());
     }
 
     @Override
     protected void doReload(DSTextureData data) {
         this.dsTextureData = data;
+        resources.texture = data.getTexture();
     }
 
     public Texture getTexture() {
@@ -42,9 +50,21 @@ public class DSTexture extends Asset<DSTextureData> {
 
     /**
      * Obtains the NUI {@link UITextureRegion} associated with this texture.
-     * @return the assoicated UI texture
+     * @return the associated UI texture
      */
     public UITextureRegion getUiTexture() {
         return dsTextureData;
+    }
+
+    private static class TextureResources implements DisposableResource {
+        private Texture texture;
+
+        /**
+         * Closes the asset. It is expected this should only happen once.
+         */
+        @Override
+        public void close() {
+            texture.dispose();
+        }
     }
 }

--- a/engine/src/main/java/org/destinationsol/assets/textures/DSTextureFactory.java
+++ b/engine/src/main/java/org/destinationsol/assets/textures/DSTextureFactory.java
@@ -23,6 +23,6 @@ public class DSTextureFactory implements AssetFactory<DSTexture, DSTextureData> 
 
     @Override
     public DSTexture build(ResourceUrn urn, AssetType<DSTexture, DSTextureData> type, DSTextureData data) {
-        return new DSTexture(urn, type, data);
+        return DSTexture.create(urn, type, data);
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/drawables/SpriteManager.java
+++ b/engine/src/main/java/org/destinationsol/game/drawables/SpriteManager.java
@@ -227,4 +227,8 @@ public final class SpriteManager {
 
         return regions;
     }
+
+    public static void clearCache() {
+        sprites.clear();
+    }
 }

--- a/engine/src/main/java/org/destinationsol/game/screens/WaypointCreationScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/WaypointCreationScreen.java
@@ -16,10 +16,12 @@
 package org.destinationsol.game.screens;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.assets.Assets;
 import org.destinationsol.common.SolColor;
 import org.destinationsol.menu.MenuLayout;
 import org.destinationsol.ui.SolInputManager;
@@ -58,9 +60,12 @@ public class WaypointCreationScreen extends SolUiBaseScreen {
         previewRect = menuLayout.buttonRect(-1, -1);
         outcomeColor = Color.BLACK.cpy();
 
-        sliderRed = new SolUiSlider(menuLayout.buttonRect(-1, 0), "Red: ", 1, 2);
-        sliderGreen = new SolUiSlider(menuLayout.buttonRect(-1, 1), "Green: ", 1, 2);
-        sliderBlue = new SolUiSlider(menuLayout.buttonRect(-1, 2), "Blue:", 1, 2);
+        TextureAtlas.AtlasRegion sliderTexture = Assets.getAtlasRegion("engine:ui/slider");
+        TextureAtlas.AtlasRegion sliderMarkerTexture = Assets.getAtlasRegion("engine:ui/sliderMarker");
+
+        sliderRed = new SolUiSlider(menuLayout.buttonRect(-1, 0), "Red: ", 1, 2,sliderTexture, sliderMarkerTexture);
+        sliderGreen = new SolUiSlider(menuLayout.buttonRect(-1, 1), "Green: ", 1, 2, sliderTexture, sliderMarkerTexture);
+        sliderBlue = new SolUiSlider(menuLayout.buttonRect(-1, 2), "Blue:", 1, 2, sliderTexture, sliderMarkerTexture);
 
         background = menuLayout.background(-1, -1, 6);
     }

--- a/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
@@ -246,4 +246,8 @@ public class ModuleManager {
             logger.info("Module Discovered: {}", module);
         }
     }
+
+    public void dispose() {
+        environment.close();
+    }
 }

--- a/engine/src/main/java/org/destinationsol/ui/SolUiSlider.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolUiSlider.java
@@ -18,26 +18,28 @@ package org.destinationsol.ui;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
-import org.destinationsol.assets.Assets;
 import org.destinationsol.common.SolColor;
 import org.destinationsol.common.SolMath;
 
 public class SolUiSlider {
     private static final float HANDLE_SCALE = 0.0125f;
 
-    private static final TextureAtlas.AtlasRegion sliderTexture = Assets.getAtlasRegion("engine:ui/slider");
-    private static final TextureAtlas.AtlasRegion sliderMarkerTexture = Assets.getAtlasRegion("engine:ui/sliderMarker");
+    private final TextureAtlas.AtlasRegion sliderTexture;
+    private final TextureAtlas.AtlasRegion sliderMarkerTexture;
 
     private final Rectangle rectangle;
     private float value;
     private String text;
     private final int trimAt;
 
-    public SolUiSlider(Rectangle sliderRectangle, String text, float startingValue, int trimAt) {
+    public SolUiSlider(Rectangle sliderRectangle, String text, float startingValue, int trimAt,
+                       TextureAtlas.AtlasRegion sliderTexture, TextureAtlas.AtlasRegion sliderMarkerTexture) {
         rectangle = sliderRectangle;
         value = SolMath.clamp(value);
         this.text = text;
         this.trimAt = trimAt;
+        this.sliderTexture = sliderTexture;
+        this.sliderMarkerTexture = sliderMarkerTexture;
     }
 
     public void draw(UiDrawer uiDrawer) {

--- a/engine/src/main/java/org/destinationsol/ui/UiDrawer.java
+++ b/engine/src/main/java/org/destinationsol/ui/UiDrawer.java
@@ -39,7 +39,7 @@ public class UiDrawer implements ResizeSubscriber {
     private Matrix4 straightMtx;
     private final float uiLineWidth;
 
-    public static final TextureRegion whiteTexture = Assets.getAtlasRegion("engine:uiWhiteTex");
+    public final TextureRegion whiteTexture;
     public final Rectangle filler;
     private final CommonDrawer drawer;
     //TODO WTF is `isTextMode` for? discuss and potentially (=probably) remove
@@ -52,6 +52,7 @@ public class UiDrawer implements ResizeSubscriber {
     public UiDrawer(CommonDrawer commonDrawer) {
         displayDimensions = SolApplication.displayDimensions;
         drawer = commonDrawer;
+        whiteTexture = Assets.getAtlasRegion("engine:uiWhiteTex");
 
         uiLineWidth = 1.0f / displayDimensions.getHeight();
 


### PR DESCRIPTION
# Description
When the game is closed using the back button on Android, the activity containing it is disposed. The runtime VM and all static variables are not disposed though, so lingering references remained in the SpriteManager cache to textures that didn't exist anymore. The SpriteManager cache is now cleared when the game's activity is destroyed.

I also added some further code to properly dispose of gestalt-managed textures, since the reason why textures appeared to be randomly swapped was because the underlying sprites referenced invalid OpenGL handles that had not been cleaned-up properly. By correctly disposing of these textures upon activity destruction, the invalid handles now show black rectangles instead.

A bit more context on the Android activity lifecycle (which is exposed by libGDX through the `SolApplication#pause` and `SolApplication#destroy` methods) can be found [here](https://developer.android.com/guide/components/activities/activity-lifecycle#onpause).

# Testing
Follow the testing instructions found in #558. The game should now appear normally, rather than with randomly-swapped textures.

# Notes
- This fixes #558
- This also fixes MovingBlocks/DestSolAndroid#9
- This also fixes a long-standing bug that I don't think there is an issue for, where all `SolUiControl` buttons show visual artifacts after closing the game using the back button.