### PR TITLE
Android Fastlane releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,8 +100,10 @@ pipeline {
                 }
                 stage('Create Release APK') {
                     steps {
-                        sh 'fastlane buildRelease'
-                        archiveArtifacts 'android/build/outputs/apk/release/android-release.apk'
+                        dir('android') {
+                            sh 'fastlane buildRelease'
+                            archiveArtifacts 'build/outputs/apk/release/android-release.apk'
+                        }
                     }
                 }
                 stage('Publish Alpha To Play Store') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,11 +75,16 @@ pipeline {
             }
         }
         stage('Publish to Play Store') {
+            when {
+                // Example: v2.1.0
+                tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: "REGEXP"
+            }
             environment {
                 DESTSOL_ANDROID_SIGNING_KEYSTORE=credentials('destsol-signing-keystore')
                 DESTSOL_ANDROID_SIGNING_STORE_PASS=credentials('destsol-keystore-pass')
                 DESTSOL_ANDROID_SIGNING_KEY_ALIAS=credentials('destsol-signing-alias')
                 DESTSOL_ANDROID_SINGING_KEY_PASS=credentials('destsol-signing-pass')
+                DESTSOL_PLAYSTORE_SECRET=credentials('destsol-playstore-secret')
                 WEBHOOK = credentials('destsolDiscordWebhook')
             }
             stages {
@@ -87,6 +92,7 @@ pipeline {
                     steps {
                         dir('android') {
                             sh 'bundle install'
+                            sh 'cp $DESTSOL_PLAYSTORE_SECRET playstore_secret.json'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,8 +96,10 @@ pipeline {
                     }
                 }
                 stage('Create Release APK') {
-                    sh 'fastlane buildRelease'
-                    archiveArtifacts 'android/build/outputs/apk/release/android-release.apk'
+                    steps {
+                        sh 'fastlane buildRelease'
+                        archiveArtifacts 'android/build/outputs/apk/release/android-release.apk'
+                    }
                 }
                 stage('Publish Alpha To Play Store') {
                     when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,8 +91,7 @@ pipeline {
                 stage('Prepare Fastlane') {
                     steps {
                         dir('android') {
-                            sh 'bundle install'
-                            sh 'cp $DESTSOL_PLAYSTORE_SECRET playstore_secret.json'
+                            sh 'ln -s $DESTSOL_PLAYSTORE_SECRET playstore_secret.json'
                         }
                     }
                 }
@@ -103,7 +102,7 @@ pipeline {
                     }
                     steps {
                         dir('android') {
-                            sh 'bundle exec fastlane deployAlpha'
+                            sh 'fastlane deployAlpha'
                         }
                     }
                 }
@@ -114,7 +113,7 @@ pipeline {
                     }
                     steps {
                         dir('android') {
-                            sh 'bundle exec fastlane deployBeta'
+                            sh 'fastlane deployBeta'
                         }
                         discordSend title: "Beta ${env.GIT_TAG} published to Play Store", result: currentBuild.currentResult, webhookURL: env.WEBHOOK
                     }
@@ -127,7 +126,7 @@ pipeline {
                     }
                     steps {
                         dir('android') {
-                            sh 'bundle exec fastlane deployProduction'
+                            sh 'fastlane deployProduction'
                         }
                         discordSend title: "Release ${env.GIT_TAG} published to Play Store", result: currentBuild.currentResult, webhookURL: env.WEBHOOK
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,57 +1,121 @@
-node ("android") {
-    stage('Checkout') {
-        echo "Going to check out the things !"
-        checkout scm
-        sh 'chmod +x gradlew'
+pipeline {
+    agent {
+        label 'android'
     }
-    stage('Build') {
-        // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
-        sh './gradlew --console=plain clean distZipBundleJres'
-        archiveArtifacts 'desktop/build/distributions/DestinationSol.zip'
-    }
-    stage('Analytics') {
-        sh "./gradlew --console=plain check javadoc"
-    }
-    stage('Record') {
-        junit testResults: '**/build/test-results/test/*.xml',  allowEmptyResults: true
-        recordIssues tool: javaDoc()
-        step([$class: 'JavadocArchiver', javadocDir: 'engine/build/docs/javadoc', keepAll: false])
-        recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
-        recordIssues tool: findBugs(pattern: '**/build/reports/findbugs/*.xml', useRankAsPriority: true)
-        recordIssues tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
-        recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
-    }
-    stage('Build Android') {
-        sh 'echo sdk.dir=/opt/android-sdk > local.properties'
-        dir('android') {
-            // Allow varying from the default Android repo path for easier development. Assume same Android branch as engine branch.
-            def androidGitPath = "https://github.com/MovingBlocks/DestSolAndroid.git"
-            if (env.PUBLISH_ORG) {
-                androidGitPath = androidGitPath.replace("MovingBlocks", env.PUBLISH_ORG)
-                println "Updated target Android Git path to: " + androidGitPath
-            } else {
-                println "Not varying the Android path from default " + androidGitPath
+    stages {
+        stage('Setup') {
+            steps {
+                echo "Repository checkout complete!"
+                sh 'chmod +x gradlew'
             }
-            // Figure out a suitable target brand in the Android repo
-            def androidBranch = "develop"
-            if (env.BRANCH_NAME.equalsIgnoreCase("master") || env.BRANCH_NAME.startsWith("android/")) {
-                println "Going to use target unusual Android branch " + env.BRANCH_NAME
-                androidBranch = env.BRANCH_NAME
-            } else {
-                println "Going to use target Android branch 'develop' - not building 'master' nor anything starting with 'android/'"
-            }
-            checkout scm: [$class: 'GitSCM', branches: [[name: androidBranch]], extensions: [], userRemoteConfigs: [[credentialsId: 'GooeyHub', url: androidGitPath]]]
         }
-        sh './gradlew --console=plain :android:assembleDebug'
-        archiveArtifacts 'android/build/outputs/apk/debug/android-debug.apk'
-    }
-    stage('Record Android') {
-       sh './gradlew --console=plain :android:lint'
-       recordIssues tool: androidLintParser(pattern: 'android/build/reports/lint-results.xml')
-    }
-    stage('Notify') {
-        withCredentials([string(credentialsId: 'destsolDiscordWebhook', variable: 'WEBHOOK')]) {
-            discordSend title: env.BRANCH_NAME, link: env.BUILD_URL, result: currentBuild.currentResult, webhookURL: env.WEBHOOK
+        stage('Build') {
+            steps {
+                // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
+                sh './gradlew --console=plain clean distZipBundleJres'
+                archiveArtifacts 'desktop/build/distributions/DestinationSol.zip'
+            }
+        }
+        stage('Analytics') {
+            steps {
+                sh "./gradlew --console=plain check javadoc"
+            }
+        }
+        stage('Record') {
+            steps {
+                junit testResults: '**/build/test-results/test/*.xml',  allowEmptyResults: true
+                recordIssues tool: javaDoc()
+                step([$class: 'JavadocArchiver', javadocDir: 'engine/build/docs/javadoc', keepAll: false])
+                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
+                recordIssues tool: findBugs(pattern: '**/build/reports/findbugs/*.xml', useRankAsPriority: true)
+                recordIssues tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
+                recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+            }
+        }
+        stage('Build Android') {
+            steps {
+                sh 'echo sdk.dir=/opt/android-sdk > local.properties'
+                dir('android') {
+                    script {
+                        // Allow varying from the default Android repo path for easier development. Assume same Android branch as engine branch.
+                        def androidGitPath = "https://github.com/MovingBlocks/DestSolAndroid.git"
+                        if (env.PUBLISH_ORG) {
+                            androidGitPath = androidGitPath.replace("MovingBlocks", env.PUBLISH_ORG)
+                            println "Updated target Android Git path to: " + androidGitPath
+                        } else {
+                            println "Not varying the Android path from default " + androidGitPath
+                        }
+                        // Figure out a suitable target brand in the Android repo
+                        def androidBranch = "develop"
+                        if (env.BRANCH_NAME.equalsIgnoreCase("master") || env.BRANCH_NAME.startsWith("android/")) {
+                            println "Going to use target unusual Android branch " + env.BRANCH_NAME
+                            androidBranch = env.BRANCH_NAME
+                        } else {
+                            println "Going to use target Android branch 'develop' - not building 'master' nor anything starting with 'android/'"
+                        }
+                        checkout scm: [$class: 'GitSCM', branches: [[name: androidBranch]], extensions: [], userRemoteConfigs: [[credentialsId: 'GooeyHub', url: androidGitPath]]]
+                    }
+                }
+                sh './gradlew --console=plain :android:assembleDebug'
+                archiveArtifacts 'android/build/outputs/apk/debug/android-debug.apk'
+            }
+        }
+        stage('Record Android') {
+            steps {
+               sh './gradlew --console=plain :android:lint'
+               recordIssues tool: androidLintParser(pattern: 'android/build/reports/lint-results.xml')
+           }
+        }
+        stage('Notify') {
+            environment {
+                WEBHOOK = credentials('destsolDiscordWebhook')
+            }
+            steps {
+                discordSend title: env.BRANCH_NAME, link: env.BUILD_URL, result: currentBuild.currentResult, webhookURL: env.WEBHOOK
+            }
+        }
+        stage('Publish Beta To Play Store') {
+            when {
+                // Example: v2.1.0-beta
+                tag pattern: 'v\\d+\\.\\d+\\.\\d+-beta$', comparator: "REGEXP"
+            }
+            environment {
+                DESTSOL_ANDROID_SIGNING_KEYSTORE=credentials('destsol-signing-keystore')
+                DESTSOL_ANDROID_SIGNING_STORE_PASS=credentials('destsol-keystore-pass')
+                DESTSOL_ANDROID_SIGNING_KEY_ALIAS=credentials('destsol-signing-alias')
+                DESTSOL_ANDROID_SINGING_KEY_PASS=credentials('destsol-signing-pass')
+                WEBHOOK = credentials('destsolDiscordWebhook')
+            }
+            steps {
+                dir('android') {
+                    sh 'bundle install'
+                    sh 'bundle exec fastlane buildRelease'
+                    sh 'bundle exec fastlane deployBeta'
+                }
+                discordSend title: "Beta ${env.GIT_TAG} published to Play Store", result: currentBuild.currentResult, webhookURL: env.WEBHOOK
+            }
+        }
+        stage('Publish Release To Play Store') {
+            when {
+                // Example: v2.1.0
+                // This intentionally does not include things like v2.1.0-beta
+                tag pattern: 'v\\d+\\.\\d+\\.\\d+$', comparator: "REGEXP"
+            }
+            environment {
+                DESTSOL_ANDROID_SIGNING_KEYSTORE=credentials('destsol-signing-keystore')
+                DESTSOL_ANDROID_SIGNING_STORE_PASS=credentials('destsol-keystore-pass')
+                DESTSOL_ANDROID_SIGNING_KEY_ALIAS=credentials('destsol-signing-alias')
+                DESTSOL_ANDROID_SINGING_KEY_PASS=credentials('destsol-signing-pass')
+                WEBHOOK = credentials('destsolDiscordWebhook')
+            }
+            steps {
+                dir('android') {
+                    sh 'bundle update'
+                    sh 'bundle exec fastlane buildRelease'
+                    sh 'bundle exec fastlane deployProduction'
+                }
+                discordSend title: "Release ${env.GIT_TAG} published to Play Store", result: currentBuild.currentResult, webhookURL: env.WEBHOOK
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,10 @@ pipeline {
                         }
                     }
                 }
+                stage('Create Release APK') {
+                    sh 'fastlane buildRelease'
+                    archiveArtifacts 'android/build/outputs/apk/release/android-release.apk'
+                }
                 stage('Publish Alpha To Play Store') {
                     when {
                         // Example: v2.1.0-alpha

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,9 +45,12 @@ pipeline {
                         } else {
                             println "Not varying the Android path from default " + androidGitPath
                         }
-                        // Figure out a suitable target brand in the Android repo
+                        // Figure out a suitable target branch in the Android repo
                         def androidBranch = "develop"
-                        if (env.BRANCH_NAME.equalsIgnoreCase("master") || env.BRANCH_NAME.startsWith("android/")) {
+                        if (env.TAG_NAME != null && env.TAG_NAME ==~ /v\\d+\\.\\d+\\.\\d+.*/) {
+                            println "Going to use target Android tag " + env.TAG_NAME
+                            androidBranch = "refs/tags/" + env.TAG_NAME
+                        } else if (env.BRANCH_NAME.equalsIgnoreCase("master") || env.BRANCH_NAME.startsWith("android/")) {
                             println "Going to use target unusual Android branch " + env.BRANCH_NAME
                             androidBranch = env.BRANCH_NAME
                         } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         }
                         // Figure out a suitable target branch in the Android repo
                         def androidBranch = "develop"
-                        if (env.TAG_NAME != null && env.TAG_NAME ==~ /v\\d+\\.\\d+\\.\\d+.*/) {
+                        if (env.TAG_NAME != null && env.TAG_NAME ==~ /v\d+\.\d+\.\d+.*/) {
                             println "Going to use target Android tag " + env.TAG_NAME
                             androidBranch = "refs/tags/" + env.TAG_NAME
                         } else if (env.BRANCH_NAME.equalsIgnoreCase("master") || env.BRANCH_NAME.startsWith("android/")) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request adds support for fastlane releases to Google Play based on the use of specific tags. Tagging a release as `va.b.c-alpha` will release to the `alpha` track, `va.b.c-beta` to the `beta` track and `va.b.c` to the production track. It also re-organises the `Jenkinsfile` to use the declarative pipeline syntax.

# Testing
Testing this requires the following additional secrets in Jenkins:

| Id | Type | Description |
|---|------|-------------|
| destsol-playstore-secret | Secret File | The secret json for Play Store deployments |
| destsol-signing-keystore | Secret File | The keystore used to sign releases |
| destsol-keystore-pass | Secret Text | The password used to unlock the signing keystore |
| destsol-signing-alias | Secret Text | The key alias used to sign releases |
| destsol-signing-pass | Secret Text | The password for the key used to sign releases |

# Notes
This depends on MovingBlocks/DestSolAndroid#25 and MovingBlocks/JenkinsAgentAndroid#1.