### PR TITLE
Update LibGDX to version 1.9.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,10 @@ allprojects {
     version = '2.0.1'
     ext {
         appName = 'DestinationSol'
-        gdxVersion = '1.9.8'
+        gdxVersion = '1.9.14'
+        // The LibGDX controllers library is versioned differently to the main LibGDX versions.
+        // See https://github.com/libgdx/gdx-controllers/wiki/Compatibility for compatible versions.
+        gdxControllersVersion = '2.1.0'
         roboVMVersion = '2.3.3'
         nuiVersion = '3.1.0-SNAPSHOT'
     }

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -13,13 +13,6 @@ dependencies {
     // the FindBugs version is set in the configuration
 }
 
-version = '2.0.1'
-ext {
-    appName = 'DestinationSol'
-    gdxVersion = '1.9.8'
-    roboVMVersion = '2.3.3'
-}
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
     implementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
-    implementation "com.badlogicgames.gdx:gdx-controllers-lwjgl3:$gdxVersion"
+    implementation "com.badlogicgames.gdx-controllers:gdx-controllers-desktop:$gdxControllersVersion"
 
     implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.25'
     implementation group: 'org.terasology.crashreporter', name: 'cr-destsol', version: '4.0.0'

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -27,20 +27,19 @@ buildscript {
         classpath 'dom4j:dom4j:1.6.1'
 
         // HACK: Needed for NUI and gestalt entity-component reflections
-        classpath group: 'org.terasology.nui', name: 'nui', version: '3.1.0-SNAPSHOT'
+        classpath group: 'org.terasology.nui', name: 'nui', version: nuiVersion
         classpath group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
         classpath group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.2.0-SNAPSHOT'
     }
 }
 
 dependencies {
-
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     api group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
 
     api "com.badlogicgames.gdx:gdx:$gdxVersion"
     api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
-    api "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
+    api "com.badlogicgames.gdx-controllers:gdx-controllers-core:$gdxControllersVersion"
 
     api(group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.2.0-SNAPSHOT')
     api(group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.2.0-SNAPSHOT')
@@ -62,8 +61,7 @@ dependencies {
     testImplementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
     testImplementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
     testImplementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
-    testImplementation "com.badlogicgames.gdx:gdx-controllers-desktop:$gdxVersion"
-    testImplementation "com.badlogicgames.gdx:gdx-controllers-platform:$gdxVersion:natives-desktop"
+    testImplementation "com.badlogicgames.gdx-controllers:gdx-controllers-desktop:$gdxControllersVersion"
 
     // Test lib dependencies
     testCompile("org.junit.jupiter:junit-jupiter-api:5.5.2")

--- a/engine/src/main/java/org/destinationsol/game/screens/ShipControllerControl.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ShipControllerControl.java
@@ -18,8 +18,6 @@ package org.destinationsol.game.screens;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.Controllers;
-import com.badlogic.gdx.controllers.PovDirection;
-import com.badlogic.gdx.math.Vector3;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.slf4j.Logger;
@@ -160,30 +158,6 @@ public class ShipControllerControl implements ShipUiControl {
                 }
 
                 return true;
-            }
-
-            @Override
-            public boolean povMoved(Controller controller, int povIndex, PovDirection value) {
-                logger.debug("#{}, pov {}: {}", indexOf(controller), povIndex, value);
-                return false;
-            }
-
-            @Override
-            public boolean xSliderMoved(Controller controller, int sliderIndex, boolean value) {
-                logger.debug("#{},  x slider  {}: {}", indexOf(controller), sliderIndex, value);
-                return false;
-            }
-
-            @Override
-            public boolean ySliderMoved(Controller controller, int sliderIndex, boolean value) {
-                logger.debug("#{},  y slider  {}: {}", indexOf(controller), sliderIndex, value);
-                return false;
-            }
-
-            @Override
-            public boolean accelerometerMoved(Controller controller, int accelerometerIndex, Vector3 value) {
-                // not printing this as we get too many values
-                return false;
             }
         });
 

--- a/engine/src/main/java/org/destinationsol/menu/InputMapControllerScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/InputMapControllerScreen.java
@@ -23,8 +23,6 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.Controllers;
-import com.badlogic.gdx.controllers.PovDirection;
-import com.badlogic.gdx.math.Vector3;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.slf4j.Logger;
@@ -329,26 +327,6 @@ public class InputMapControllerScreen extends InputMapOperations {
 
                     }
                     return true;
-                }
-
-                @Override
-                public boolean povMoved(Controller controller, int povIndex, PovDirection value) {
-                    return false;
-                }
-
-                @Override
-                public boolean xSliderMoved(Controller controller, int sliderIndex, boolean value) {
-                    return false;
-                }
-
-                @Override
-                public boolean ySliderMoved(Controller controller, int sliderIndex, boolean value) {
-                    return false;
-                }
-
-                @Override
-                public boolean accelerometerMoved(Controller controller, int accelerometerIndex, Vector3 value) {
-                    return false;
                 }
             });
         }

