### PR TITLE
feat: make the golden asteroid at spawn optional

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -281,7 +281,7 @@ public class SolApplication implements ApplicationListener {
             entitySystemManager.sendEvent(new RenderEvent(), new Renderable(), new Position());
 
             //TODO remove this block - it is for debugging purposes
-            if (!entityCreated) {
+            if (DebugOptions.SPAWN_ECS_ASTEROID && !entityCreated) {
 
                 Size size = new Size();
                 size.size = 2;
@@ -406,6 +406,7 @@ public class SolApplication implements ApplicationListener {
         // TODO: remove the following line when all screens have been ported to use NUI
         inputManager.setScreen(this, null);
         nuiManager.pushScreen(menuScreens.main);
+        entityCreated = false;
     }
 
     public boolean isMobile() {

--- a/engine/src/main/java/org/destinationsol/game/DebugOptions.java
+++ b/engine/src/main/java/org/destinationsol/game/DebugOptions.java
@@ -33,6 +33,7 @@ public class DebugOptions {
     public static String FORCE_PLANET_TYPE = "";
     public static String FORCE_SYSTEM_TYPE = "";
     public static boolean NO_OBJS = false;
+    public static boolean SPAWN_ECS_ASTEROID = false;
 
     // Presentation
     public static boolean NO_DRAS = false;
@@ -65,6 +66,7 @@ public class DebugOptions {
         FORCE_PLANET_TYPE = r.getString("forcePlanetType", FORCE_PLANET_TYPE);
         FORCE_SYSTEM_TYPE = r.getString("forceSystemType", FORCE_SYSTEM_TYPE);
         NO_OBJS = r.getBoolean("noObjs", NO_OBJS);
+        SPAWN_ECS_ASTEROID = r.getBoolean("spawnECSAsteroid", SPAWN_ECS_ASTEROID);
         NO_DRAS = r.getBoolean("noDras", NO_DRAS);
         ZOOM_OVERRIDE = r.getFloat("zoomOverride", ZOOM_OVERRIDE);
         GRID_SZ = r.getFloat("gridSz", GRID_SZ);

--- a/engine/src/main/resources/debugOptions.ini
+++ b/engine/src/main/resources/debugOptions.ini
@@ -4,6 +4,7 @@ spawnPlace= # possible choices: planet, maze, trader
 forcePlanetType=
 forceSystemType=
 noObjs=false
+spawnECSAsteroid=true
 
 # presentation
 noDras=false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request makes spawning the golden asteroid conditional on enabling a debug option. This option is on by-default in from-source workspaces.

Whilst the ECS asteroid is a useful debugging tool, I do not believe that it is intended for regular players to use.

# Testing
- Play the game and the golden ECS asteroid should spawn as usual.
- Close the game.
- Change `spawnECSAsteriod` in `debugOptions.ini` to `false`.
- When starting a new game, the golden asteroid should no longer spawn.
