### PR TITLE
build: add gradle library include builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ modules/*
 modules/**/build.gradle
 !modules/core
 !modules/subprojects.gradle
+libs/*
+!libs/subprojects.gradle
 
 ## GWT
 war/

--- a/libs/subprojects.gradle
+++ b/libs/subprojects.gradle
@@ -1,0 +1,21 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This magically allows subdirs to become included builds
+// https://docs.gradle.org/6.4.1/userguide/composite_builds.html
+file(".").eachDir { possibleIncludedBuildDirectory ->
+    File buildFile = new File(possibleIncludedBuildDirectory, "build.gradle")
+    File settingsFile = new File(possibleIncludedBuildDirectory, "settings.gradle")
+
+    if (buildFile.exists() && settingsFile.exists()) {
+        logger.info("{} will be included in the composite build.",
+            rootDir.relativePath(possibleIncludedBuildDirectory))
+        includeBuild(possibleIncludedBuildDirectory)
+    } else {
+        logger.warn("{} REJECTED as an included build. build.gradle: {}, settings.gradle: {}",
+                rootDir.relativePath(possibleIncludedBuildDirectory),
+                buildFile.exists() ? "present" : "MISSING",
+                settingsFile.exists() ? "present" : "MISSING"
+        )
+    }
+}


### PR DESCRIPTION
## Description
This pull request adds a convenience shortcut for including external gradle-built libraries from source into the main Destination Sol build. I find it useful for when I need to make and test changes to `gestalt` and `TeraNUI` in particular.

## Usage:
To include a gradle-built library from source, just clone it into the libs sub-directory, e.g. for `gestalt`:
```sh
git clone https://github.com/MovingBlocks/gestalt.git libs\gestalt
```

Any dependencies on that library will then use the source version, rather than fetching the dependency from an external repository.

## Credits
All credit for this goes to the authors of the original Terasology build file at https://github.com/MovingBlocks/Terasology/blob/develop/libs/subprojects.settings.gradle.