### PR TITLE
fix(world): make new world generation deterministic

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -350,7 +350,7 @@ public class SolApplication implements ApplicationListener {
         entitySystemManager.initialise();
 
         solGame.createUpdateSystems();
-        solGame.startGame(shipName, isNewGame, worldConfig, entitySystemManager);
+        solGame.startGame(shipName, isNewGame, entitySystemManager);
 
         if (!isNewGame) {
             try {

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -43,6 +43,7 @@ import org.json.JSONObject;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.List;
 
 public class GalaxyFiller {
     private static final float STATION_CONSUME_SECTOR = 45f;
@@ -140,7 +141,7 @@ public class GalaxyFiller {
             return;
         }
         createStarPorts(game);
-        ArrayList<SolarSystem> systems = game.getGalaxyBuilder().getBuiltSolarSystems();
+        List<SolarSystem> systems = game.getGalaxyBuilder().getBuiltSolarSystems();
 
         JSONObject rootNode = Validator.getValidatedJSON(moduleName + ":startingStation", "engine:schemaStartingStation");
 

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -20,6 +20,8 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.math.Vector2;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
@@ -232,16 +234,29 @@ public class SaveManager {
     }
 
     /**
-     * Saves the world to a file. Currently stores the seed used to generate the world and the number of systems
-     * @param numberOfSystems
+     * Saves the world to a file. Currently stores the seed used to generate the world,
+     * the number of systems and the generators used.
+     * @param worldConfig the current world configuration.
      */
-    public static void saveWorld(int numberOfSystems) {
+    public static void saveWorld(WorldConfig worldConfig) {
         Long seed = SolRandom.getSeed();
         String fileName = SaveManager.getResourcePath(Const.WORLD_SAVE_FILE_NAME);
 
         JsonObject world = new JsonObject();
         world.addProperty("seed", seed);
-        world.addProperty("systems", numberOfSystems);
+        world.addProperty("systems", worldConfig.getNumberOfSystems());
+
+        JsonArray solarSystemGenerators = new JsonArray();
+        for (String solarSystemGenerator : worldConfig.getSolarSystemGenerators()) {
+            solarSystemGenerators.add(solarSystemGenerator);
+        }
+        world.add("solarSystemGenerators", solarSystemGenerators);
+
+        JsonArray featureGenerators = new JsonArray();
+        for (String featureGenerator : worldConfig.getFeatureGenerators()) {
+            featureGenerators.add(featureGenerator);
+        }
+        world.add("featureGenerators", featureGenerators);
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String stringToWrite = gson.toJson(world);
@@ -270,6 +285,26 @@ public class SaveManager {
 
                 if (world.has("systems")) {
                     config.setNumberOfSystems(world.get("systems").getAsInt());
+                }
+
+                if (world.has("solarSystemGenerators")) {
+                    List<String> solarSystemGenerators = new ArrayList<>();
+                    for (JsonElement value : world.getAsJsonArray("solarSystemGenerators")) {
+                        if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                            solarSystemGenerators.add(value.getAsString());
+                        }
+                    }
+                    config.setSolarSystemGenerators(solarSystemGenerators);
+                }
+
+                if (world.has("featureGenerators")) {
+                    List<String> featureGenerators = new ArrayList<>();
+                    for (JsonElement value : world.getAsJsonArray("featureGenerators")) {
+                        if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                            featureGenerators.add(value.getAsString());
+                        }
+                    }
+                    config.setFeatureGenerators(featureGenerators);
                 }
 
                 logger.debug("Successfully loaded the world file");

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -149,6 +149,8 @@ public class SolGame {
     protected SolCam solCam;
     @Inject
     protected ModuleManager moduleManager;
+    @Inject
+    protected WorldConfig worldConfig;
 
     protected SolApplication solApplication;
     private Hero hero;
@@ -236,7 +238,7 @@ public class SolGame {
         }
     }
 
-    public void startGame(String shipName, boolean isNewGame, WorldConfig worldConfig, EntitySystemManager entitySystemManager) {
+    public void startGame(String shipName, boolean isNewGame, EntitySystemManager entitySystemManager) {
         this.entitySystemManager = entitySystemManager;
 
         respawnState = new RespawnState();
@@ -331,7 +333,7 @@ public class SolGame {
             if (!hero.isTranscendent()) {
                 saveShip();
             }
-            SaveManager.saveWorld(getPlanetManager().getSystems().size());
+            SaveManager.saveWorld(worldConfig);
 
             try {
                 context.get(SerialisationManager.class).serialise();
@@ -601,6 +603,10 @@ public class SolGame {
 
     public DrawableManager getDrawableManager() {
         return drawableManager;
+    }
+
+    public WorldConfig getWorldConfig() {
+        return worldConfig;
     }
 
     public void setRespawnState() {

--- a/engine/src/main/java/org/destinationsol/game/StarPort.java
+++ b/engine/src/main/java/org/destinationsol/game/StarPort.java
@@ -125,7 +125,7 @@ public class StarPort implements SolObject {
             ship.setMoney(ship.getMoney() - FARE);
             Transcendent transcendent = new Transcendent(ship, fromPlanet, toPlanet, game);
             if (transcendent.getShip().getPilot().isPlayer()) {
-                SaveManager.saveWorld(game.getPlanetManager().getSystems().size());
+                SaveManager.saveWorld(game.getWorldConfig());
                 game.getHero().setTranscendent(transcendent);
             }
             ObjectManager objectManager = game.getObjectManager();
@@ -404,7 +404,7 @@ public class StarPort implements SolObject {
                 SolShip ship = this.ship.toObject(game);
                 if (ship.getPilot().isPlayer()) {
                     game.getHero().setSolShip(ship, game);
-                    SaveManager.saveWorld(game.getPlanetManager().getSystems().size());
+                    SaveManager.saveWorld(game.getWorldConfig());
                 }
                 objectManager.addObjDelayed(ship);
                 blip(game, ship);

--- a/engine/src/main/java/org/destinationsol/game/WorldConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/WorldConfig.java
@@ -17,18 +17,29 @@ package org.destinationsol.game;
 
 import org.destinationsol.game.planet.SystemsBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class WorldConfig {
     protected long seed;
     protected int numberOfSystems;
+    private List<String> solarSystemGenerators;
+    private List<String> featureGenerators;
 
     public WorldConfig() {
         seed = System.currentTimeMillis();
         numberOfSystems = SystemsBuilder.DEFAULT_SYSTEM_COUNT;
+        solarSystemGenerators = new ArrayList<>();
+        featureGenerators = new ArrayList<>();
     }
 
-    public WorldConfig(long seed, int numberOfSystems) {
+    public WorldConfig(long seed, int numberOfSystems,
+                       List<String> solarSystemGenerators,
+                       List<String> featureGenerators) {
         this.seed = seed;
         this.numberOfSystems = numberOfSystems;
+        this.solarSystemGenerators = solarSystemGenerators;
+        this.featureGenerators = featureGenerators;
     }
 
     public long getSeed() {
@@ -45,5 +56,21 @@ public class WorldConfig {
 
     public void setNumberOfSystems(int numberOfSystems) {
         this.numberOfSystems = numberOfSystems;
+    }
+
+    public List<String> getSolarSystemGenerators() {
+        return solarSystemGenerators;
+    }
+
+    public void setFeatureGenerators(List<String> featureGenerators) {
+        this.featureGenerators = featureGenerators;
+    }
+
+    public List<String> getFeatureGenerators() {
+        return featureGenerators;
+    }
+
+    public void setSolarSystemGenerators(List<String> solarSystemGenerators) {
+        this.solarSystemGenerators = solarSystemGenerators;
     }
 }

--- a/engine/src/main/java/org/destinationsol/world/GalaxyBuilder.java
+++ b/engine/src/main/java/org/destinationsol/world/GalaxyBuilder.java
@@ -67,9 +67,15 @@ public class GalaxyBuilder {
             populateSolarSystemGeneratorList();
         } else {
             for (String typeName : worldConfig.getSolarSystemGenerators()) {
-                for (Class<? extends SolarSystemGenerator> possibleGeneratorType :
-                        moduleManager.getEnvironment().getSubtypesOf(SolarSystemGenerator.class, type -> type.getName().equals(typeName))) {
-                    solarSystemGeneratorTypes.add(possibleGeneratorType);
+                Iterable<Class<? extends SolarSystemGenerator>> generatorTypes =
+                        moduleManager.getEnvironment().getSubtypesOf(SolarSystemGenerator.class, type -> type.getName().equals(typeName));
+                if (!generatorTypes.iterator().hasNext()) {
+                    logger.error("Unable to find SolarSystemGenerator type {}! World generation will likely be incorrect.", typeName);
+                    continue;
+                }
+
+                for (Class<? extends SolarSystemGenerator> generatorType : generatorTypes) {
+                    solarSystemGeneratorTypes.add(generatorType);
                 }
             }
         }
@@ -78,9 +84,15 @@ public class GalaxyBuilder {
             populateFeatureGeneratorList();
         } else {
             for (String typeName : worldConfig.getFeatureGenerators()) {
-                for (Class<? extends FeatureGenerator> possibleGeneratorType :
-                        moduleManager.getEnvironment().getSubtypesOf(FeatureGenerator.class, type -> type.getName().equals(typeName))) {
-                    featureGeneratorTypes.add(possibleGeneratorType);
+                Iterable<Class<? extends FeatureGenerator>> generatorTypes =
+                        moduleManager.getEnvironment().getSubtypesOf(FeatureGenerator.class, type -> type.getName().equals(typeName));
+                if (!generatorTypes.iterator().hasNext()) {
+                    logger.error("Unable to find FeatureGenerator type {}! World generation will likely be incorrect.", typeName);
+                    continue;
+                }
+
+                for (Class<? extends FeatureGenerator> generatorType : generatorTypes) {
+                    featureGeneratorTypes.add(generatorType);
                 }
             }
         }

--- a/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
@@ -466,7 +466,7 @@ public abstract class SolarSystemGenerator {
                 && !PlanetGenerator.class.isAssignableFrom(featureGeneratorTypes.get(index));
     }
 
-    public void setFeatureGeneratorTypes(ArrayList<Class<? extends FeatureGenerator>> generators) {
+    public void setFeatureGeneratorTypes(List<Class<? extends FeatureGenerator>> generators) {
         featureGeneratorTypes.addAll(generators);
     }
 

--- a/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
@@ -67,8 +67,10 @@ public class MazeGeneratorTest implements AssetsHelperInitializer {
 
         setupConfigManagers();
 
+        WorldConfig worldConfig = new WorldConfig();
+        worldConfig.setNumberOfSystems(1);
         context = new DefaultBeanContext(registry);
-        galaxyBuilder = new GalaxyBuilder(new WorldConfig(), moduleManager, context.getBean(SolarSystemConfigManager.class), context);
+        galaxyBuilder = new GalaxyBuilder(worldConfig, moduleManager, context.getBean(SolarSystemConfigManager.class), context);
 
         ArrayList<SolarSystemGenerator> solarSystemGenerators = galaxyBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
When #607 was merged, it broke the determinism of world generation. This means that continuing an existing save would often end-up generating a completely different system than the one that was present when the game was saved. The precise reason for this issue is because the ordering of types returned by `ModuleEnvionment::getSubtypesOf` is undefined. I often found that the exact ordering of types in the returned list changed every time the game was run. The galaxy generation code is very sensitive to the ordering of these lists.

A simple solution to this problem would be to sort the lists by type name. This would not help though if additional feature generators were added later-on, since they could change the list ordering and size again. Because of this, I decided to save the generators used with the world configuration instead. This does mean that you will have to start a new game to see any new system/feature generators in use though.

I also updated some occurences of publicly-facing `ArrayList<T>` methods to the more generic `List<T>` in `GalaxyBuilder`, since I was modifying that code anyway.

It appears that some world generation tests were commented-out in #622. This pull request also restores those stubbed tests with working implementations again.

# Testing
- Start the game application
- Create a new game.
- Open the map to get a rough view of the system layout.
- Exit the game application completely through the main menu.
- Start the game application again.
- Continue from your previous save.
- Open the map and ensure that it contains an identical system layout to before.

# Notes
- With these changes, you will have to start a new game to have any new system/feature generators added subsequent to the world's creation included in the world generation process. The game should log an error if any generators are removed.
