### PR TITLE
Module select UI

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -333,6 +333,9 @@ public class SolApplication implements ApplicationListener {
 
     public void play(boolean tut, String shipName, boolean isNewGame, WorldConfig worldConfig) {
         ModuleManager moduleManager = appContext.getBean(ModuleManager.class);
+        moduleManager.loadEnvironment(worldConfig.getModules());
+        appContext.getBean(AssetHelper.class).switchEnvironment(moduleManager.getEnvironment());
+
         gameContext = appContext.getNestedContainer(
                 new GameConfigurationServiceRegistry(worldConfig),
                 new EventReceiverServiceRegistry(moduleManager.getEnvironment()),

--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -350,7 +350,7 @@ public class SolApplication implements ApplicationListener {
         entitySystemManager.initialise();
 
         solGame.createUpdateSystems();
-        solGame.startGame(shipName, isNewGame, worldConfig, entitySystemManager);
+        solGame.startGame(shipName, isNewGame, entitySystemManager);
 
         if (!isNewGame) {
             try {

--- a/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
+++ b/engine/src/main/java/org/destinationsol/assets/AssetHelper.java
@@ -131,6 +131,10 @@ public class AssetHelper {
         return list;
     }
 
+    public void switchEnvironment(ModuleEnvironment environment) {
+        assetTypeManager.switchEnvironment(environment);
+    }
+
     public void dispose() {
         try {
             assetTypeManager.unloadEnvironment();

--- a/engine/src/main/java/org/destinationsol/assets/music/OggMusicManager.java
+++ b/engine/src/main/java/org/destinationsol/assets/music/OggMusicManager.java
@@ -238,7 +238,7 @@ public class OggMusicManager {
     }
 
     public void resetMusic() {
-        musicMap.put(GAME_MUSIC_SET, new ArrayList<>());
+        musicMap.clear();
     }
 
     public String getCurrentMusicSet() {

--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -43,6 +43,7 @@ import org.json.JSONObject;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.List;
 
 public class GalaxyFiller {
     private static final float STATION_CONSUME_SECTOR = 45f;
@@ -140,7 +141,7 @@ public class GalaxyFiller {
             return;
         }
         createStarPorts(game);
-        ArrayList<SolarSystem> systems = game.getGalaxyBuilder().getBuiltSolarSystems();
+        List<SolarSystem> systems = game.getGalaxyBuilder().getBuiltSolarSystems();
 
         JSONObject rootNode = Validator.getValidatedJSON(moduleName + ":startingStation", "engine:schemaStartingStation");
 

--- a/engine/src/main/java/org/destinationsol/game/SaveManager.java
+++ b/engine/src/main/java/org/destinationsol/game/SaveManager.java
@@ -20,6 +20,8 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.math.Vector2;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
@@ -232,16 +234,29 @@ public class SaveManager {
     }
 
     /**
-     * Saves the world to a file. Currently stores the seed used to generate the world and the number of systems
-     * @param numberOfSystems
+     * Saves the world to a file. Currently stores the seed used to generate the world,
+     * the number of systems and the generators used.
+     * @param worldConfig the current world configuration.
      */
-    public static void saveWorld(int numberOfSystems) {
+    public static void saveWorld(WorldConfig worldConfig) {
         Long seed = SolRandom.getSeed();
         String fileName = SaveManager.getResourcePath(Const.WORLD_SAVE_FILE_NAME);
 
         JsonObject world = new JsonObject();
         world.addProperty("seed", seed);
-        world.addProperty("systems", numberOfSystems);
+        world.addProperty("systems", worldConfig.getNumberOfSystems());
+
+        JsonArray solarSystemGenerators = new JsonArray();
+        for (String solarSystemGenerator : worldConfig.getSolarSystemGenerators()) {
+            solarSystemGenerators.add(solarSystemGenerator);
+        }
+        world.add("solarSystemGenerators", solarSystemGenerators);
+
+        JsonArray featureGenerators = new JsonArray();
+        for (String featureGenerator : worldConfig.getFeatureGenerators()) {
+            featureGenerators.add(featureGenerator);
+        }
+        world.add("featureGenerators", featureGenerators);
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String stringToWrite = gson.toJson(world);
@@ -270,6 +285,26 @@ public class SaveManager {
 
                 if (world.has("systems")) {
                     config.setNumberOfSystems(world.get("systems").getAsInt());
+                }
+
+                if (world.has("solarSystemGenerators")) {
+                    List<String> solarSystemGenerators = new ArrayList<>();
+                    for (JsonElement value : world.getAsJsonArray("solarSystemGenerators")) {
+                        if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                            solarSystemGenerators.add(value.getAsString());
+                        }
+                    }
+                    config.setSolarSystemGenerators(solarSystemGenerators);
+                }
+
+                if (world.has("featureGenerators")) {
+                    List<String> featureGenerators = new ArrayList<>();
+                    for (JsonElement value : world.getAsJsonArray("featureGenerators")) {
+                        if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                            featureGenerators.add(value.getAsString());
+                        }
+                    }
+                    config.setFeatureGenerators(featureGenerators);
                 }
 
                 logger.debug("Successfully loaded the world file");

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -149,6 +149,8 @@ public class SolGame {
     protected SolCam solCam;
     @Inject
     protected ModuleManager moduleManager;
+    @Inject
+    protected WorldConfig worldConfig;
 
     protected SolApplication solApplication;
     private Hero hero;
@@ -236,7 +238,7 @@ public class SolGame {
         }
     }
 
-    public void startGame(String shipName, boolean isNewGame, WorldConfig worldConfig, EntitySystemManager entitySystemManager) {
+    public void startGame(String shipName, boolean isNewGame, EntitySystemManager entitySystemManager) {
         this.entitySystemManager = entitySystemManager;
 
         respawnState = new RespawnState();
@@ -331,7 +333,7 @@ public class SolGame {
             if (!hero.isTranscendent()) {
                 saveShip();
             }
-            SaveManager.saveWorld(getPlanetManager().getSystems().size());
+            SaveManager.saveWorld(worldConfig);
 
             try {
                 context.get(SerialisationManager.class).serialise();
@@ -601,6 +603,10 @@ public class SolGame {
 
     public DrawableManager getDrawableManager() {
         return drawableManager;
+    }
+
+    public WorldConfig getWorldConfig() {
+        return worldConfig;
     }
 
     public void setRespawnState() {

--- a/engine/src/main/java/org/destinationsol/game/StarPort.java
+++ b/engine/src/main/java/org/destinationsol/game/StarPort.java
@@ -125,7 +125,7 @@ public class StarPort implements SolObject {
             ship.setMoney(ship.getMoney() - FARE);
             Transcendent transcendent = new Transcendent(ship, fromPlanet, toPlanet, game);
             if (transcendent.getShip().getPilot().isPlayer()) {
-                SaveManager.saveWorld(game.getPlanetManager().getSystems().size());
+                SaveManager.saveWorld(game.getWorldConfig());
                 game.getHero().setTranscendent(transcendent);
             }
             ObjectManager objectManager = game.getObjectManager();
@@ -404,7 +404,7 @@ public class StarPort implements SolObject {
                 SolShip ship = this.ship.toObject(game);
                 if (ship.getPilot().isPlayer()) {
                     game.getHero().setSolShip(ship, game);
-                    SaveManager.saveWorld(game.getPlanetManager().getSystems().size());
+                    SaveManager.saveWorld(game.getWorldConfig());
                 }
                 objectManager.addObjDelayed(ship);
                 blip(game, ship);

--- a/engine/src/main/java/org/destinationsol/game/WorldConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/WorldConfig.java
@@ -16,30 +16,37 @@
 package org.destinationsol.game;
 
 import org.destinationsol.game.planet.SystemsBuilder;
+import org.terasology.gestalt.module.Module;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class WorldConfig {
     protected long seed;
     protected int numberOfSystems;
     private List<String> solarSystemGenerators;
     private List<String> featureGenerators;
+    private Set<Module> modules;
 
     public WorldConfig() {
         seed = System.currentTimeMillis();
         numberOfSystems = SystemsBuilder.DEFAULT_SYSTEM_COUNT;
         solarSystemGenerators = new ArrayList<>();
         featureGenerators = new ArrayList<>();
+        modules = new HashSet<>();
     }
 
     public WorldConfig(long seed, int numberOfSystems,
                        List<String> solarSystemGenerators,
-                       List<String> featureGenerators) {
+                       List<String> featureGenerators,
+                       Set<Module> modules) {
         this.seed = seed;
         this.numberOfSystems = numberOfSystems;
         this.solarSystemGenerators = solarSystemGenerators;
         this.featureGenerators = featureGenerators;
+        this.modules = modules;
     }
 
     public long getSeed() {
@@ -72,5 +79,13 @@ public class WorldConfig {
 
     public void setSolarSystemGenerators(List<String> solarSystemGenerators) {
         this.solarSystemGenerators = solarSystemGenerators;
+    }
+
+    public Set<Module> getModules() {
+        return modules;
+    }
+
+    public void setModules(Set<Module> modules) {
+        this.modules = modules;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/WorldConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/WorldConfig.java
@@ -17,18 +17,29 @@ package org.destinationsol.game;
 
 import org.destinationsol.game.planet.SystemsBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class WorldConfig {
     protected long seed;
     protected int numberOfSystems;
+    private List<String> solarSystemGenerators;
+    private List<String> featureGenerators;
 
     public WorldConfig() {
         seed = System.currentTimeMillis();
         numberOfSystems = SystemsBuilder.DEFAULT_SYSTEM_COUNT;
+        solarSystemGenerators = new ArrayList<>();
+        featureGenerators = new ArrayList<>();
     }
 
-    public WorldConfig(long seed, int numberOfSystems) {
+    public WorldConfig(long seed, int numberOfSystems,
+                       List<String> solarSystemGenerators,
+                       List<String> featureGenerators) {
         this.seed = seed;
         this.numberOfSystems = numberOfSystems;
+        this.solarSystemGenerators = solarSystemGenerators;
+        this.featureGenerators = featureGenerators;
     }
 
     public long getSeed() {
@@ -45,5 +56,21 @@ public class WorldConfig {
 
     public void setNumberOfSystems(int numberOfSystems) {
         this.numberOfSystems = numberOfSystems;
+    }
+
+    public List<String> getSolarSystemGenerators() {
+        return solarSystemGenerators;
+    }
+
+    public void setFeatureGenerators(List<String> featureGenerators) {
+        this.featureGenerators = featureGenerators;
+    }
+
+    public List<String> getFeatureGenerators() {
+        return featureGenerators;
+    }
+
+    public void setSolarSystemGenerators(List<String> solarSystemGenerators) {
+        this.solarSystemGenerators = solarSystemGenerators;
     }
 }

--- a/engine/src/main/java/org/destinationsol/menu/MenuScreens.java
+++ b/engine/src/main/java/org/destinationsol/menu/MenuScreens.java
@@ -22,6 +22,7 @@ import org.destinationsol.ui.nui.screens.mainMenu.CreditsScreen;
 import org.destinationsol.ui.nui.screens.mainMenu.InputMapScreen;
 import org.destinationsol.ui.nui.screens.mainMenu.LoadingScreen;
 import org.destinationsol.ui.nui.screens.mainMenu.MainMenuScreen;
+import org.destinationsol.ui.nui.screens.mainMenu.ModulesScreen;
 import org.destinationsol.ui.nui.screens.mainMenu.NewGameScreen;
 import org.destinationsol.ui.nui.screens.mainMenu.NewShipScreen;
 import org.destinationsol.ui.nui.screens.mainMenu.OptionsScreen;
@@ -36,6 +37,7 @@ public class MenuScreens {
     public final LoadingScreen loading;
     public final NewGameScreen newGame;
     public final NewShipScreen newShip;
+    public final ModulesScreen modules;
 
     public MenuScreens(SolLayouts layouts, boolean mobile, GameOptions gameOptions, NUIManager nuiManager) {
         MenuLayout menuLayout = layouts.menuLayout;
@@ -47,5 +49,6 @@ public class MenuScreens {
         loading = (LoadingScreen) nuiManager.createScreen("engine:loadingScreen");
         newGame = (NewGameScreen) nuiManager.createScreen("engine:newGameScreen");
         newShip = (NewShipScreen) nuiManager.createScreen("engine:newShipScreen");
+        modules = (ModulesScreen) nuiManager.createScreen("engine:modulesScreen");
     }
 }

--- a/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
+++ b/engine/src/main/java/org/destinationsol/modules/ModuleManager.java
@@ -220,6 +220,7 @@ public class ModuleManager implements AutoCloseable {
     private final FacadeModuleConfig moduleConfig;
     protected ModuleRegistry registry;
     protected Module engineModule;
+    private Set<Module> builtInModules;
 
     @Inject
     public ModuleManager(BeanContext beanContext, ModuleFactory moduleFactory, ModuleRegistry moduleRegistry,
@@ -240,9 +241,12 @@ public class ModuleManager implements AutoCloseable {
             File modulesRoot = moduleConfig.getModulesPath();
             scanner.scan(registry, modulesRoot);
 
+            builtInModules = Sets.newHashSet();
+            builtInModules.add(engineModule);
+            builtInModules.add(nuiModule);
+            registry.addAll(builtInModules);
+
             Set<Module> requiredModules = Sets.newHashSet();
-            registry.add(engineModule);
-            registry.add(nuiModule);
             requiredModules.addAll(registry);
 
             loadEnvironment(requiredModules);
@@ -253,6 +257,8 @@ public class ModuleManager implements AutoCloseable {
     }
 
     public void loadEnvironment(Set<Module> modules) {
+        modules.addAll(builtInModules);
+
         StandardPermissionProviderFactory permissionFactory = new StandardPermissionProviderFactory();
         for (String api : API_WHITELIST) {
             permissionFactory.getBasePermissionSet().addAPIPackage(api);
@@ -288,6 +294,10 @@ public class ModuleManager implements AutoCloseable {
         return environment;
     }
 
+    public Set<Module> getBuiltInModules() {
+        return builtInModules;
+    }
+
     //TODO: REMOVE THIS
     public static ModuleEnvironment getEnvironmentStatic() {
         return environment;
@@ -297,6 +307,10 @@ public class ModuleManager implements AutoCloseable {
         for (Module module : registry) {
             logger.info("Module Discovered: {}", module);
         }
+    }
+
+    public ModuleRegistry getRegistry() {
+        return registry;
     }
 
     public void dispose() {

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/MainMenuScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/MainMenuScreen.java
@@ -20,12 +20,14 @@ import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
 import org.destinationsol.assets.music.OggMusicManager;
 import org.destinationsol.game.WorldConfig;
+import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.ui.nui.NUIManager;
 import org.destinationsol.ui.nui.NUIScreenLayer;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.widgets.UIButton;
 
 import javax.inject.Inject;
+import java.util.HashSet;
 
 /**
  * The main menu screen. This is the first screen shown when you open the game.
@@ -33,18 +35,22 @@ import javax.inject.Inject;
 public class MainMenuScreen extends NUIScreenLayer {
 
     private final SolApplication solApplication;
+    private final ModuleManager moduleManager;
     private UIButton tutorialButton;
 
     @Inject
-    public MainMenuScreen(SolApplication solApplication) {
+    public MainMenuScreen(SolApplication solApplication, ModuleManager moduleManager) {
         this.solApplication = solApplication;
+        this.moduleManager = moduleManager;
     }
 
     @Override
     public void initialise() {
         tutorialButton = find("tutorialButton", UIButton.class);
         tutorialButton.subscribe(button -> {
-            solApplication.getMenuScreens().loading.setMode(true, "Imperial Small", true, new WorldConfig());
+            WorldConfig worldConfig = new WorldConfig();
+            worldConfig.setModules(new HashSet<>(moduleManager.getEnvironment().getModulesOrderedByDependencies()));
+            solApplication.getMenuScreens().loading.setMode(true, "Imperial Small", true, worldConfig);
             nuiManager.setScreen(solApplication.getMenuScreens().loading);
         });
 

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/ModulesScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/ModulesScreen.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.destinationsol.ui.nui.screens.mainMenu;
+
+import org.destinationsol.SolApplication;
+import org.destinationsol.modules.ModuleManager;
+import org.destinationsol.ui.nui.NUIScreenLayer;
+import org.terasology.gestalt.module.Module;
+import org.terasology.nui.databinding.ReadOnlyBinding;
+import org.terasology.nui.itemRendering.StringTextRenderer;
+import org.terasology.nui.widgets.UIButton;
+import org.terasology.nui.widgets.UIList;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This screen is used to select the modules that should be active when playing a particular save.
+ * You can activate and de-activate modules only when initially creating a game.
+ * This is to prevent side-effects from new modules being introduced unexpectedly.
+ */
+public class ModulesScreen extends NUIScreenLayer {
+    private final SolApplication solApplication;
+    private final ModuleManager moduleManager;
+    private Set<Module> selectedModules;
+
+    @Inject
+    public ModulesScreen(SolApplication solApplication, ModuleManager moduleManager) {
+        this.solApplication = solApplication;
+        this.moduleManager = moduleManager;
+    }
+
+    @Override
+    public void initialise() {
+        selectedModules = new HashSet<>();
+
+        UIList<Module> moduleList = find("modulesList", UIList.class);
+        List<Module> modules = new ArrayList<>(moduleManager.getEnvironment().getModulesOrderedByDependencies());
+        modules.removeAll(moduleManager.getBuiltInModules());
+        moduleList.setList(modules);
+        moduleList.setItemRenderer(new StringTextRenderer<Module>() {
+            @Override
+            public String getString(Module value) {
+                if (!selectedModules.contains(value)) {
+                    return value.getId().toString();
+                } else {
+                    return value.getId().toString() + " (Active)";
+                }
+            }
+        });
+        moduleList.subscribe((list, module) -> {
+            if (selectedModules.contains(module)) {
+                selectedModules.remove(module);
+            } else {
+                selectedModules.add(module);
+            }
+        });
+
+        UIButton activateButton = find("activateButton", UIButton.class);
+        activateButton.bindEnabled(new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                Module selectedModule = moduleList.getSelection();
+                return selectedModule != null && !selectedModules.contains(selectedModule);
+            }
+        });
+        activateButton.subscribe(button -> selectedModules.add(moduleList.getSelection()));
+
+        UIButton deactivateButton = find("deactivateButton", UIButton.class);
+        deactivateButton.bindEnabled(new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                Module selectedModule = moduleList.getSelection();
+                return selectedModule != null && selectedModules.contains(selectedModule);
+            }
+        });
+        deactivateButton.subscribe(button -> selectedModules.remove(moduleList.getSelection()));
+
+        UIButton confirmButton = find("confirmButton", UIButton.class);
+        confirmButton.subscribe(button -> {
+            nuiManager.setScreen(solApplication.getMenuScreens().newShip);
+        });
+    }
+
+    public Set<Module> getSelectedModules() {
+        return selectedModules;
+    }
+
+    public void setSelectedModules(Set<Module> selectedModules) {
+        this.selectedModules = selectedModules;
+    }
+}

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/NewShipScreen.java
@@ -21,41 +21,53 @@ import org.destinationsol.assets.json.Json;
 import org.destinationsol.assets.json.Validator;
 import org.destinationsol.game.WorldConfig;
 import org.destinationsol.game.planet.SystemsBuilder;
+import org.destinationsol.modules.ModuleManager;
 import org.destinationsol.ui.nui.NUIManager;
 import org.destinationsol.ui.nui.NUIScreenLayer;
 import org.destinationsol.ui.nui.widgets.KeyActivatedButton;
 import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.gestalt.module.Module;
+import org.terasology.gestalt.naming.Name;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.backends.libgdx.GDXInputUtil;
 import org.terasology.nui.widgets.UIButton;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class NewShipScreen extends NUIScreenLayer {
 
     private final SolApplication solApplication;
-    private int numberOfSystems = SystemsBuilder.DEFAULT_SYSTEM_COUNT;
+    private final ModuleManager moduleManager;
     private int playerSpawnConfigIndex = 0;
     private List<String> playerSpawnConfigNames = new ArrayList<>();
+    private WorldConfig worldConfig;
 
     @Inject
-    public NewShipScreen(SolApplication solApplication) {
+    public NewShipScreen(SolApplication solApplication, ModuleManager moduleManager) {
         this.solApplication = solApplication;
+        this.moduleManager = moduleManager;
     }
 
     @Override
     public void initialise() {
+        worldConfig = new WorldConfig();
+        worldConfig.setNumberOfSystems(SystemsBuilder.DEFAULT_SYSTEM_COUNT);
+        worldConfig.setModules(new HashSet<>(moduleManager.getEnvironment().getModulesOrderedByDependencies()));
+
         UIButton systemsButton = find("systemsButton", UIButton.class);
-        systemsButton.setText("Systems: " + numberOfSystems);
+        systemsButton.setText("Systems: " + worldConfig.getNumberOfSystems());
         systemsButton.subscribe(button -> {
-            int systemCount = (numberOfSystems + 1) % 10;
+            int systemCount = (worldConfig.getNumberOfSystems() + 1) % 10;
             if (systemCount < 2) {
                 systemCount = 2;
             }
-            numberOfSystems = systemCount;
-            ((UIButton)button).setText("Systems: " + numberOfSystems);
+            worldConfig.setNumberOfSystems(systemCount);
+            ((UIButton)button).setText("Systems: " + worldConfig.getNumberOfSystems());
         });
 
         for (ResourceUrn configUrn : Assets.getAssetHelper().listAssets(Json.class, "playerSpawnConfig")) {
@@ -69,13 +81,17 @@ public class NewShipScreen extends NUIScreenLayer {
             ((UIButton)button).setText("Starting Ship: " + playerSpawnConfigNames.get(playerSpawnConfigIndex));
         });
 
+        UIButton modulesButton = find("modulesButton", UIButton.class);
+        modulesButton.subscribe(button -> {
+            ModulesScreen modulesScreen = solApplication.getMenuScreens().modules;
+            modulesScreen.setSelectedModules(worldConfig.getModules());
+            nuiManager.setScreen(modulesScreen);
+        });
+
         // NOTE: The original code used getKeyEscape() for both the "OK" and "Cancel" buttons. This was probably a mistake.
         KeyActivatedButton okButton = find("okButton", KeyActivatedButton.class);
         okButton.setKey(GDXInputUtil.GDXToNuiKey(solApplication.getOptions().getKeyShoot()));
         okButton.subscribe(button -> {
-            WorldConfig worldConfig = new WorldConfig();
-            worldConfig.setNumberOfSystems(numberOfSystems);
-
             LoadingScreen loadingScreen = solApplication.getMenuScreens().loading;
             loadingScreen.setMode(false, playerSpawnConfigNames.get(playerSpawnConfigIndex), true, worldConfig);
             nuiManager.setScreen(loadingScreen);
@@ -86,6 +102,28 @@ public class NewShipScreen extends NUIScreenLayer {
         cancelButton.subscribe(button -> {
             nuiManager.setScreen(solApplication.getMenuScreens().newGame);
         });
+    }
+
+    @Override
+    public void onAdded() {
+        worldConfig.setSeed(System.currentTimeMillis());
+
+        String currentShip = playerSpawnConfigNames.get(playerSpawnConfigIndex);
+        playerSpawnConfigNames.clear();
+        Set<ResourceUrn> configUrns = Assets.getAssetHelper().listAssets(Json.class, "playerSpawnConfig");
+        for (Module module : worldConfig.getModules()) {
+            ResourceUrn configUrn = new ResourceUrn(module.getId(), new Name("playerSpawnConfig"));
+            if (configUrns.contains(configUrn)) {
+                playerSpawnConfigNames.addAll(Validator.getValidatedJSON(configUrn.toString(), "engine:schemaPlayerSpawnConfig").keySet());
+            }
+        }
+
+        if (!playerSpawnConfigNames.contains(currentShip)) {
+            // The player picked a ship that's now invalid, so reset their selection.
+            playerSpawnConfigIndex = 0;
+            UIButton startingShipButton = find("startingShipButton", UIButton.class);
+            startingShipButton.setText("Starting Ship: " + playerSpawnConfigNames.get(playerSpawnConfigIndex));
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/world/GalaxyBuilder.java
+++ b/engine/src/main/java/org/destinationsol/world/GalaxyBuilder.java
@@ -67,9 +67,15 @@ public class GalaxyBuilder {
             populateSolarSystemGeneratorList();
         } else {
             for (String typeName : worldConfig.getSolarSystemGenerators()) {
-                for (Class<? extends SolarSystemGenerator> possibleGeneratorType :
-                        moduleManager.getEnvironment().getSubtypesOf(SolarSystemGenerator.class, type -> type.getName().equals(typeName))) {
-                    solarSystemGeneratorTypes.add(possibleGeneratorType);
+                Iterable<Class<? extends SolarSystemGenerator>> generatorTypes =
+                        moduleManager.getEnvironment().getSubtypesOf(SolarSystemGenerator.class, type -> type.getName().equals(typeName));
+                if (!generatorTypes.iterator().hasNext()) {
+                    logger.error("Unable to find SolarSystemGenerator type {}! World generation will likely be incorrect.", typeName);
+                    continue;
+                }
+
+                for (Class<? extends SolarSystemGenerator> generatorType : generatorTypes) {
+                    solarSystemGeneratorTypes.add(generatorType);
                 }
             }
         }
@@ -78,9 +84,15 @@ public class GalaxyBuilder {
             populateFeatureGeneratorList();
         } else {
             for (String typeName : worldConfig.getFeatureGenerators()) {
-                for (Class<? extends FeatureGenerator> possibleGeneratorType :
-                        moduleManager.getEnvironment().getSubtypesOf(FeatureGenerator.class, type -> type.getName().equals(typeName))) {
-                    featureGeneratorTypes.add(possibleGeneratorType);
+                Iterable<Class<? extends FeatureGenerator>> generatorTypes =
+                        moduleManager.getEnvironment().getSubtypesOf(FeatureGenerator.class, type -> type.getName().equals(typeName));
+                if (!generatorTypes.iterator().hasNext()) {
+                    logger.error("Unable to find FeatureGenerator type {}! World generation will likely be incorrect.", typeName);
+                    continue;
+                }
+
+                for (Class<? extends FeatureGenerator> generatorType : generatorTypes) {
+                    featureGeneratorTypes.add(generatorType);
                 }
             }
         }

--- a/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
+++ b/engine/src/main/java/org/destinationsol/world/generators/SolarSystemGenerator.java
@@ -466,7 +466,7 @@ public abstract class SolarSystemGenerator {
                 && !PlanetGenerator.class.isAssignableFrom(featureGeneratorTypes.get(index));
     }
 
-    public void setFeatureGeneratorTypes(ArrayList<Class<? extends FeatureGenerator>> generators) {
+    public void setFeatureGeneratorTypes(List<Class<? extends FeatureGenerator>> generators) {
         featureGeneratorTypes.addAll(generators);
     }
 

--- a/engine/src/main/resources/org/destinationsol/assets/skins/mainMenu.skin
+++ b/engine/src/main/resources/org/destinationsol/assets/skins/mainMenu.skin
@@ -61,6 +61,9 @@
         "creditsButton": {
             "font": "engine:main#0.60"
         },
+        "modulesButton": {
+            "font": "engine:main#0.55"
+        },
         "menuHeaderText": {
             "font": "engine:main#1.0"
         },

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainMenu/modulesScreen.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainMenu/modulesScreen.ui
@@ -1,0 +1,106 @@
+{
+    "type": "ModulesScreen",
+    "skin": "engine:mainMenu",
+    "contents": {
+        "type": "RelativeLayout",
+        "contents": [
+            {
+                "type": "UILabel",
+                "id": "headerText",
+                "family": "menuHeaderText",
+                "text": "Modules",
+                "layoutInfo": {
+                    "position-horizontal-center": {},
+                    "position-top": {
+                        "target": "TOP",
+                        "offset": 32
+                    },
+                    "use-content-height": true
+                }
+            },
+            {
+                "type": "ColumnLayout",
+                "id": "moduleSelectLayout",
+                "columns": 2,
+                "column-widths": [0.7, 0.3],
+                "horizontalSpacing": 16,
+                "contents": [
+                    {
+                        "type": "ScrollableArea",
+                        "content": {
+                            "type": "UIList",
+                            "id": "modulesList",
+                            "family": "menuButtons"
+                        }
+                    },
+                    {
+                        "type": "RelativeLayout",
+                        "id": "moduleActionButtons",
+                        "contents": [
+                            {
+                                "type": "UIButton",
+                                "id": "activateButton",
+                                "text": "Activate Module",
+                                "layoutInfo": {
+                                    "position-bottom": {
+                                        "target": "MIDDLE",
+                                        "offset": 5
+                                    },
+                                    "use-content-height": true
+                                }
+                            },
+                            {
+                                "type": "UIButton",
+                                "id": "deactivateButton",
+                                "text": "Deactivate Module",
+                                "layoutInfo": {
+                                    "position-top": {
+                                        "target": "MIDDLE",
+                                        "offset": 5
+                                    },
+                                    "use-content-height": true
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "layoutInfo": {
+                    "position-horizontal-center": {},
+                    "position-bottom": {
+                        "widget": "confirmButton",
+                        "target": "TOP",
+                        "offset": 16
+                    },
+                    "position-top": {
+                        "widget": "headerText",
+                        "target": "BOTTOM",
+                        "offset": 16
+                    },
+                    "position-left": {
+                        "offset": 16
+                    },
+                    "position-right": {
+                        "offset": 16
+                    }
+                }
+            },
+            {
+                "type": "UIButton",
+                "id": "confirmButton",
+                "text": "Confirm",
+                "layoutInfo": {
+                    "position-bottom": {
+                        "offset": 32
+                    },
+                    "position-left": {
+                        "offset": 32
+                    },
+                    "position-right": {
+                        "offset": 32
+                    },
+                    "use-content-height": true
+                }
+            }
+        ]
+    }
+}

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainMenu/newShipScreen.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainMenu/newShipScreen.ui
@@ -56,6 +56,18 @@
                     "use-content-height": true,
                     "use-content-width": true
                 }
+            },
+            {
+                "type": "UIButton",
+                "id": "modulesButton",
+                "family": "modulesButton",
+                "text": "Modules",
+                "layoutInfo": {
+                    "position-right": {},
+                    "position-bottom": {},
+                    "width": 100,
+                    "height": 50
+                }
             }
         ]
     }

--- a/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
+++ b/engine/src/test/java/org/destinationsol/world/generators/MazeGeneratorTest.java
@@ -67,8 +67,10 @@ public class MazeGeneratorTest implements AssetsHelperInitializer {
 
         setupConfigManagers();
 
+        WorldConfig worldConfig = new WorldConfig();
+        worldConfig.setNumberOfSystems(1);
         context = new DefaultBeanContext(registry);
-        galaxyBuilder = new GalaxyBuilder(new WorldConfig(), moduleManager, context.getBean(SolarSystemConfigManager.class), context);
+        galaxyBuilder = new GalaxyBuilder(worldConfig, moduleManager, context.getBean(SolarSystemConfigManager.class), context);
 
         ArrayList<SolarSystemGenerator> solarSystemGenerators = galaxyBuilder.initializeRandomSolarSystemGenerators();
         solarSystemGenerator = solarSystemGenerators.get(0);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request adds a module select screen, which allows the player to choose which modules to use when starting a new game.

![image](https://user-images.githubusercontent.com/24301287/177849847-c4d240e9-4a69-4cfb-8cd3-337460360f22.png)

# Testing
- Continue an existing game (to ensure that this still works).
- Select the `Play Game` item in the main menu, followed by the `New Game` option. A <kbd>Modules</kbd> button should be visible in the bottom-left corner.
- Select the `Modules` button and the modules screen should appear.
- Create a few new games to test the following things:
  - When the `warp` module (or any other module, as applicable) is de-activated, you should not be able to select warp ships. Warp features, such as wormholes, should not appear in-game.
  - When the game is resumed, it should still only contain the modules selected upon its creation. No new modules should have be running, even if added after the save was created.

# Known Issues
- Console commands persist event after their module is removed. This is because the console is part of the application context, rather than the game context, which isn't unloaded until the application exits.
- Modifications made to NUI screens by modules persist even after that module is removed.

# Notes
 - This depends on #647.
 - Feel free to comment on the UI designs. 