--- a/engine/src/main/java/org/destinationsol/ui/SolInputProcessor.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputProcessor.java
@@ -71,8 +71,8 @@ public class SolInputProcessor implements InputProcessor {
     }
 
     @Override
-    public boolean scrolled(int amount) {
-        inputManager.scrolled(amount > 0);
+    public boolean scrolled(float amountX, float amountY) {
+        inputManager.scrolled(amountY > 0);
         return false;
     }
 }

--- a/engine/src/test/java/org/destinationsol/testingUtilities/MockGL.java
+++ b/engine/src/test/java/org/destinationsol/testingUtilities/MockGL.java
@@ -424,12 +424,12 @@ public class MockGL implements GL20 {
     }
 
     @Override
-    public String glGetActiveAttrib(int program, int index, IntBuffer size, Buffer type) {
+    public String glGetActiveAttrib(int program, int index, IntBuffer size, IntBuffer type) {
         return "NULL";
     }
 
     @Override
-    public String glGetActiveUniform(int program, int index, IntBuffer size, Buffer type) {
+    public String glGetActiveUniform(int program, int index, IntBuffer size, IntBuffer type) {
         return "NULL";
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request updates LibGDX to version 1.9.14.

To see what has changed you can view the release notes for interim LibGDX versions:
 - [LibGDX 1.9.10](https://libgdx.com/news/2019/07/gdx_1_9_10)
 - [LibGDX 1.9.11](https://libgdx.com/news/2020/07/gdx_1_9_11)
 - [LibGDX 1.9.12](https://libgdx.com/news/2020/10/gdx_1_9_12)
 - [LibGDX 1.9.13](https://libgdx.com/news/2021/01/gdx_1_9_13)
 - [LibGDX 1.9.14](https://libgdx.com/news/2021/02/gdx-1-9-14)

In terms of breaking LibGDX API changes:
- InputProcessor scrolled method now receives scroll amount for X and Y. Changed type to float to support devices which report fractional scroll amounts. Updated InputEvent in scene2d accordingly: added scrollAmountX, scrollAmountY attributes and corresponding setters and getters ([#6154](https://github.com/libgdx/libgdx/pull/6154)).
- Vector2 angleRad(Vector2) now correctly returns counter-clockwise angles ([#5428](https://github.com/libgdx/libgdx/pull/5428)).
- getDeltaTime() now returns the raw delta time instead of a smoothed one on Android ([#6228](https://github.com/libgdx/libgdx/pull/6228)).
- Gdx.files.external on Android now uses app external storage ([File handling](https://github.com/libgdx/libgdx/wiki/File-handling)).
- HeadlessApplicationConfiguration#renderInterval was changed to #updatesPerSecond

The [`gdx-controllers`](https://github.com/libgdx/gdx-controllers) library has changed its versioning, so it no longer shares a version number with its corresponding LibGDX release. The version numbers have therefore been changed in the corresponding gradle files that use them.

I found that the `libGdxVersion` variable was being defined seperately in two different gradle files, so I removed the variables from `config/gradle/common.gradle` so that they are all defined in the same file (`build.gradle` in the root directory). I assumed that all variables in an `allprojects` block are applied to all sub-projects recursively of the root project.

# Testing
- Build the game, which should not display any compile errors.
- Run the game and test things as usual
- If possible, try using all the avaliable input modes (`Keyboard`, `Keyboard+Mouse` and `Controller`)
- If possible, try doing this using both the android and desktop facades

This should not require any android changes, as it uses the gradle `gdxVersion` variable rather than hard-coding the version used.

# Notes
LibGDX 1.9.13 introduced the foregroundFPS setting for the LWJGL3 back-end, which was previously present in the LWJGL2 back-end. I have not used it for now though as there is no equivalent code for the android back-end.

This depends on MovingBlocks/TeraNUI#68, as there can only be one version of LibGDX present on the classpath (and the newer versions have ABI-breaking changes in them).