### PR TITLE
fix(mazes): fix incorrect box2d fixtures for maze tiles

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/maze/MazeTileObject.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeTileObject.java
@@ -188,9 +188,9 @@ public class MazeTileObject implements SolObject {
                 tex.flip(!tex.isFlipX(), !tex.isFlipY());
                 backgroundTexture.flip(!backgroundTexture.isFlipX(), !backgroundTexture.isFlipY());
             }
-            RectSprite s = SpriteManager.createSprite(tex.name, MazeBuilder.TILE_SZ, 0, 0, new Vector2(), DrawableLevel.GROUND, 0, 0, SolColor.WHITE, false);
+            RectSprite s = SpriteManager.createStaticSprite(tex, MazeBuilder.TILE_SZ, 0, 0, new Vector2(), DrawableLevel.GROUND, 0, 0, SolColor.WHITE, false);
             drawables.add(s);
-            RectSprite s2 = SpriteManager.createSprite(backgroundTexture.name, MazeBuilder.TILE_SZ, 0, 0, new Vector2(), DrawableLevel.DECO, 0, 0, SolColor.WHITE, false);
+            RectSprite s2 = SpriteManager.createStaticSprite(backgroundTexture, MazeBuilder.TILE_SZ, 0, 0, new Vector2(), DrawableLevel.DECO, 0, 0, SolColor.WHITE, false);
             drawables.add(s2);
             Body body = buildBody(game, angle, position, tile, flipped);
             MazeTileObject res = new MazeTileObject(tile, drawables, body, position, angle, flipped);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request fixes incorrect maze collisions by partially-reverting the maze tile changes in https://github.com/MovingBlocks/DestinationSol/commit/e5f6c68524ef8867d06c80c504bb127ccdde643a. This causes the sprite tile textures to be correctly flipped, although it prevent mazes from using animated sprites.

### Before
![image](https://user-images.githubusercontent.com/24301287/151659545-79f318e9-7888-46d2-923d-9dc8e248e22e.png)
### After
![image](https://user-images.githubusercontent.com/24301287/151701375-08d2d47d-f6bf-4491-800e-1eee3d12b763.png)

# Testing
- In the `engine/src/main/resources/debugOptions.ini` file, set `drawPhysicBorders` to `true` and `spawnPlace` to `maze`.
- Start a new game.
- Fly left towards the nearest maze.
- Verify that all of the maze colliders are roughly the right shape and in the right place.
- Try flying through the maze passages.

# Notes
- This fixes #576.