### PR TITLE
General NUI Fixes

### DIFF
--- a/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
@@ -33,6 +33,7 @@ import org.destinationsol.common.SolColor;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.context.Context;
+import org.destinationsol.ui.nui.NUIManager;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -292,11 +293,12 @@ public class SolInputManager {
         if (solApplication.isMobile()) {
             return;
         }
+        NUIManager nuiManager = solApplication.getNuiManager();
         SolGame game = solApplication.getGame();
 
         mousePos.set(inputPointers[0].x, inputPointers[0].y);
         if (solApplication.getOptions().controlType == GameOptions.ControlType.MIXED || solApplication.getOptions().controlType == GameOptions.ControlType.MOUSE) {
-            if (game == null || mouseOnUi) {
+            if (game == null || mouseOnUi || nuiManager.isMouseOnUi()) {
                 currCursor = uiCursor;
             } else {
                 currCursor = game.getScreens().mainGameScreen.getShipControl().getInGameTex();

--- a/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
@@ -24,7 +24,6 @@ import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.sound.OggSound;
 import org.destinationsol.game.context.Context;
 import org.destinationsol.ui.UiDrawer;
-import org.destinationsol.util.InjectionHelper;
 import org.terasology.joml.geom.Rectanglei;
 import org.joml.Vector2i;
 import org.terasology.input.InputType;
@@ -37,7 +36,6 @@ import org.terasology.input.device.MouseAction;
 import org.terasology.input.device.MouseDevice;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.FocusManager;
-import org.terasology.nui.FocusManagerImpl;
 import org.terasology.nui.TabbingManager;
 import org.terasology.nui.UITextureRegion;
 import org.terasology.nui.UIWidget;
@@ -192,6 +190,8 @@ public class NUIManager {
      * @param solApplication the application to use
      */
     public void update(SolApplication solApplication) {
+        mouse.update();
+
         for (int pointer = 0; pointer < mouse.getMaxPointers(); pointer++) {
             canvas.processMousePosition(mouse.getPosition(pointer), pointer);
         }
@@ -232,9 +232,13 @@ public class NUIManager {
         for (MouseAction action : mouse.getInputQueue()) {
             if (action.getInput().getType() == InputType.MOUSE_BUTTON) {
                 if (action.getState().isDown()) {
-                    canvas.processMouseClick((MouseInput) action.getInput(), action.getMousePosition(), action.getPointer());
+                    if (canvas.processMouseClick((MouseInput) action.getInput(), action.getMousePosition(), action.getPointer())) {
+                        continue;
+                    }
                 } else {
-                    canvas.processMouseRelease((MouseInput) action.getInput(), action.getMousePosition(), action.getPointer());
+                    if (canvas.processMouseRelease((MouseInput) action.getInput(), action.getMousePosition(), action.getPointer())) {
+                        continue;
+                    }
                 }
 
                 NUIMouseButtonEvent event = new NUIMouseButtonEvent((MouseInput) action.getInput(), action.getState(), action.getMousePosition());

--- a/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
@@ -123,7 +123,7 @@ public class NUIManager {
     private static final String WHITE_TEXTURE_URN = "engine:uiWhiteTex";
     private static final String DEFAULT_SKIN_URN = "engine:default";
     private static final String BUTTON_CLICK_URN = "engine:uiHover";
-    private static final float MOBILE_UI_DENSITY = 1.5f;
+    private static final float MOBILE_UI_DENSITY = 2.0f;
     /**
      * The value 0.9 was found from {@link org.destinationsol.ui.SolInputManager#playClick}, so it was copied here to
      * retain the same click sound as the built-in UI.

--- a/engine/src/main/java/org/destinationsol/ui/nui/NUIScreenLayer.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/NUIScreenLayer.java
@@ -123,15 +123,19 @@ public abstract class NUIScreenLayer extends AbstractWidget {
      */
     @Override
     public boolean onKeyEvent(NUIKeyEvent event) {
-        if (escapeCloses() && event.getState() == ButtonState.UP && event.getKey() == Keyboard.Key.ESCAPE) {
-            nuiManager.removeScreen(this);
-            return true;
-        }
-
         // Send key events to all KeyActivatedButton sub-widgets. These buttons are supposed to react to key events
         // even when they are not in-focus.
         for (UIWidget widget : contents.findAll(KeyActivatedButton.class)) {
-            widget.onKeyEvent(event);
+            if (widget.onKeyEvent(event)) {
+                return true;
+            }
+        }
+
+        // Process escape key handling after KeyActivatedButton key events, since some screens might implement
+        // a close button bound to the escape key.
+        if (escapeCloses() && event.getState() == ButtonState.UP && event.getKey() == Keyboard.Key.ESCAPE) {
+            nuiManager.removeScreen(this);
+            return true;
         }
 
         return super.onKeyEvent(event);

--- a/engine/src/main/java/org/destinationsol/ui/nui/widgets/KeyActivatedButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/widgets/KeyActivatedButton.java
@@ -42,6 +42,17 @@ public class KeyActivatedButton extends UIButton {
     @LayoutConfig
     private Binding<Boolean> activateWhenInvisible = new DefaultBinding<>(false);
 
+    public KeyActivatedButton() {
+    }
+
+    public KeyActivatedButton(String id) {
+        super(id);
+    }
+
+    public KeyActivatedButton(String id, String text) {
+        super(id, text);
+    }
+
     /**
      * Binds the key used to activate this {@code KeyActivatedButton}.
      *

--- a/engine/src/main/java/org/destinationsol/ui/nui/widgets/KeyActivatedButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/widgets/KeyActivatedButton.java
@@ -104,6 +104,20 @@ public class KeyActivatedButton extends UIButton {
             return true;
         }
 
+        // WidgetWithOrder contains some logic that consumed all UP key and DOWN key events, even when it does nothing
+        // with them. This might be worthwhile for scrolling lists but shouldn't do anything otherwise.
+        if (parent == null) {
+            return false;
+        }
         return super.onKeyEvent(event);
+    }
+
+    /**
+     * Simulates a button press, activating the widget immediately.
+     * This can be used for unconventional input triggers, such as mouse wheel moves,
+     * which are mapped as auxiliary triggers for the button.
+     */
+    public void simulatePress() {
+        activateWidget();
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/nui/widgets/UIWarnButton.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/widgets/UIWarnButton.java
@@ -38,6 +38,17 @@ public class UIWarnButton extends KeyActivatedButton {
     private boolean warnPercGrows;
     private float warnAlpha = 1f;
 
+    public UIWarnButton() {
+    }
+
+    public UIWarnButton(String id) {
+        super(id);
+    }
+
+    public UIWarnButton(String id, String text) {
+        super(id, text);
+    }
+
     @Override
     public void onDraw(Canvas canvas) {
         if (warnCounter > 0) {
@@ -78,6 +89,14 @@ public class UIWarnButton extends KeyActivatedButton {
      */
     public void enableWarn() {
         warnCounter = WARN_COUNTER_MAX;
+    }
+
+    /**
+     * Returns true if the button is currently in a "warn" phase.
+     * @return true, if the button is currently in a "warn" phase, otherwise false.
+     */
+    public boolean isWarning() {
+        return warnCounter > 0;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request provides several fixes, both minor and major, which improve the general usability of NUI within Destination Sol:
 - Show the UI cursor when hovering over NUI elements (as is done with the built-in UI)
 - Increase the base mobile UI density to allow for larger UIs (although they will occupy less screen space in comparison to before)
 - Call `NUIScreenLayer#onRemoved` post-removal, rather than pre-removal. The previous behaviour was likely unintentional.
 - Consume key up/down events in `NUIScreenLayer` if any of its child `KeyActivatedButton` widgets consume those events.
 - Prevent `KeyActivatedButton` from unconditionally consuming up/down arrow key events.
 - Add some public constructors to Destination Sol's custom NUI widgets, so that they can be safely instantiated in code.

# Testing
Most of these fixes come from scenarios encountered whilst porting the in-game screens to use NUI. As such, they solve problems are not yet exposed in the `develop` codebase.

The following things should be testable directly with these changes though:
- Verify that all NUI screens still render as before
- Verify that hovering over NUI elements shows the UI cursor in-game

# Notes
- The `NUIScreenLayer#onRemoved` change is technically an breaking change in functionality, however, since there has never been a release containing NUI yet, it should not have a significant impact.
