### PR TITLE
fix: fix respawn crash when the hero is transcendent

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -522,7 +522,7 @@ public class SolGame {
         respawnState.setPlayerRespawned(true);
         if (hero.isAlive()) {
             setRespawnState();
-            objectManager.removeObjDelayed(hero.getShip());
+            objectManager.removeObjDelayed(hero.isNonTranscendent() ? hero.getShip() : hero.getTranscendentHero());
         }
         createGame(null, true);
     }
@@ -634,8 +634,12 @@ public class SolGame {
 
     public void setRespawnState() {
         respawnState.setRespawnMoney(.75f * hero.getMoney());
-        hero.setMoney(respawnState.getRespawnMoney()); // to update the display while the camera waits for respawn if the player died
-        respawnState.setRespawnHull(hero.isNonTranscendent() ? hero.getHull().getHullConfig() : hero.getTranscendentHero().getShip().getHullConfig());
+        if (hero.isNonTranscendent()) {
+            hero.setMoney(respawnState.getRespawnMoney()); // to update the display while the camera waits for respawn if the player died
+            respawnState.setRespawnHull(hero.getHull().getHullConfig());
+        } else {
+            respawnState.setRespawnHull(hero.getTranscendentHero().getShip().getHullConfig());
+        }
         respawnState.getRespawnItems().clear();
         respawnState.getRespawnWaypoints().clear();
         respawnState.setPlayerRespawned(true);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request fixes a crash that occurs when the player attempts to respawn whilst trancendent (going through a star port).

# Testing
- Start a new game or continue an existing one.
- Fly to the nearest star port and enter it.
- Whilst travelling between star ports, open the in-game menu and press the `Respawn` button.
- The game should not crash and the player should be respawned successfully.

# Notes
This fixes #568.
