### PR TITLE
feat(input): remove fixed keyboard controls from GameOptions

### DIFF
--- a/engine/src/main/java/org/destinationsol/input/DefaultControls.java
+++ b/engine/src/main/java/org/destinationsol/input/DefaultControls.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.destinationsol.input;
+
+import com.badlogic.gdx.Input;
+import org.destinationsol.GameOptions;
+
+import java.util.EnumSet;
+
+/**
+ * These are the default controls used in the base game.
+ * You can obtain the inputs used to trigger these controls using {@link GameOptions#getControl(InputControls)}.
+ */
+public enum DefaultControls implements InputControls {
+    MOUSE_UP("keyUpMouse", "Up", EnumSet.of(GameOptions.ControlType.MIXED), Input.Keys.W),
+    MOUSE_DOWN("keyDownMouse", "Down", EnumSet.of(GameOptions.ControlType.MIXED), Input.Keys.S),
+    UP("keyUp", "Up", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.UP),
+    DOWN("keyDown", "Down", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.DOWN),
+    LEFT("keyLeft", "Left", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.LEFT),
+    RIGHT("keyRight", "Right", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.RIGHT),
+    SHOOT("keyShoot", "Shoot", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.SPACE),
+    SHOOT2("keyShoot2", "Shoot Secondary", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.CONTROL_LEFT),
+    ABILITY("keyAbility", "Ability", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.SHIFT_LEFT),
+    ESCAPE("keyEscape", "Escape", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.ESCAPE),
+    MAP("keyMap", "Map", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.TAB),
+    INVENTORY("keyInventory", "Inventory", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.I),
+    TALK("keyTalk", "Talk", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.T),
+    PAUSE("keyPause", "Pause", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.P),
+    DROP("keyDrop", "Drop", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.D),
+    SELL("keySellMenu", "Sell", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.S),
+    BUY("keyBuyMenu", "Buy", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.B),
+    CHANGE_SHIP("keyChangeShipMenu", "Change Ship", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.C),
+    HIRE_SHIP("keyHireShipMenu", "Hire Ship", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.H),
+    MERCENARY_INTERACTION("keyMercenaryInteraction", "Hire Ship", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.M),
+    FREE_CAMERA_MOVEMENT("keyFreeCameraMovement", "Free Camera", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.V),
+    ZOOM_IN("keyZoomIn", "Zoom In", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.PAGE_UP),
+    ZOOM_OUT("keyZoomOut", "Zoom Out", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.PAGE_DOWN);
+
+    private final String controlName;
+    private final String displayName;
+    private final EnumSet<GameOptions.ControlType> controlTypes;
+    private final int[] defaultInputs;
+
+    DefaultControls(String controlName, String displayName, EnumSet<GameOptions.ControlType> controlTypes, int... defaultInputs) {
+        this.controlName = controlName;
+        this.displayName = displayName;
+        this.controlTypes = controlTypes;
+        this.defaultInputs = defaultInputs;
+    }
+
+    public String getControlName() {
+        return controlName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public EnumSet<GameOptions.ControlType> getControlTypes() {
+        return controlTypes;
+    }
+
+    public int[] getDefaultInputs() {
+        return defaultInputs;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/input/InputControls.java
+++ b/engine/src/main/java/org/destinationsol/input/InputControls.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.destinationsol.input;
+
+import org.destinationsol.GameOptions;
+
+import java.util.EnumSet;
+
+/**
+ * The base interface implementing new controls that conform to certain control types.
+ *
+ * It is recommended that you create an enum implementing this interface per-module to contain all the new controls you add to the game.
+ * <br>
+ * Example Implementation:
+ * <pre>
+ * public enum ModuleControls implements InputControls {
+ *     CONTROL_1("module_control1", "Control 1", EnumSet.of(GameOptions.ControlType.KEYBOARD), Input.Keys.W),
+ *     CONTROL_2("module_control2", "Control 2", EnumSet.of(GameOptions.ControlType.MIXED), Input.Keys.S),
+ *     CONTROL_2("module_control3", "Control 3", EnumSet.allOf(GameOptions.ControlType.class), Input.Keys.PAGE_DOWN);
+ *
+ *     private final String controlName;
+ *     private final String displayName;
+ *     private final EnumSet<GameOptions.ControlType> controlTypes;
+ *     private final int[] defaultInputs;
+ *
+ *     ModuleControls(String controlName, String displayName, EnumSet<GameOptions.ControlType> controlTypes, int... defaultInputs) {
+ *         this.controlName = controlName;
+ *         this.displayName = displayName;
+ *         this.controlTypes = controlTypes;
+ *         this.defaultInputs = defaultInputs;
+ *     }
+ *
+ *     public String getControlName() {
+ *         return controlName;
+ *     }
+ *
+ *     public String getDisplayName() {
+ *         return displayName;
+ *     }
+ *
+ *     public EnumSet<GameOptions.ControlType> getControlTypes() {
+ *         return controlTypes;
+ *     }
+ *
+ *     public int[] getDefaultInputs() {
+ *         return defaultInputs;
+ *     }
+ * }
+ * </pre>
+ * @see DefaultControls the built-in game controls
+ */
+public interface InputControls {
+    /**
+     * Returns the control name. This is the name used internally to serialise and de-serialise the control values.
+     * @return the control name
+     */
+    String getControlName();
+
+    /**
+     * Returns the control's display name. This name is used when referencing the control in user-facing text.
+     * @return the control's display name
+     */
+    String getDisplayName();
+
+    /**
+     * Returns the supported control schemes for this control.
+     * @return the supported control schemes
+     */
+    EnumSet<GameOptions.ControlType> getControlTypes();
+
+    /**
+     * Returns the default assigned input values for this control. Any one of these values can trigger the control.
+     * @return the default assigned input values
+     */
+    int[] getDefaultInputs();
+}

--- a/engine/src/main/java/org/destinationsol/menu/InputMapControllerScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/InputMapControllerScreen.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.Controllers;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.input.DefaultControls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,39 +138,39 @@ public class InputMapControllerScreen extends InputMapOperations {
         itemsList.set(index++, InitItem(GameOptions.DEFAULT_AXIS_ABILITY, GameOptions.DEFAULT_BUTTON_ABILITY, "Ability"));
 
         InputConfigItem item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_PAUSE);
+        item.setInputKey(Input.Keys.toString(DefaultControls.PAUSE.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_MAP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.MAP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_INVENTORY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.INVENTORY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_DROP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.DROP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_TALK);
+        item.setInputKey(Input.Keys.toString(DefaultControls.TALK.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_SELL);
+        item.setInputKey(Input.Keys.toString(DefaultControls.SELL.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_BUY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.BUY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_CHANGE_SHIP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.CHANGE_SHIP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_HIRE_SHIP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.HIRE_SHIP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
     }
 

--- a/engine/src/main/java/org/destinationsol/menu/InputMapKeyboardScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/InputMapKeyboardScreen.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputProcessor;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.input.DefaultControls;
 import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.SolUiControl;
 
@@ -107,67 +108,67 @@ public class InputMapKeyboardScreen extends InputMapOperations {
 
         // This needs to be in the same order the list is initialised
         InputConfigItem item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_UP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.UP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_DOWN);
+        item.setInputKey(Input.Keys.toString(DefaultControls.DOWN.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_LEFT);
+        item.setInputKey(Input.Keys.toString(DefaultControls.LEFT.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_RIGHT);
+        item.setInputKey(Input.Keys.toString(DefaultControls.RIGHT.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_SHOOT);
+        item.setInputKey(Input.Keys.toString(DefaultControls.SHOOT.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_SHOOT2);
+        item.setInputKey(Input.Keys.toString(DefaultControls.SHOOT2.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_ABILITY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.ABILITY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_PAUSE);
+        item.setInputKey(Input.Keys.toString(DefaultControls.PAUSE.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_MAP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.MAP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_INVENTORY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.INVENTORY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_DROP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.DROP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_TALK);
+        item.setInputKey(Input.Keys.toString(DefaultControls.TALK.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_SELL);
+        item.setInputKey(Input.Keys.toString(DefaultControls.SELL.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_BUY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.BUY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_CHANGE_SHIP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.CHANGE_SHIP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_HIRE_SHIP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.HIRE_SHIP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
     }
 

--- a/engine/src/main/java/org/destinationsol/menu/InputMapMixedScreen.java
+++ b/engine/src/main/java/org/destinationsol/menu/InputMapMixedScreen.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputProcessor;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.input.DefaultControls;
 import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.SolUiControl;
 
@@ -90,47 +91,47 @@ public class InputMapMixedScreen extends InputMapOperations {
 
         // This needs to be in the same order the list is initialised
         InputConfigItem item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_MOUSE_UP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.MOUSE_UP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_MOUSE_DOWN);
+        item.setInputKey(Input.Keys.toString(DefaultControls.MOUSE_DOWN.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_PAUSE);
+        item.setInputKey(Input.Keys.toString(DefaultControls.PAUSE.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_MAP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.MAP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_INVENTORY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.INVENTORY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_DROP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.DROP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_TALK);
+        item.setInputKey(Input.Keys.toString(DefaultControls.TALK.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_SELL);
+        item.setInputKey(Input.Keys.toString(DefaultControls.SELL.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_BUY);
+        item.setInputKey(Input.Keys.toString(DefaultControls.BUY.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_CHANGE_SHIP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.CHANGE_SHIP.getDefaultInputs()[0]));
         itemsList.set(index++, item);
 
         item = itemsList.get(index);
-        item.setInputKey(GameOptions.DEFAULT_HIRE_SHIP);
+        item.setInputKey(Input.Keys.toString(DefaultControls.HIRE_SHIP.getDefaultInputs()[0]));
         itemsList.set(index, item);
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request moves the input control constants from `GameOptions` into a separate `DefaultOptions` enum. `GameOptions` has been changed to instead use a dynamic map of controls to their triggering inputs. This should allow for greater extensibility in the future, since modules can now define input controls. There is no way at present to persist the runtime-added controls yet.

An input control consists of an action that can be triggered by any number of input keys. The control itself contains the constant data describing what the control is and how it can be used. Controls are now associated with input types, which can be any of `KEYBOARD`, `MIXED`, `MOUSE` and `CONTROLLER`. Controls can be associated with multiple input types.

A control can now support an arbitrary number of keys as triggering inputs. This is implemented internally within `GameOptions` but currently nothing in the game supports it. Changing the input bindings from the main menu will replace all existing bindings for that control with the single binding chosen currently.

# Testing
- Play the game and make sure that all inputs work as before.
- For each input type, try changing the input bindings from the main menu. Ensure that the following operations work as before:
  - Display input binding
  - Change input binding
  - Save input bindings
  - Reset input bindings to defaults
- Restart the game after changing the input bindings and test again. Ensure that the changed inputs have persisted across saves.

# Future Improvements
These changes are not happening in this pull request but would be ideal as follow-ups.
- Support actually using multiple input bindings within the game e.g. all specified bindings should trigger a button, not just the first one.
- Populate the main menu inputs screen dynamically based on the input types specified by the controls.
- Allow the user to select both a primary button and a secondary button for each control from the main menu inputs screen.

# Notes
- This pull request moves all the keyboard input bindings which where previously stored in a series of constant variables. Because of this, reviewers should be aware that copy-paste errors are highly likely.
- It might be possible to port Terasology's input system to Destination Sol but that would require a considerably larger effort (and more ECS). This pull request attempts to adapt the existing code to be more future-proof instead.