### PR TITLE
Convert remaining MainGameScreen visuals to NUI

### DIFF
--- a/engine/src/main/java/org/destinationsol/SolApplication.java
+++ b/engine/src/main/java/org/destinationsol/SolApplication.java
@@ -362,7 +362,7 @@ public class SolApplication implements ApplicationListener {
 
         factionDisplay = new FactionDisplay(gameContext.getBean(SolCam.class));
         nuiManager.removeScreen(menuScreens.loading);
-        inputManager.setScreen(this, solGame.getScreens().mainGameScreen);
+        inputManager.setScreen(this, solGame.getScreens().oldMainGameScreen);
     }
 
     public SolInputManager getInputManager() {

--- a/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
+++ b/engine/src/main/java/org/destinationsol/game/PlayerCreator.java
@@ -185,7 +185,7 @@ class PlayerCreator {
         if (isMouseControl) {
             return new AiPilot(new BeaconDestProvider(), true, Faction.LAANI, false, "you", Const.AI_DET_DIST);
         } else {
-            return new UiControlledPilot(game.getScreens().getMainGameScreen().getShipControl());
+            return new UiControlledPilot(game.getScreens().getOldMainGameScreen().getShipControl());
         }
     }
 

--- a/engine/src/main/java/org/destinationsol/game/SolCam.java
+++ b/engine/src/main/java/org/destinationsol/game/SolCam.java
@@ -177,7 +177,7 @@ public class SolCam implements UpdateAwareSystem {
     }
 
     private void applyInput(SolGame game) {
-        MainGameScreen screen = game.getScreens().mainGameScreen;
+        MainGameScreen screen = game.getScreens().oldMainGameScreen;
         boolean d = screen.isCameraDown();
         boolean u = screen.isCameraUp();
         boolean l = screen.isCameraLeft();

--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -22,7 +22,6 @@ import org.destinationsol.Const;
 import org.destinationsol.ContextWrapper;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
-import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.sound.OggSoundManager;
 import org.destinationsol.assets.sound.SpecialSounds;
 import org.destinationsol.common.DebugCol;
@@ -68,10 +67,8 @@ import org.destinationsol.ui.Waypoint;
 import org.destinationsol.ui.nui.screens.MainGameScreen;
 import org.destinationsol.world.GalaxyBuilder;
 import org.terasology.context.exception.BeanNotFoundException;
-import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.di.BeanContext;
 import org.terasology.gestalt.entitysystem.entity.EntityRef;
-import org.terasology.nui.asset.UIElement;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -266,7 +263,7 @@ public class SolGame {
             }
         }, 0, 30);
         gameScreens.consoleScreen.init(this);
-        solApplication.getNuiManager().pushScreen(mainGameScreen);
+        solApplication.getNuiManager().pushScreen(gameScreens.mainGameScreen);
         tutorialManager.ifPresent(TutorialManager::start);
     }
 

--- a/engine/src/main/java/org/destinationsol/game/item/ItemManager.java
+++ b/engine/src/main/java/org/destinationsol/game/item/ItemManager.java
@@ -78,6 +78,14 @@ public class ItemManager {
         }
     }
 
+    public ItemConfig parseItem(String item) {
+        List<ItemConfig> items = parseItems(item);
+        if (items.isEmpty()) {
+            return null;
+        }
+        return items.get(0);
+    }
+
     public List<ItemConfig> parseItems(String items) {
         ArrayList<ItemConfig> result = new ArrayList<>();
 

--- a/engine/src/main/java/org/destinationsol/game/screens/BorderDrawer.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/BorderDrawer.java
@@ -56,7 +56,7 @@ public class BorderDrawer {
     private final ArrayList<PlanetProximityIndicator> planetProximityIndicators;
     private final Vector2 myTmpVec = new Vector2();
 
-    BorderDrawer() {
+    public BorderDrawer() {
         displayDimensions = SolApplication.displayDimensions;
 
         TextureAtlas.AtlasRegion texture = Assets.getAtlasRegion("engine:uiPlanetProximityIndicator");

--- a/engine/src/main/java/org/destinationsol/game/screens/BuyItemsScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/BuyItemsScreen.java
@@ -54,7 +54,7 @@ public class BuyItemsScreen extends InventoryOperationsScreen {
         TalkScreen talkScreen = game.getScreens().talkScreen;
         SolShip target = talkScreen.getTarget();
         if (talkScreen.isTargetFar(hero)) {
-            solApplication.getInputManager().setScreen(solApplication, game.getScreens().mainGameScreen);
+            solApplication.getInputManager().setScreen(solApplication, game.getScreens().oldMainGameScreen);
             return;
         }
         SolItem selItem = is.getSelectedItem();

--- a/engine/src/main/java/org/destinationsol/game/screens/ChangeShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ChangeShipScreen.java
@@ -58,7 +58,7 @@ public class ChangeShipScreen extends InventoryOperationsScreen {
         Hero hero = game.getHero();
         TalkScreen talkScreen = game.getScreens().talkScreen;
         if (talkScreen.isTargetFar(hero)) {
-            solApplication.getInputManager().setScreen(solApplication, game.getScreens().mainGameScreen);
+            solApplication.getInputManager().setScreen(solApplication, game.getScreens().oldMainGameScreen);
             return;
         }
         SolItem selItem = is.getSelectedItem();

--- a/engine/src/main/java/org/destinationsol/game/screens/ChooseMercenaryScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ChooseMercenaryScreen.java
@@ -60,19 +60,19 @@ public class ChooseMercenaryScreen extends InventoryOperationsScreen {
 
         if (giveControl.isJustOff() && selNull) {
             SolShip solship = ((MercItem) selItem).getSolShip();
-            inputMan.setScreen(solApplication, screens.mainGameScreen);
+            inputMan.setScreen(solApplication, screens.oldMainGameScreen);
             is.giveItemsScreen.setTarget(solship);
             is.setOperations(is.giveItemsScreen);
             inputMan.addScreen(solApplication, is);
         } else if (takeControl.isJustOff() && selNull) {
             SolShip solship = ((MercItem) selItem).getSolShip();
-            inputMan.setScreen(solApplication, screens.mainGameScreen);
+            inputMan.setScreen(solApplication, screens.oldMainGameScreen);
             is.takeItems.setTarget(solship);
             is.setOperations(is.takeItems);
             inputMan.addScreen(solApplication, is);
         } else if (equipControl.isJustOff() && selNull) {
             SolShip solship = ((MercItem) selItem).getSolShip();
-            inputMan.setScreen(solApplication, screens.mainGameScreen);
+            inputMan.setScreen(solApplication, screens.oldMainGameScreen);
             is.showInventory.setTarget(solship);
             is.setOperations(is.showInventory);
             inputMan.addScreen(solApplication, is);

--- a/engine/src/main/java/org/destinationsol/game/screens/ConsoleScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ConsoleScreen.java
@@ -162,7 +162,7 @@ public class ConsoleScreen implements SolUiScreen, ConsoleSubscriber {
     @Override
     public void updateCustom(SolApplication solApplication, SolInputManager.InputPointer[] inputPointers, boolean clickedOutside) {
         if (exitControl.isJustOff()) {
-            solApplication.getInputManager().setScreen(solApplication, solApplication.getGame().getScreens().mainGameScreen);
+            solApplication.getInputManager().setScreen(solApplication, solApplication.getGame().getScreens().oldMainGameScreen);
         }
         if (commandHistoryUpControl.isJustOff()) {
             if (commandHistoryIndex > 0) {

--- a/engine/src/main/java/org/destinationsol/game/screens/GameScreens.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/GameScreens.java
@@ -23,7 +23,10 @@ import org.destinationsol.ui.SolLayouts;
 import javax.inject.Inject;
 
 public class GameScreens {
-    public final MainGameScreen mainGameScreen;
+    private static final String NUI_MAIN_GAME_SCREEN_DESKTOP_URI = "engine:mainGameScreen_desktop";
+    private static final String NUI_MAIN_GAME_SCREEN_MOBILE_URI = "engine:mainGameScreen_mobile";
+    public final MainGameScreen oldMainGameScreen;
+    public final org.destinationsol.ui.nui.screens.MainGameScreen mainGameScreen;
     public final MapScreen mapScreen;
     public final MenuScreen menuScreen;
     public final InventoryScreen inventoryScreen;
@@ -35,7 +38,13 @@ public class GameScreens {
     public GameScreens(SolApplication cmp, Context context) {
         SolLayouts layouts = cmp.getLayouts();
         RightPaneLayout rightPaneLayout = layouts.rightPaneLayout;
-        mainGameScreen = new MainGameScreen(rightPaneLayout, context);
+        oldMainGameScreen = new MainGameScreen(rightPaneLayout, context);
+        boolean isMobile = cmp.isMobile();
+        if (!isMobile) {
+            mainGameScreen = (org.destinationsol.ui.nui.screens.MainGameScreen) cmp.getNuiManager().createScreen(NUI_MAIN_GAME_SCREEN_DESKTOP_URI);
+        } else {
+            mainGameScreen = (org.destinationsol.ui.nui.screens.MainGameScreen) cmp.getNuiManager().createScreen(NUI_MAIN_GAME_SCREEN_MOBILE_URI);
+        }
         mapScreen = new MapScreen(rightPaneLayout, cmp.isMobile(), cmp.getOptions());
         menuScreen = new MenuScreen(layouts.menuLayout, cmp.getOptions());
         inventoryScreen = new InventoryScreen(cmp.getOptions());
@@ -46,7 +55,7 @@ public class GameScreens {
 
     // This was added for PlayerCreatorTest.java (used in PlayerCreator)
     // so that it can successfully mock the returned result.
-    public MainGameScreen getMainGameScreen() {
-        return mainGameScreen;
+    public MainGameScreen getOldMainGameScreen() {
+        return oldMainGameScreen;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/screens/HireShipsScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/HireShipsScreen.java
@@ -52,7 +52,7 @@ public class HireShipsScreen extends InventoryOperationsScreen {
         Hero hero = game.getHero();
         TalkScreen talkScreen = game.getScreens().talkScreen;
         if (talkScreen.isTargetFar(hero)) {
-            solApplication.getInputManager().setScreen(solApplication, game.getScreens().mainGameScreen);
+            solApplication.getInputManager().setScreen(solApplication, game.getScreens().oldMainGameScreen);
             return;
         }
         SolItem selItem = is.getSelectedItem();

--- a/engine/src/main/java/org/destinationsol/game/screens/InventoryScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/InventoryScreen.java
@@ -157,11 +157,11 @@ public class InventoryScreen extends SolUiBaseScreen {
                 GameScreens screens = game.getScreens();
                 InventoryScreen is = screens.inventoryScreen;
                 
-                inputMan.setScreen(solApplication, screens.mainGameScreen);
+                inputMan.setScreen(solApplication, screens.oldMainGameScreen);
                 is.setOperations(is.chooseMercenaryScreen);
                 inputMan.addScreen(solApplication, is);
             }
-            solApplication.getInputManager().setScreen(solApplication, solApplication.getGame().getScreens().mainGameScreen);
+            solApplication.getInputManager().setScreen(solApplication, solApplication.getGame().getScreens().oldMainGameScreen);
             return;
         }
         if (previousControl.isJustOff()) {

--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -15,92 +15,44 @@
  */
 package org.destinationsol.game.screens;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.g2d.TextureAtlas;
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.math.Vector2;
-import org.destinationsol.Const;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
-import org.destinationsol.assets.Assets;
-import org.destinationsol.common.SolColor;
-import org.destinationsol.common.SolMath;
 import org.destinationsol.game.DebugOptions;
-import org.destinationsol.game.FactionManager;
-import org.destinationsol.game.HardnessCalc;
-import org.destinationsol.game.Hero;
-import org.destinationsol.game.SolCam;
 import org.destinationsol.game.SolGame;
-import org.destinationsol.game.SolObject;
 import org.destinationsol.game.context.Context;
-import org.destinationsol.game.item.Gun;
-import org.destinationsol.game.item.ItemManager;
-import org.destinationsol.game.item.Shield;
-import org.destinationsol.game.item.SolItem;
-import org.destinationsol.game.planet.Planet;
-import org.destinationsol.game.ship.ShipAbility;
-import org.destinationsol.game.ship.SolShip;
-import org.destinationsol.ui.DisplayDimensions;
-import org.destinationsol.ui.FontSize;
 import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.SolUiBaseScreen;
 import org.destinationsol.ui.SolUiControl;
 import org.destinationsol.ui.SolUiScreen;
 import org.destinationsol.ui.UiDrawer;
+import org.destinationsol.ui.nui.NUIManager;
+import org.destinationsol.ui.nui.NUIScreenLayer;
 import org.destinationsol.ui.nui.screens.ConsoleScreen;
 import org.destinationsol.ui.nui.screens.UIShipControlsScreen;
-import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.nui.asset.UIElement;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated This class only exists for compatibility purposes whilst the rest of the code is
+ * transitions to the new NUI-based MainGameScreen. Almost all functionality is now implemented by the new screen.
+ * @see org.destinationsol.ui.nui.screens.MainGameScreen the new NUI-based MainGameScreen
+ */
+@Deprecated
 public class MainGameScreen extends SolUiBaseScreen {
-    // TODO: Rename!
-    private static final float ICON_SZ = .03f;
-    private static final float BAR_SZ = ICON_SZ * 5;
-    private static final int MAX_ICON_COUNT = 3;
     static final float CELL_SZ = .17f;
-    private static final float H_PAD = .005f;
-    private static final float V_PAD = H_PAD;
     static final float HELPER_ROW_1 = 1 - 3f * CELL_SZ;
-    private static final float HELPER_ROW_2 = HELPER_ROW_1 - .5f * CELL_SZ;
-    private static final float HELPER_ROW_3 = HELPER_ROW_2 - .5f * CELL_SZ;
 
     private final ShipUiControl shipControl;
-    private final SolUiControl freeCamControl;
     private final SolUiControl pauseControl;
     private final CameraKeyboardControl cameraControl;
-
-    private final ZoneNameAnnouncer zoneNameAnnouncer;
-    private final BorderDrawer borderDrawer;
-
-    private final TextureAtlas.AtlasRegion lifeTexture;
-    private final TextureAtlas.AtlasRegion infinityTexture;
-    private final TextureAtlas.AtlasRegion waitTexture;
-    private final TextureAtlas.AtlasRegion compassTexture;
-
-    private final Color myCompassTint;
-    private final TextPlace myLifeTp;
-    private final TextPlace myRepairsExcessTp;
-    private final TextPlace myShieldLifeTp;
-    private final TextPlace myG1AmmoTp;
-    private final TextPlace myG1AmmoExcessTp;
-    private final TextPlace myG2AmmoTp;
-    private final TextPlace myG2AmmoExcessTp;
-    private final TextPlace myChargesExcessTp;
-    private final TextPlace myMoneyExcessTp;
     private final SolApplication solApplication;
-    private final Context context;
 
     private List<SolUiScreen> gameOverlayScreens = new ArrayList<>();
     private List<WarnDrawer> warnDrawers = new ArrayList<>();
 
     MainGameScreen(RightPaneLayout rightPaneLayout, Context context) {
-        DisplayDimensions displayDimensions = SolApplication.displayDimensions;
-
-        this.context = context;
         solApplication = context.get(SolApplication.class);
         GameOptions gameOptions = solApplication.getOptions();
 
@@ -122,42 +74,9 @@ public class MainGameScreen extends SolUiBaseScreen {
                 break;
         }
 
-        boolean mobile = solApplication.isMobile();
-        float lastCol = displayDimensions.getRatio() - MainGameScreen.CELL_SZ;
-        // No button, since on mobile, it should be ideally controlled straightly by dragging.
-        freeCamControl = new SolUiControl(null, false, gameOptions.getKeyFreeCameraMovement());
-        controls.add(freeCamControl);
         pauseControl = new SolUiControl(null, true, gameOptions.getKeyPause());
         controls.add(pauseControl);
         cameraControl = new CameraKeyboardControl(gameOptions, controls);
-
-        // possible warning messages in order of importance, so earlier one will be drawn on the center
-        warnDrawers.add(new SunWarnDrawer());
-        warnDrawers.add(new DmgWarnDrawer());
-        warnDrawers.add(new CollisionWarnDrawer());
-        warnDrawers.add(new NoShieldWarn());
-        warnDrawers.add(new NoArmorWarn());
-        warnDrawers.add(new EnemyWarn());
-
-        zoneNameAnnouncer = new ZoneNameAnnouncer();
-        borderDrawer = new BorderDrawer();
-
-        lifeTexture = Assets.getAtlasRegion("engine:iconLife");
-        infinityTexture = Assets.getAtlasRegion("engine:iconInfinity");
-        waitTexture = Assets.getAtlasRegion("engine:iconWait");
-
-        compassTexture = Assets.getAtlasRegion("engine:uiCompass");
-        myCompassTint = SolColor.col(1, 0);
-
-        myLifeTp = new TextPlace(SolColor.W50);
-        myRepairsExcessTp = new TextPlace(SolColor.WHITE);
-        myShieldLifeTp = new TextPlace(SolColor.W50);
-        myG1AmmoTp = new TextPlace(SolColor.W50);
-        myG1AmmoExcessTp = new TextPlace(SolColor.WHITE);
-        myG2AmmoTp = new TextPlace(SolColor.W50);
-        myG2AmmoExcessTp = new TextPlace(SolColor.WHITE);
-        myChargesExcessTp = new TextPlace(SolColor.WHITE);
-        myMoneyExcessTp = new TextPlace(SolColor.WHITE);
     }
 
     @Override
@@ -180,34 +99,6 @@ public class MainGameScreen extends SolUiBaseScreen {
         return new Rectangle(x + gap, y + gap, CELL_SZ - gap * 2, cellH - gap * 2);
     }
 
-    private void maybeDrawHeight(UiDrawer drawer) {
-        SolGame game = solApplication.getGame();
-        Planet np = game.getPlanetManager().getNearestPlanet();
-        SolCam cam = context.get(SolCam.class);
-        Vector2 camPos = cam.getPosition();
-        if (np != null && np.getPosition().dst(camPos) < np.getFullHeight()) {
-            drawHeight(drawer, np, camPos, cam.getAngle());
-        }
-    }
-
-    private void drawHeight(UiDrawer drawer, Planet np, Vector2 camPos, float camAngle) {
-        float toPlanet = camPos.dst(np.getPosition());
-        toPlanet -= np.getGroundHeight();
-        if (Const.ATM_HEIGHT < toPlanet) {
-            return;
-        }
-        float perc = toPlanet / Const.ATM_HEIGHT;
-        float sz = .08f;
-        float maxY = 1 - sz / 2;
-        float y = 1 - perc;
-        myCompassTint.a = SolMath.clamp(1.5f * y);
-        if (maxY < y) {
-            y = maxY;
-        }
-        float angle = np.getAngle() - camAngle;
-        drawer.draw(compassTexture, sz, sz, sz / 2, sz / 2, sz / 2, y, angle, myCompassTint);
-    }
-
     @Override
     public void updateCustom(SolApplication solApplication, SolInputManager.InputPointer[] inputPointers, boolean clickedOutside) {
         if (DebugOptions.PRINT_BALANCE) {
@@ -216,19 +107,18 @@ public class MainGameScreen extends SolUiBaseScreen {
         }
         SolGame game = solApplication.getGame();
         SolInputManager inputMan = solApplication.getInputManager();
+        NUIManager nuiManager = solApplication.getNuiManager();
         GameScreens screens = game.getScreens();
-        Hero hero = game.getHero();
 
         for (WarnDrawer warnDrawer : warnDrawers) {
             warnDrawer.update(game);
         }
 
-        zoneNameAnnouncer.update(game, context);
-
-        boolean controlsEnabled = inputMan.getTopScreen() == this;
+        NUIScreenLayer topScreen = nuiManager.getTopScreen();
+        boolean controlsEnabled = inputMan.getTopScreen() == this &&
+                (topScreen instanceof org.destinationsol.ui.nui.screens.MainGameScreen ||
+                        inputMan.getTopScreen() instanceof UIShipControlsScreen);
         shipControl.update(solApplication, controlsEnabled);
-
-        SolCam.DIRECT_CAM_CONTROL = freeCamControl.isOn();
 
         if (solApplication.getNuiManager().hasScreenOfType(ConsoleScreen.class)) {
             controls.forEach(x -> x.setEnabled(false));
@@ -246,136 +136,8 @@ public class MainGameScreen extends SolUiBaseScreen {
         }
     }
 
-    private boolean drawGunStat(UiDrawer uiDrawer, Hero hero, boolean secondary, float col0, float col1,
-                                float col2, float y) {
-        Gun g = hero.getHull().getGun(secondary);
-        if (g == null) {
-            return false;
-        }
-        TextureAtlas.AtlasRegion tex = g.config.icon;
-
-        uiDrawer.draw(tex, ICON_SZ, ICON_SZ, 0, 0, col0, y, 0, SolColor.WHITE);
-        float curr;
-        float max;
-        if (g.reloadAwait > 0) {
-            max = g.config.reloadTime;
-            curr = max - g.reloadAwait;
-        } else {
-            curr = g.ammo;
-            max = g.config.clipConf.size;
-        }
-        TextPlace ammoTp = g.reloadAwait > 0 ? null : secondary ? myG2AmmoTp : myG1AmmoTp;
-        drawBar(uiDrawer, col1, y, curr, max, ammoTp);
-        if (g.reloadAwait > 0) {
-            drawWait(uiDrawer, col1, y);
-        }
-        if (!g.config.clipConf.infinite) {
-            int clipCount = hero.getItemContainer().count(g.config.clipConf.example);
-            drawIcons(uiDrawer, col2, y, clipCount, g.config.clipConf.icon, secondary ? myG2AmmoExcessTp : myG1AmmoExcessTp);
-        } else {
-            uiDrawer.draw(infinityTexture, ICON_SZ, ICON_SZ, 0, 0, col2, y, 0, SolColor.WHITE);
-        }
-        return true;
-    }
-
-    private void drawWait(UiDrawer uiDrawer, float x, float y) {
-        uiDrawer.draw(waitTexture, ICON_SZ, ICON_SZ, ICON_SZ / 2, ICON_SZ / 2, x + BAR_SZ / 2, y + ICON_SZ / 2, 0, SolColor.WHITE);
-    }
-
-    private void drawBar(UiDrawer uiDrawer, float x, float y, float curr, float max, TextPlace tp) {
-        float perc = curr / max;
-        uiDrawer.draw(uiDrawer.whiteTexture, BAR_SZ, ICON_SZ, 0, 0, x, y, 0, SolColor.UI_DARK);
-        uiDrawer.draw(uiDrawer.whiteTexture, BAR_SZ * perc, ICON_SZ, 0, 0, x, y, 0, SolColor.UI_LIGHT);
-        if (tp != null && max > 1 && curr > 0) {
-            tp.text = (int) curr + "/" + (int) max;
-            tp.position.set(x + BAR_SZ / 2, y + ICON_SZ / 2);
-        }
-    }
-
-    private void drawIcons(UiDrawer uiDrawer, float x, float y, int count, TextureAtlas.AtlasRegion tex,
-                           TextPlace textPlace) {
-        int excess = count - MAX_ICON_COUNT;
-        int iconCount = excess > 0 ? MAX_ICON_COUNT : count;
-        for (int i = 0; i < iconCount; i++) {
-            uiDrawer.draw(tex, ICON_SZ, ICON_SZ, 0, 0, x, y, 0, SolColor.WHITE);
-            x += ICON_SZ + H_PAD;
-        }
-        if (excess > 0) {
-            updateTextPlace(x, y, "+" + excess, textPlace);
-        }
-    }
-
-    private void updateTextPlace(float x, float y, String text, TextPlace textPlace) {
-        textPlace.text = text;
-        textPlace.position.set(x + ICON_SZ / 2, y + ICON_SZ / 2);
-    }
-
     @Override
     public void drawImages(UiDrawer uiDrawer, SolApplication solApplication) {
-        myLifeTp.text = null;
-        myRepairsExcessTp.text = null;
-        myShieldLifeTp.text = null;
-        myG1AmmoTp.text = null;
-        myG1AmmoExcessTp.text = null;
-        myG2AmmoTp.text = null;
-        myG2AmmoExcessTp.text = null;
-        myChargesExcessTp.text = null;
-        myMoneyExcessTp.text = null;
-
-        maybeDrawHeight(uiDrawer);
-        borderDrawer.draw(uiDrawer, solApplication, context);
-
-        SolGame game = solApplication.getGame();
-        Hero hero = game.getHero();
-        if (hero.isNonTranscendent()) {
-            float row = BorderDrawer.PLANET_PROXIMITY_INDICATOR_SIZE + V_PAD;
-            float col0 = BorderDrawer.PLANET_PROXIMITY_INDICATOR_SIZE + H_PAD;
-            float col1 = col0 + ICON_SZ + H_PAD;
-            float col2 = col1 + BAR_SZ + H_PAD;
-
-            Shield shield = hero.getShield();
-            if (shield != null) {
-                uiDrawer.draw(shield.getIcon(game), ICON_SZ, ICON_SZ, 0, 0, col0, row, 0, SolColor.WHITE);
-                drawBar(uiDrawer, col1, row, MathUtils.floor(shield.getLife()), shield.getMaxLife(), myShieldLifeTp);
-                row += ICON_SZ + V_PAD;
-            }
-
-            uiDrawer.draw(lifeTexture, ICON_SZ, ICON_SZ, 0, 0, col0, row, 0, SolColor.WHITE);
-            drawBar(uiDrawer, col1, row, MathUtils.floor(hero.getLife()), hero.getHull().config.getMaxLife(), myLifeTp);
-            int repairKitCount = hero.getItemContainer().count(game.getItemMan().getRepairExample());
-            ItemManager itemManager = game.getItemMan();
-            drawIcons(uiDrawer, col2, row, repairKitCount, itemManager.repairIcon, myRepairsExcessTp);
-
-            row += ICON_SZ + V_PAD;
-            boolean consumed = drawGunStat(uiDrawer, hero, false, col0, col1, col2, row);
-            if (consumed) {
-                row += ICON_SZ + V_PAD;
-            }
-            consumed = drawGunStat(uiDrawer, hero, true, col0, col1, col2, row);
-            if (consumed) {
-                row += ICON_SZ + V_PAD;
-            }
-
-            ShipAbility ability = hero.getAbility();
-            SolItem abilityChargeEx = ability == null ? null : ability.getConfig().getChargeExample();
-            if (abilityChargeEx != null) {
-                int abilityChargeCount = hero.getItemContainer().count(abilityChargeEx);
-                TextureAtlas.AtlasRegion icon = abilityChargeEx.getIcon(game);
-                uiDrawer.draw(icon, ICON_SZ, ICON_SZ, 0, 0, col0, row, 0, SolColor.WHITE);
-                float chargePercentage = 1 - SolMath.clamp(hero.getAbilityAwait() / ability.getConfig().getRechargeTime());
-                drawBar(uiDrawer, col1, row, chargePercentage, 1, null);
-                if (chargePercentage < 1) {
-                    drawWait(uiDrawer, col1, row);
-                }
-                drawIcons(uiDrawer, col2, row, abilityChargeCount, icon, myChargesExcessTp);
-                row += ICON_SZ + V_PAD;
-            }
-            uiDrawer.draw(game.getItemMan().moneyIcon, ICON_SZ, ICON_SZ, 0, 0, col0, row, 0, SolColor.WHITE);
-            myMoneyExcessTp.text = Integer.toString(Math.round(hero.getMoney()));
-            myMoneyExcessTp.position.set(col1, row + ICON_SZ / 2);
-            //updateTextPlace(col1, row, (int) hero.getMoney() + "", myMoneyExcessTp);
-        }
-
         int drawPlace = 0;
         for (WarnDrawer wd : warnDrawers) {
             if (wd.drawPercentage > 0) {
@@ -390,24 +152,12 @@ public class MainGameScreen extends SolUiBaseScreen {
 
     @Override
     public void drawText(UiDrawer uiDrawer, SolApplication solApplication) {
-        myLifeTp.draw(uiDrawer);
-        myRepairsExcessTp.draw(uiDrawer);
-        myShieldLifeTp.draw(uiDrawer);
-        myG1AmmoTp.draw(uiDrawer);
-        myG1AmmoExcessTp.draw(uiDrawer);
-        myG2AmmoTp.draw(uiDrawer);
-        myG2AmmoExcessTp.draw(uiDrawer);
-        myChargesExcessTp.draw(uiDrawer);
-        myMoneyExcessTp.draw(uiDrawer, UiDrawer.TextAlignment.LEFT);
-
         int drawPlace = 0;
         for (WarnDrawer warnDrawer : warnDrawers) {
             if (warnDrawer.drawPercentage > 0) {
                 warnDrawer.drawText(uiDrawer, drawPlace++);
             }
         }
-
-        zoneNameAnnouncer.drawText(uiDrawer);
 
         for (SolUiScreen screen : gameOverlayScreens) {
             screen.drawText(uiDrawer, solApplication);
@@ -443,117 +193,71 @@ public class MainGameScreen extends SolUiBaseScreen {
         return cameraControl.isRight();
     }
 
+    /**
+     * @deprecated Use NUI screens instead. All NUI screens are overlays.
+     * @see NUIScreenLayer
+     * @see NUIManager#createScreen(String)
+     * @see NUIManager#pushScreen(NUIScreenLayer)
+     */
+    @Deprecated
     public void addOverlayScreen(SolUiScreen screen) {
         gameOverlayScreens.add(screen);
         screen.onAdd(solApplication);
         controls.addAll(screen.getControls());
     }
 
+    /**
+     * @deprecated Use NUI screens instead. All NUI screens are overlays.
+     * @see NUIManager#removeScreen(NUIScreenLayer)
+     */
+    @Deprecated
     public void removeOverlayScreen(SolUiScreen screen) {
         gameOverlayScreens.remove(screen);
         controls.removeAll(screen.getControls());
     }
 
+    /**
+     * @deprecated Use NUI screens instead. All NUI screens are overlays.
+     * @see NUIManager#hasScreen(NUIScreenLayer)
+     */
+    @Deprecated
     public boolean hasOverlay(SolUiScreen screen) {
         return gameOverlayScreens.contains(screen);
     }
 
+    /**
+     * @deprecated Use the new MainGameScreen and UIWarnDrawer instead.
+     * @see org.destinationsol.ui.nui.widgets.UIWarnDrawer
+     * @see org.destinationsol.ui.nui.screens.MainGameScreen#addWarnDrawer(String, org.terasology.nui.Color, String, org.terasology.nui.databinding.Binding)
+     * @see org.destinationsol.ui.nui.screens.MainGameScreen#addWarnDrawer(org.destinationsol.ui.nui.widgets.UIWarnDrawer)
+     */
+    @Deprecated
     public void addWarnDrawer(WarnDrawer drawer) {
         if (!warnDrawers.contains(drawer)) {
             warnDrawers.add(drawer);
         }
     }
 
+    /**
+     * @deprecated Use the new MainGameScreen and UIWarnDrawer instead.
+     * @see org.destinationsol.ui.nui.widgets.UIWarnDrawer
+     * @see org.destinationsol.ui.nui.screens.MainGameScreen#removeWarnDrawer(String)
+     * @see org.destinationsol.ui.nui.screens.MainGameScreen#removeWarnDrawer(org.destinationsol.ui.nui.widgets.UIWarnDrawer)
+     */
+    @Deprecated
     public void removeWarnDrawer(WarnDrawer drawer) {
         warnDrawers.remove(drawer);
     }
 
+    /**
+     * @deprecated Use the new MainGameScreen and UIWarnDrawer instead.
+     * @see org.destinationsol.ui.nui.widgets.UIWarnDrawer
+     * @see org.destinationsol.ui.nui.screens.MainGameScreen#hasWarnDrawer(String)
+     * @see org.destinationsol.ui.nui.screens.MainGameScreen#hasWarnDrawer(org.destinationsol.ui.nui.widgets.UIWarnDrawer)
+     */
+    @Deprecated
     public boolean hasWarnDrawer(WarnDrawer drawer) {
         return warnDrawers.contains(drawer);
-    }
-
-    public static class TextPlace {
-        public final Color color;
-        public String text;
-        public Vector2 position = new Vector2();
-
-        TextPlace(Color col) {
-            color = new Color(col);
-        }
-
-        public void draw(UiDrawer uiDrawer) {
-            uiDrawer.drawString(text, position.x, position.y, FontSize.HUD, true, color);
-        }
-
-        public void draw(UiDrawer uiDrawer, UiDrawer.TextAlignment align) {
-            uiDrawer.drawString(text, position.x, position.y, FontSize.HUD, align, true, color);
-        }
-    }
-
-    private static class NoShieldWarn extends WarnDrawer {
-        NoShieldWarn() {
-            super("No Shield");
-        }
-
-        protected boolean shouldWarn(SolGame game) {
-            Hero hero = game.getHero();
-            return hero.isNonTranscendent() && hero.getShield() == null;
-        }
-    }
-
-    private static class NoArmorWarn extends WarnDrawer {
-        NoArmorWarn() {
-            super("No Armor");
-        }
-
-        protected boolean shouldWarn(SolGame game) {
-            Hero hero = game.getHero();
-            return hero.isNonTranscendent() && hero.getArmor() == null;
-        }
-    }
-
-    private static class EnemyWarn extends WarnDrawer {
-        EnemyWarn() {
-            super("Dangerous\nEnemy");
-        }
-
-        protected boolean shouldWarn(SolGame game) {
-            Hero hero = game.getHero();
-            if (hero.isTranscendent()) {
-                return false;
-            }
-
-            float heroCap = HardnessCalc.getShipDmgCap(hero.getShip());
-            List<SolObject> objs = game.getObjectManager().getObjects();
-            FactionManager fm = game.getFactionMan();
-            SolCam cam = game.getContext().get(SolCam.class);
-            float viewDist = cam.getViewDistance();
-            float dps = 0;
-
-            for (SolObject o : objs) {
-                if (!(o instanceof SolShip)) {
-                    continue;
-                }
-
-                SolShip ship = (SolShip) o;
-
-                if (viewDist < ship.getPosition().dst(hero.getPosition())) {
-                    continue;
-                }
-
-                if (!fm.areEnemies(hero.getShip(), ship)) {
-                    continue;
-                }
-
-                dps += HardnessCalc.getShipDps(ship);
-
-                if (HardnessCalc.isDangerous(heroCap, dps)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }
 

--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -117,7 +117,7 @@ public class MainGameScreen extends SolUiBaseScreen {
         NUIScreenLayer topScreen = nuiManager.getTopScreen();
         boolean controlsEnabled = inputMan.getTopScreen() == this &&
                 (topScreen instanceof org.destinationsol.ui.nui.screens.MainGameScreen ||
-                        inputMan.getTopScreen() instanceof UIShipControlsScreen);
+                        topScreen instanceof UIShipControlsScreen);
         shipControl.update(solApplication, controlsEnabled);
 
         if (solApplication.getNuiManager().hasScreenOfType(ConsoleScreen.class)) {

--- a/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MapScreen.java
@@ -89,7 +89,7 @@ public class MapScreen extends SolUiBaseScreen {
             mapDrawer.getMapDrawPositionAdditive().set(0, 0);
             isPickingWaypointSpot = false;
             addWaypointControl.setDisplayName(NEW_WAYPOINT_TEXT);
-            im.setScreen(solApplication, game.getScreens().mainGameScreen);
+            im.setScreen(solApplication, game.getScreens().oldMainGameScreen);
         }
 
         boolean zoomIn = zoomInControl.isJustOff();
@@ -100,7 +100,7 @@ public class MapScreen extends SolUiBaseScreen {
         float mapZoom = mapDrawer.getZoom();
         zoomInControl.setEnabled(mapZoom != MapDrawer.MIN_ZOOM);
         zoomOutControl.setEnabled(mapZoom != MapDrawer.MAX_ZOOM);
-        ShipUiControl shipControl = game.getScreens().mainGameScreen.getShipControl();
+        ShipUiControl shipControl = game.getScreens().oldMainGameScreen.getShipControl();
         if (shipControl instanceof ShipMouseControl) {
             shipControl.update(solApplication, true);
         }

--- a/engine/src/main/java/org/destinationsol/game/screens/MenuScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MenuScreen.java
@@ -71,7 +71,7 @@ public class MenuScreen extends SolUiBaseScreen {
         }
         if (respawnControl.isJustOff()) {
             game.respawn();
-            im.setScreen(solApplication, game.getScreens().mainGameScreen);
+            im.setScreen(solApplication, game.getScreens().oldMainGameScreen);
             game.setPaused(false);
         }
         if (exitControl.isJustOff()) {
@@ -79,7 +79,7 @@ public class MenuScreen extends SolUiBaseScreen {
         }
         if (closeControl.isJustOff()) {
             game.setPaused(false);
-            im.setScreen(solApplication, game.getScreens().mainGameScreen);
+            im.setScreen(solApplication, game.getScreens().oldMainGameScreen);
         }
         doNotSellEquippedControl.setDisplayName("Can sell used items: " +
                                                   (options.canSellEquippedItems ? "Yes" : "No"));

--- a/engine/src/main/java/org/destinationsol/game/screens/SellItems.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/SellItems.java
@@ -66,7 +66,7 @@ public class SellItems extends InventoryOperationsScreen {
         SolShip target = talkScreen.getTarget();
         Hero hero = game.getHero();
         if (talkScreen.isTargetFar(hero)) {
-            solApplication.getInputManager().setScreen(solApplication, game.getScreens().mainGameScreen);
+            solApplication.getInputManager().setScreen(solApplication, game.getScreens().oldMainGameScreen);
             return;
         }
         SolItem selItem = inventoryScreen.getSelectedItem();

--- a/engine/src/main/java/org/destinationsol/game/screens/TalkScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/TalkScreen.java
@@ -75,7 +75,7 @@ public class TalkScreen extends SolUiBaseScreen {
         Hero hero = game.getHero();
         SolInputManager inputManager = solApplication.getInputManager();
         if (closeControl.isJustOff() || isTargetFar(hero)) {
-            inputManager.setScreen(solApplication, game.getScreens().mainGameScreen);
+            inputManager.setScreen(solApplication, game.getScreens().oldMainGameScreen);
             return;
         }
 
@@ -90,7 +90,7 @@ public class TalkScreen extends SolUiBaseScreen {
         boolean hire = hireControl.isJustOff();
         if (sell || buy || sellShips || hire) {
             inventoryScreen.setOperations(sell ? inventoryScreen.sellItems : buy ? inventoryScreen.buyItemsScreen : sellShips ? inventoryScreen.changeShipScreen : inventoryScreen.hireShipsScreen);
-            inputManager.setScreen(solApplication, game.getScreens().mainGameScreen);
+            inputManager.setScreen(solApplication, game.getScreens().oldMainGameScreen);
             inputManager.addScreen(solApplication, inventoryScreen);
         }
     }

--- a/engine/src/main/java/org/destinationsol/game/screens/ZoneNameAnnouncer.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/ZoneNameAnnouncer.java
@@ -37,7 +37,7 @@ public class ZoneNameAnnouncer {
     private String zone;
     private String text;
 
-    ZoneNameAnnouncer() {
+    public ZoneNameAnnouncer() {
         displayDimensions = SolApplication.displayDimensions;
     }
 

--- a/engine/src/main/java/org/destinationsol/game/ship/EmWave.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/EmWave.java
@@ -93,7 +93,7 @@ public class EmWave implements ShipAbility {
         public static AbilityConfig load(JSONObject abNode, ItemManager itemManager, AbilityCommonConfig cc) {
             float rechargeTime = (float) abNode.getDouble("rechargeTime");
             float duration = (float) abNode.getDouble("duration");
-            SolItem chargeExample = itemManager.getExample("emWaveCharge");
+            SolItem chargeExample = itemManager.parseItem("core:emWaveCharge").examples.get(0);
             return new EmWaveConfig(rechargeTime, chargeExample, duration, cc);
         }
 

--- a/engine/src/main/java/org/destinationsol/game/ship/KnockBack.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/KnockBack.java
@@ -107,7 +107,7 @@ public class KnockBack implements ShipAbility {
         public static AbilityConfig load(JSONObject abNode, ItemManager itemManager, AbilityCommonConfig cc) {
             float rechargeTime = (float) abNode.getDouble("rechargeTime");
             float force = (float) abNode.getDouble("force");
-            SolItem chargeExample = itemManager.getExample("knockBackCharge");
+            SolItem chargeExample = itemManager.parseItem("core:knockBackCharge").examples.get(0);
             return new KnockBackConfig(rechargeTime, chargeExample, force, cc);
         }
 

--- a/engine/src/main/java/org/destinationsol/game/ship/SloMo.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SloMo.java
@@ -86,7 +86,7 @@ public class SloMo implements ShipAbility {
         public static AbilityConfig load(JSONObject abNode, ItemManager itemManager, AbilityCommonConfig cc) {
             float factor = (float) abNode.getDouble("factor");
             float rechargeTime = (float) abNode.getDouble("rechargeTime");
-            SolItem chargeExample = itemManager.getExample("sloMoCharge");
+            SolItem chargeExample = itemManager.parseItem("core:sloMoCharge").examples.get(0);
             return new SloMoConfig(factor, rechargeTime, chargeExample, cc);
         }
 

--- a/engine/src/main/java/org/destinationsol/game/ship/Teleport.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/Teleport.java
@@ -126,7 +126,7 @@ public class Teleport implements ShipAbility {
 
         public static AbilityConfig load(JSONObject abNode, ItemManager itemManager, AbilityCommonConfig cc) {
             float angle = (float) abNode.getDouble("angle");
-            SolItem chargeExample = itemManager.getExample("teleportCharge");
+            SolItem chargeExample = itemManager.parseItem("core:teleportCharge").examples.get(0);
             float rechargeTime = (float) abNode.getDouble("rechargeTime");
             return new TeleportConfig(angle, chargeExample, rechargeTime, cc);
         }

--- a/engine/src/main/java/org/destinationsol/game/ship/UnShield.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/UnShield.java
@@ -107,7 +107,7 @@ public class UnShield implements ShipAbility {
         public static AbilityConfig load(JSONObject abNode, ItemManager itemManager, AbilityCommonConfig cc) {
             float rechargeTime = (float) abNode.getDouble("rechargeTime");
             float amount = (float) abNode.getDouble("amount");
-            SolItem chargeExample = itemManager.getExample("unShieldCharge");
+            SolItem chargeExample = itemManager.parseItem("core:unShieldCharge").examples.get(0);
             return new UnShieldConfig(rechargeTime, chargeExample, amount, cc);
         }
 

--- a/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
@@ -301,7 +301,7 @@ public class SolInputManager {
             if (game == null || mouseOnUi || nuiManager.isMouseOnUi()) {
                 currCursor = uiCursor;
             } else {
-                currCursor = game.getScreens().mainGameScreen.getShipControl().getInGameTex();
+                currCursor = game.getScreens().oldMainGameScreen.getShipControl().getInGameTex();
                 if (currCursor == null) {
                     currCursor = uiCursor;
                 }

--- a/engine/src/main/java/org/destinationsol/ui/TutorialManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/TutorialManager.java
@@ -59,7 +59,7 @@ public class TutorialManager implements UpdateAwareSystem {
 
     public void start() {
         boolean mobile = game.get().getSolApplication().isMobile();
-        MainGameScreen main = screens.mainGameScreen;
+        MainGameScreen main = screens.oldMainGameScreen;
         boolean mouseCtrl = main.getShipControl() instanceof ShipMixedControl;
         org.destinationsol.ui.nui.screens.MainGameScreen nuiMain = game.get().getMainGameScreen();
         SolUiControl shootCtrl = null;

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/MainGameScreen.java
@@ -15,34 +15,87 @@
  */
 package org.destinationsol.ui.nui.screens;
 
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.physics.box2d.Fixture;
+import com.badlogic.gdx.physics.box2d.RayCastCallback;
+import org.destinationsol.Const;
 import org.destinationsol.GameOptions;
 import org.destinationsol.SolApplication;
+import org.destinationsol.assets.Assets;
+import org.destinationsol.common.SolColor;
+import org.destinationsol.common.SolMath;
 import org.destinationsol.game.FactionManager;
+import org.destinationsol.game.HardnessCalc;
 import org.destinationsol.game.Hero;
+import org.destinationsol.game.SolCam;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.SolObject;
+import org.destinationsol.game.item.Gun;
+import org.destinationsol.game.item.Shield;
+import org.destinationsol.game.item.SolItem;
+import org.destinationsol.game.planet.Planet;
+import org.destinationsol.game.screens.BorderDrawer;
 import org.destinationsol.game.screens.GameScreens;
 import org.destinationsol.game.screens.TalkScreen;
+import org.destinationsol.game.screens.ZoneNameAnnouncer;
 import org.destinationsol.game.ship.SolShip;
 import org.destinationsol.ui.SolInputManager;
+import org.destinationsol.ui.UiDrawer;
+import org.destinationsol.ui.nui.NUIManager;
 import org.destinationsol.ui.nui.NUIScreenLayer;
+import org.destinationsol.ui.nui.widgets.EmptyIfInvisibleContainer;
+import org.destinationsol.ui.nui.widgets.UILabelledIcon;
 import org.destinationsol.ui.nui.widgets.UIWarnButton;
+import org.destinationsol.ui.nui.widgets.UIWarnDrawer;
+import org.destinationsol.world.generators.SolarSystemGenerator;
 import org.terasology.input.ButtonState;
 import org.terasology.input.Keyboard;
 import org.terasology.nui.AbstractWidget;
+import org.terasology.nui.Canvas;
+import org.terasology.nui.Color;
+import org.terasology.nui.HorizontalAlign;
+import org.terasology.nui.UITextureRegion;
 import org.terasology.nui.UIWidget;
+import org.terasology.nui.VerticalAlign;
 import org.terasology.nui.backends.libgdx.GDXInputUtil;
+import org.terasology.nui.databinding.Binding;
+import org.terasology.nui.databinding.DefaultBinding;
+import org.terasology.nui.databinding.ReadOnlyBinding;
 import org.terasology.nui.events.NUIKeyEvent;
+import org.terasology.nui.events.NUIMouseButtonEvent;
+import org.terasology.nui.layouts.ColumnLayout;
+import org.terasology.nui.layouts.FlowLayout;
+import org.terasology.nui.layouts.relative.HorizontalHint;
+import org.terasology.nui.layouts.relative.RelativeLayout;
+import org.terasology.nui.layouts.relative.RelativeLayoutHint;
+import org.terasology.nui.layouts.relative.VerticalHint;
+import org.terasology.nui.widgets.UIIconBar;
+import org.terasology.nui.widgets.UIImage;
+import org.terasology.nui.widgets.UILabel;
+import org.terasology.nui.widgets.UILoadBar;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * The main HUD screen displayed when in-game. This screen is responsible for the menu buttons shown
  * on the right-hand side of the UI. Through it, the menu, map, current ship inventory, communications UI
  * and mercenaries UI can be accessed.
+ * It also displays status bars for weapons, ability cool-downs, health/shield percentages and HUD warnings.
  */
 public class MainGameScreen extends NUIScreenLayer {
+    private static final String WHITE_TEXTURE_URN = "engine:uiWhiteTex";
+    private static final String COMPASS_TEXTURE_URN = "engine:uiCompass";
+    private static final String LIFE_TEXTURE_URN = "engine:iconLife";
+    private static final String REPAIR_ITEM_TEXTURE_URN = "engine:iconRepairItem";
+    private static final String WAIT_TEXTURE_URN = "engine:iconWait";
+    private static final String INFINITY_TEXTURE_URN = "engine:iconInfinity";
+    private static final String CONSOLE_SCREEN_URN = "engine:console";
+    private final CollisionWarnDrawerRayCastCallback warnCallback = new CollisionWarnDrawerRayCastCallback();
+    private UITextureRegion whiteTexture;
+    private TextureRegion compassTexture;
     private SolShip talkTarget;
     private UIWarnButton menuButton;
     private UIWarnButton mapButton;
@@ -50,6 +103,16 @@ public class MainGameScreen extends NUIScreenLayer {
     private UIWarnButton talkButton;
     private UIWarnButton mercsButton;
     private ConsoleScreen consoleScreen;
+    private AbstractWidget shieldStats;
+    private AbstractWidget hullStats;
+    private AbstractWidget gun1Stats;
+    private AbstractWidget gun2Stats;
+    private AbstractWidget abilityStats;
+    private UILabelledIcon moneyIcon;
+    private FlowLayout warnDrawers;
+    private BorderDrawer borderDrawer;
+    private ZoneNameAnnouncer zoneNameAnnouncer;
+    private com.badlogic.gdx.graphics.Color compassTint;
 
     private final SolApplication solApplication;
 
@@ -60,7 +123,11 @@ public class MainGameScreen extends NUIScreenLayer {
 
     @Override
     public void initialise() {
-        consoleScreen = (ConsoleScreen) nuiManager.createScreen("engine:console");
+        whiteTexture = Assets.getDSTexture(WHITE_TEXTURE_URN).getUiTexture();
+        compassTexture = Assets.getAtlasRegion(COMPASS_TEXTURE_URN);
+        compassTint = SolColor.col(1, 0);
+
+        consoleScreen = (ConsoleScreen) nuiManager.createScreen(CONSOLE_SCREEN_URN);
 
         GameOptions gameOptions = solApplication.getOptions();
 
@@ -83,6 +150,276 @@ public class MainGameScreen extends NUIScreenLayer {
         mercsButton = find("mercsButton", UIWarnButton.class);
         mercsButton.setKey(GDXInputUtil.GDXToNuiKey(gameOptions.getKeyMercenaryInteraction()));
         mercsButton.subscribe(this::onMercsButtonClicked);
+
+        ColumnLayout statsBars = find("statsBars", ColumnLayout.class);
+
+        shieldStats = createStatsRow("shield", new ReadOnlyBinding<UITextureRegion>() {
+                    @Override
+                    public UITextureRegion get() {
+                        SolGame game = solApplication.getGame();
+                        Hero hero = game.getHero();
+                        Shield shield = hero.getShield();
+                        if (shield != null) {
+                            return Assets.getDSTexture(shield.getIcon(game).name).getUiTexture();
+                        } else {
+                            return null;
+                        }
+                    }
+                },
+                new ReadOnlyBinding<Float>() {
+                    @Override
+                    public Float get() {
+                        Hero hero = solApplication.getGame().getHero();
+                        Shield heroShield = hero.getShield();
+                        if (heroShield != null) {
+                            return heroShield.getLife() / heroShield.getMaxLife();
+                        } else {
+                            return 0.0f;
+                        }
+                    }
+                }, new ReadOnlyBinding<String>() {
+                    @Override
+                    public String get() {
+                        Hero hero = solApplication.getGame().getHero();
+                        Shield heroShield = hero.getShield();
+                        if (heroShield != null) {
+                            return (int) Math.floor(heroShield.getLife()) + "/" + (int) Math.floor(heroShield.getMaxLife());
+                        } else {
+                            return "";
+                        }
+                    }
+                }, new DefaultBinding<>(), null, new DefaultBinding<>(0.0f));
+        statsBars.addWidget(shieldStats);
+
+        hullStats = createStatsRow("health", new DefaultBinding<>(Assets.getDSTexture(LIFE_TEXTURE_URN).getUiTexture()),
+                new ReadOnlyBinding<Float>() {
+                    @Override
+                    public Float get() {
+                        Hero hero = solApplication.getGame().getHero();
+                        if (hero.isNonTranscendent()) {
+                            return hero.getLife() / hero.getHull().config.getMaxLife();
+                        } else {
+                            // The HUD is hidden when the hero is transcendent, so the value here doesn't matter.
+                            return 1.0f;
+                        }
+                    }
+                }, new ReadOnlyBinding<String>() {
+                    @Override
+                    public String get() {
+                        Hero hero = solApplication.getGame().getHero();
+                        if (hero.isNonTranscendent()) {
+                            return (int) Math.floor(Math.max(0, hero.getLife())) + "/" + hero.getHull().config.getMaxLife();
+                        } else {
+                            // The HUD is hidden when the hero is transcendent, so the value here doesn't matter.
+                            return "";
+                        }
+                    }
+                }, new DefaultBinding<>(), Assets.getDSTexture(REPAIR_ITEM_TEXTURE_URN).getUiTexture(), new ReadOnlyBinding<Float>() {
+                    @Override
+                    public Float get() {
+                        SolGame game = solApplication.getGame();
+                        Hero hero = game.getHero();
+                        return (float) hero.getItemContainer().count(game.getItemMan().getRepairExample());
+                    }
+                });
+        statsBars.addWidget(hullStats);
+
+        gun1Stats = createStatsRow("gun1", createGunIconBinding(false), createGunValueBinding(false),
+                createGunValueLabelBinding(false), createGunBarIconBinding(false),
+                null, createGunClipValueBinding(false));
+        statsBars.addWidget(gun1Stats);
+
+        gun2Stats = createStatsRow("gun2", createGunIconBinding(true), createGunValueBinding(true),
+                createGunValueLabelBinding(true), createGunBarIconBinding(true),
+                null, createGunClipValueBinding(true));
+        statsBars.addWidget(gun2Stats);
+
+        abilityStats = createStatsRow("ability", new ReadOnlyBinding<UITextureRegion>() {
+            @Override
+            public UITextureRegion get() {
+                Hero hero = solApplication.getGame().getHero();
+                SolItem example = hero.getAbility().getConfig().getChargeExample();
+                if (example != null) {
+                    return Assets.getDSTexture(example.getIcon(solApplication.getGame()).name).getUiTexture();
+                }
+                return null;
+            }
+        }, new ReadOnlyBinding<Float>() {
+            @Override
+            public Float get() {
+                Hero hero = solApplication.getGame().getHero();
+                if (hero.getAbilityAwait() > 0) {
+                    return 1.0f - hero.getAbilityAwait() / hero.getAbility().getConfig().getRechargeTime();
+                } else {
+                    return 1.0f;
+                }
+            }
+        }, new DefaultBinding<>(""), new ReadOnlyBinding<UITextureRegion>() {
+            @Override
+            public UITextureRegion get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                return hero.getAbilityAwait() > 0 ? Assets.getDSTexture(WAIT_TEXTURE_URN).getUiTexture() : null;
+            }
+        }, null, new ReadOnlyBinding<Float>() {
+            @Override
+            public Float get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                SolItem example = hero.getAbility().getConfig().getChargeExample();
+                if (example != null) {
+                    return (float) hero.getItemContainer().count(example);
+                }
+                return 0.0f;
+            }
+        });
+        statsBars.addWidget(abilityStats);
+
+        moneyIcon = new UILabelledIcon("moneyIcon");
+        moneyIcon.setSpacing(8);
+        moneyIcon.bindText(new ReadOnlyBinding<String>() {
+            @Override
+            public String get() {
+                Hero hero = solApplication.getGame().getHero();
+                return Integer.toString(Math.round(hero.getMoney()));
+            }
+        });
+        statsBars.addWidget(moneyIcon);
+
+        statsBars.bindVisible(new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                return solApplication.getGame().getHero().isNonTranscendent();
+            }
+        });
+
+        Color warnColour = new Color(1.0f, 0.5f, 0.0f, 0.5f);
+        Color dangerColour = new Color(1.0f, 0.0f, 0.0f, 0.5f);
+
+        warnDrawers = find("warnDrawers", FlowLayout.class);
+        addWarnDrawer("sunWarnDrawer", warnColour, "Sun Near", new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                if (hero.isTranscendent()) {
+                    return false;
+                }
+                Vector2 position = hero.getPosition();
+                float toCenter = game.getPlanetManager().getNearestSystem(position).getPosition().dst(position);
+                return toCenter < SolarSystemGenerator.SUN_RADIUS;
+            }
+        });
+        addWarnDrawer("damagedWarnDrawer", dangerColour, "Heavily Damaged", new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                Hero hero = solApplication.getGame().getHero();
+                if (hero.isTranscendent()) {
+                    return false;
+                }
+                float currentLife = hero.getLife();
+
+                // already dead
+                if (currentLife <= 0.0) {
+                    return false;
+                }
+
+                int maxLife = hero.getHull().config.getMaxLife();
+                return currentLife < maxLife * .3f;
+            }
+        });
+        addWarnDrawer("collisionWarnDrawer", warnColour, "Object Near", new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                if (hero.isTranscendent()) {
+                    return false;
+                }
+                Vector2 position = hero.getPosition();
+                Vector2 velocity = hero.getVelocity();
+                float acc = hero.getAcceleration();
+                float speed = velocity.len();
+                float velocityAngle = SolMath.angle(velocity);
+                if (acc <= 0 || speed < 2 * acc) {
+                    return false;
+                }
+                // time = velocity/acceleration;
+                // speed = acceleration*time*time/2 = velocity*velocity/acceleration/2;
+                float breakWay = speed * speed / acc / 2;
+                breakWay += 2 * speed;
+                Vector2 finalPos = SolMath.getVec(0, 0);
+                SolMath.fromAl(finalPos, velocityAngle, breakWay);
+                finalPos.add(position);
+                warnCallback.show = false;
+                game.getObjectManager().getWorld().rayCast(warnCallback, position, finalPos);
+                SolMath.free(finalPos);
+                return warnCallback.show;
+            }
+        });
+        addWarnDrawer("noShieldDrawer", warnColour, "No Shield", new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                Hero hero = solApplication.getGame().getHero();
+                return hero.isNonTranscendent() && hero.getShield() == null;
+            }
+        });
+        addWarnDrawer("noArmourDrawer", warnColour, "No Armor", new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                Hero hero = solApplication.getGame().getHero();
+                return hero.isNonTranscendent() && hero.getArmor() == null;
+            }
+        });
+        addWarnDrawer("enemyWarnDrawer", warnColour, "Dangerous Enemy", new ReadOnlyBinding<Boolean>() {
+            @Override
+            public Boolean get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                if (hero.isTranscendent()) {
+                    return false;
+                }
+
+                float heroCap = HardnessCalc.getShipDmgCap(hero.getShip());
+                List<SolObject> objs = game.getObjectManager().getObjects();
+                FactionManager fm = game.getFactionMan();
+                SolCam cam = game.getContext().get(SolCam.class);
+                float viewDist = cam.getViewDistance();
+                float dps = 0;
+
+                for (SolObject o : objs) {
+                    if (!(o instanceof SolShip)) {
+                        continue;
+                    }
+
+                    SolShip ship = (SolShip) o;
+
+                    if (viewDist < ship.getPosition().dst(hero.getPosition())) {
+                        continue;
+                    }
+
+                    if (!fm.areEnemies(hero.getShip(), ship)) {
+                        continue;
+                    }
+
+                    dps += HardnessCalc.getShipDps(ship);
+
+                    if (HardnessCalc.isDangerous(heroCap, dps)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        });
+
+        borderDrawer = new BorderDrawer();
+        zoneNameAnnouncer = new ZoneNameAnnouncer();
+    }
+
+    @Override
+    public void onAdded() {
+        moneyIcon.setIcon(Assets.getDSTexture(solApplication.getGame().getItemMan().moneyIcon.name).getUiTexture());
     }
 
     @Override
@@ -97,7 +434,7 @@ public class MainGameScreen extends NUIScreenLayer {
             ((AbstractWidget) contents).setVisible(false);
         }
 
-        if (solInputManager.getTopScreen() != gameScreens.mainGameScreen) {
+        if (solInputManager.getTopScreen() != gameScreens.oldMainGameScreen) {
             // User is in an original UI menu, so disable the escape key toggling the pause menu.
             menuButton.setKey(Keyboard.Key.NONE);
         } else {
@@ -156,6 +493,56 @@ public class MainGameScreen extends NUIScreenLayer {
         if (consoleScreen.isConsoleJustClosed()) {
             game.setPaused(false);
         }
+
+        shieldStats.setVisible(hero.getShield() != null);
+        gun1Stats.setVisible(hero.getHull().getGun(false) != null);
+        gun2Stats.setVisible(hero.getHull().getGun(true) != null);
+
+        Gun gun1 = hero.getHull().getGun(false);
+        if (gun1 != null) {
+            UITextureRegion gun1ClipIcon;
+            if (gun1.config.clipConf.infinite) {
+                gun1ClipIcon = Assets.getDSTexture(INFINITY_TEXTURE_URN).getUiTexture();
+            } else {
+                gun1ClipIcon = Assets.getDSTexture(gun1.config.clipConf.icon.name).getUiTexture();
+            }
+            // HACK: You can't bind to the icons of a UIIconBar, so we set them during an update instead.
+            gun1Stats.findAll(UIIconBar.class).iterator().next().setIcon(gun1ClipIcon);
+        }
+
+        Gun gun2 = hero.getHull().getGun(true);
+        if (gun2 != null) {
+            UITextureRegion gun2ClipIcon;
+            if (gun2.config.clipConf.infinite) {
+                gun2ClipIcon = Assets.getDSTexture(INFINITY_TEXTURE_URN).getUiTexture();
+            } else {
+                gun2ClipIcon = Assets.getDSTexture(gun2.config.clipConf.icon.name).getUiTexture();
+            }
+            // HACK: You can't bind to the icons of a UIIconBar, so we set them during an update instead.
+            gun2Stats.findAll(UIIconBar.class).iterator().next().setIcon(gun2ClipIcon);
+        }
+
+        SolItem example = hero.getAbility().getConfig().getChargeExample();
+        if (example != null) {
+            UITextureRegion abilityIcon = Assets.getDSTexture(example.getIcon(solApplication.getGame()).name).getUiTexture();
+            abilityStats.findAll(UIIconBar.class).iterator().next().setIcon(abilityIcon);
+        }
+
+        zoneNameAnnouncer.update(solApplication.getGame(), solApplication.getGame().getContext());
+    }
+
+    @Override
+    public void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        // Don't render the borders on-top of the map screen.
+        if (!solApplication.getInputManager().isScreenOn(solApplication.getGame().getScreens().mapScreen)) {
+            try (NUIManager.LegacyUiDrawerWrapper wrapper = nuiManager.getLegacyUiDrawer()) {
+                borderDrawer.draw(wrapper.getUiDrawer(), solApplication, solApplication.getGame().getContext());
+                zoneNameAnnouncer.drawText(wrapper.getUiDrawer());
+                drawHeightCompass(wrapper);
+            }
+        }
     }
 
     @Override
@@ -185,7 +572,30 @@ public class MainGameScreen extends NUIScreenLayer {
             return true;
         }
 
+        GameOptions gameOptions = solApplication.getOptions();
+        // TODO: How to handle free camera movement on Android? (note: this has never been supported)
+        if (event.getKey() == GDXInputUtil.GDXToNuiKey(gameOptions.getKeyFreeCameraMovement())) {
+            SolCam.DIRECT_CAM_CONTROL = event.isDown();
+        }
+
+        SolGame solGame = solApplication.getGame();
+        if (event.getState() == ButtonState.UP && event.getKey() == GDXInputUtil.GDXToNuiKey(gameOptions.getKeyPause())) {
+            solGame.setPaused(!solGame.isPaused());
+        }
+
         return super.onKeyEvent(event);
+    }
+
+    @Override
+    public void onMouseButtonEvent(NUIMouseButtonEvent event) {
+        if (event.getState() == ButtonState.UP) {
+            NUIScreenLayer topScreen = nuiManager.getTopScreen();
+            if (!solApplication.getInputManager().isMouseOnUi() &&
+                    topScreen != MainGameScreen.this && !(topScreen instanceof UIShipControlsScreen)) {
+                nuiManager.popScreen();
+                event.consume();
+            }
+        }
     }
 
     @Override
@@ -237,6 +647,259 @@ public class MainGameScreen extends NUIScreenLayer {
         return mercsButton;
     }
 
+    /**
+     * Creates and adds a new warn drawer with the specified properties and activation condition.
+     * @param id the id used for the drawer widget
+     * @param tint the tint used for the warning background
+     * @param text the text to be shown in the warning
+     * @param warnBinding the condition for the warning to be shown
+     * @return the {@link UIWarnDrawer} created
+     */
+    public UIWarnDrawer addWarnDrawer(String id, Color tint, String text, Binding<Boolean> warnBinding) {
+        UIWarnDrawer warnDrawer = new UIWarnDrawer(id, whiteTexture, tint, new UILabel(text));
+        warnDrawer.bindWarn(warnBinding);
+        warnDrawers.addWidget(new EmptyIfInvisibleContainer(warnDrawer), new RelativeLayoutHint());
+        return warnDrawer;
+    }
+
+    /**
+     * Adds the provided warn drawer to be displayed when the condition {@link UIWarnDrawer#isWarning()} is true.
+     * @param warnDrawer the warn-drawer instance to use
+     * @return the warn-drawer instance used.
+     */
+    public UIWarnDrawer addWarnDrawer(UIWarnDrawer warnDrawer) {
+        warnDrawers.addWidget(new EmptyIfInvisibleContainer(warnDrawer), new RelativeLayoutHint());
+        return warnDrawer;
+    }
+
+    /**
+     * Returns true if a warn-drawer with the specified id already exists, otherwise false.
+     * @param id the id to search for
+     * @return true, if the drawer exists, otherwise false.
+     */
+    public boolean hasWarnDrawer(String id) {
+        return warnDrawers.find(id, UIWarnDrawer.class) != null;
+    }
+
+    /**
+     * Returns true if the specified warn-drawer already exists, otherwise false.
+     * @param warnDrawerToFind the drawer to search for
+     * @return true, if the drawer exists, otherwise false.
+     */
+    public boolean hasWarnDrawer(UIWarnDrawer warnDrawerToFind) {
+        for (UIWidget warnDrawerContainer : warnDrawers) {
+            if (warnDrawerContainer instanceof EmptyIfInvisibleContainer) {
+                EmptyIfInvisibleContainer container = (EmptyIfInvisibleContainer) warnDrawerContainer;
+                if (container.iterator().hasNext() && container.iterator().next() == warnDrawerToFind) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes the warn-drawer with the specified id from use.
+     * @param id the id of the warn-drawer to remove
+     */
+    public void removeWarnDrawer(String id) {
+        UIWarnDrawer warnDrawer = warnDrawers.find(id, UIWarnDrawer.class);
+        if (warnDrawer != null) {
+            warnDrawers.removeWidget(warnDrawer);
+        }
+    }
+
+    /**
+     * Removes the specified warn drawer from use.
+     * @param warnDrawer the warn-drawer instance to remove
+     */
+    public void removeWarnDrawer(UIWarnDrawer warnDrawer) {
+        warnDrawers.removeWidget(warnDrawer);
+    }
+
+    private void drawHeightCompass(NUIManager.LegacyUiDrawerWrapper drawerWrapper) {
+        SolGame game = solApplication.getGame();
+        Planet np = game.getPlanetManager().getNearestPlanet();
+        SolCam cam = solApplication.getGame().getCam();
+        Vector2 camPos = cam.getPosition();
+        if (np != null && np.getPosition().dst(camPos) < np.getFullHeight()) {
+            UiDrawer drawer = drawerWrapper.getUiDrawer();
+
+            float toPlanet = camPos.dst(np.getPosition());
+            toPlanet -= np.getGroundHeight();
+            if (Const.ATM_HEIGHT < toPlanet) {
+                return;
+            }
+
+            float perc = toPlanet / Const.ATM_HEIGHT;
+            float sz = .08f;
+            float maxY = 1 - sz / 2;
+            float y = 1 - perc;
+            compassTint.a = SolMath.clamp(1.5f * y);
+            if (maxY < y) {
+                y = maxY;
+            }
+            float angle = np.getAngle() - cam.getAngle();
+            drawer.draw(compassTexture, sz, sz, sz / 2, sz / 2, sz / 2, y, angle, compassTint);
+        }
+    }
+
+    private AbstractWidget createStatsRow(String name, Binding<UITextureRegion> statIcon, Binding<Float> statBinding,
+                                          Binding<String> statBarTextBinding, Binding<UITextureRegion> statBarIconBinding,
+                                          UITextureRegion refillIcon, Binding<Float> refillBinding) {
+        String iconId = name + "Icon";
+        String statsBarTextId = name + "statsBarText";
+        String refillExtraTextId = name + "refillExtraText";
+        VerticalHint iconHeightHint = new VerticalHint()
+                .alignTopRelativeTo(iconId, VerticalAlign.TOP)
+                .alignBottomRelativeTo(iconId, VerticalAlign.BOTTOM);
+
+        RelativeLayout relativeLayout = new RelativeLayout();
+        UIImage icon = new UIImage(iconId, null);
+        icon.bindTexture(statIcon);
+        relativeLayout.addWidget(icon, new RelativeLayoutHint(
+                new HorizontalHint().alignLeft(),
+                new VerticalHint()
+        ).setUsingContentWidth(true).setUsingContentHeight(true));
+        UILoadBar statsBar = new UILoadBar();
+        statsBar.setAnimate(false);
+        statsBar.setFillTexture(Assets.getDSTexture("engine:buttonDown").getUiTexture());
+        statsBar.bindValue(statBinding);
+        relativeLayout.addWidget(statsBar, new RelativeLayoutHint(
+                new HorizontalHint().alignLeftRelativeTo(iconId, HorizontalAlign.RIGHT, 8).alignRight(134),
+                iconHeightHint
+        ));
+        UILabelledIcon statsValueText = new UILabelledIcon(statsBarTextId, "");
+        statsValueText.setFamily("centerAlignedLabel");
+        statsValueText.setSpacing(0);
+        statsValueText.setIconAlign(HorizontalAlign.CENTER);
+        statsValueText.bindText(statBarTextBinding);
+        statsValueText.bindIcon(statBarIconBinding);
+        relativeLayout.addWidget(statsValueText, new RelativeLayoutHint(
+                new HorizontalHint().alignLeftRelativeTo(iconId, HorizontalAlign.RIGHT, 8).alignRight(134),
+                iconHeightHint
+        ));
+
+        UIIconBar refillIconsBar = new UIIconBar();
+        refillIconsBar.setMaxIcons(3);
+        refillIconsBar.setMaxValue(3);
+        refillIconsBar.setHalfIconMode(UIIconBar.HalfIconMode.NONE);
+        // NOTE: UIIconBar doesn't support icon bindings.
+        refillIconsBar.setIcon(refillIcon);
+        refillIconsBar.bindValue(refillBinding);
+        relativeLayout.addWidget(refillIconsBar, new RelativeLayoutHint(
+                new HorizontalHint()
+                        .alignLeftRelativeTo(statsBarTextId, HorizontalAlign.RIGHT, 8)
+                        .alignRightRelativeTo(refillExtraTextId, HorizontalAlign.LEFT),
+                iconHeightHint
+        ));
+
+        UILabelledIcon refillExtrasText = new UILabelledIcon(refillExtraTextId, "  ");
+        refillExtrasText.setFamily("topLeftAlignedLabel");
+        refillExtrasText.setSpacing(0);
+        refillExtrasText.bindText(new ReadOnlyBinding<String>() {
+            @Override
+            public String get() {
+                float value = refillBinding.get();
+                if (value <= 3) {
+                    return "  ";
+                }
+                return "+" + String.format(Locale.ENGLISH, "%-2d", ((int)value - 3));
+            }
+        });
+        relativeLayout.addWidget(refillExtrasText, new RelativeLayoutHint(
+                new HorizontalHint().alignRight(),
+                iconHeightHint
+        ).setUsingContentWidth(true));
+
+        return new EmptyIfInvisibleContainer(relativeLayout);
+    }
+
+    private ReadOnlyBinding<UITextureRegion> createGunIconBinding(boolean isSecondary) {
+        return new ReadOnlyBinding<UITextureRegion>() {
+            @Override
+            public UITextureRegion get() {
+                Hero hero = solApplication.getGame().getHero();
+                Gun gun = hero.getHull().getGun(isSecondary);
+                if (gun != null) {
+                    return Assets.getDSTexture(gun.getIcon(solApplication.getGame()).name).getUiTexture();
+                }
+                return null;
+            }
+        };
+    }
+
+    private ReadOnlyBinding<Float> createGunClipValueBinding(boolean isSecondary) {
+        return new ReadOnlyBinding<Float>() {
+            @Override
+            public Float get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                Gun gun = hero.getHull().getGun(isSecondary);
+                if (gun == null) {
+                    return 0.0f;
+                }
+                if (gun.config.clipConf.infinite) {
+                    return 1.0f;
+                }
+                return (float) hero.getItemContainer().count(gun.config.clipConf.example);
+            }
+        };
+    }
+
+    private ReadOnlyBinding<Float> createGunValueBinding(boolean isSecondary) {
+        return new ReadOnlyBinding<Float>() {
+            @Override
+            public Float get() {
+                Hero hero = solApplication.getGame().getHero();
+                Gun gun = hero.getHull().getGun(isSecondary);
+                if (gun == null) {
+                    return 0.0f;
+                }
+                if (gun.reloadAwait > 0) {
+                    return 1.0f - (gun.reloadAwait / gun.config.reloadTime);
+                } else {
+                    return (float)gun.ammo / gun.config.clipConf.size;
+                }
+            }
+        };
+    }
+
+    private ReadOnlyBinding<String> createGunValueLabelBinding(boolean isSecondary) {
+        return new ReadOnlyBinding<String>() {
+            @Override
+            public String get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                Gun gun = hero.getHull().getGun(isSecondary);
+                if (gun == null) {
+                    return "";
+                }
+                if (gun.reloadAwait > 0) {
+                    return "";
+                } else {
+                    return gun.ammo + "/" + gun.config.clipConf.size;
+                }
+            }
+        };
+    }
+
+    private ReadOnlyBinding<UITextureRegion> createGunBarIconBinding(boolean isSecondary) {
+        return new ReadOnlyBinding<UITextureRegion>() {
+            @Override
+            public UITextureRegion get() {
+                SolGame game = solApplication.getGame();
+                Hero hero = game.getHero();
+                Gun gun = hero.getHull().getGun(isSecondary);
+                if (gun == null) {
+                    return null;
+                }
+                return gun.reloadAwait > 0 ? Assets.getDSTexture("engine:iconWait").getUiTexture() : null;
+            }
+        };
+    }
+
     private void onMenuButtonClicked(UIWidget widget) {
         SolInputManager solInputManager = solApplication.getInputManager();
         GameScreens gameScreens = solApplication.getGame().getScreens();
@@ -261,7 +924,7 @@ public class MainGameScreen extends NUIScreenLayer {
         SolInputManager solInputManager = solApplication.getInputManager();
         GameScreens gameScreens = game.getScreens();
 
-        solInputManager.setScreen(solApplication, gameScreens.mainGameScreen);
+        solInputManager.setScreen(solApplication, gameScreens.oldMainGameScreen);
         if (!solInputManager.isScreenOn(gameScreens.inventoryScreen)) {
             gameScreens.inventoryScreen.showInventory.setTarget(hero.getShip());
             gameScreens.inventoryScreen.setOperations(gameScreens.inventoryScreen.showInventory);
@@ -278,7 +941,7 @@ public class MainGameScreen extends NUIScreenLayer {
         SolInputManager solInputManager = solApplication.getInputManager();
         GameScreens gameScreens = game.getScreens();
 
-        solInputManager.setScreen(solApplication, gameScreens.mainGameScreen);
+        solInputManager.setScreen(solApplication, gameScreens.oldMainGameScreen);
         if (!solInputManager.isScreenOn(gameScreens.talkScreen)) {
             gameScreens.talkScreen.setTarget(talkTarget);
             solInputManager.addScreen(solApplication, gameScreens.talkScreen);
@@ -295,11 +958,29 @@ public class MainGameScreen extends NUIScreenLayer {
         SolInputManager solInputManager = solApplication.getInputManager();
         GameScreens gameScreens = game.getScreens();
 
-        solInputManager.setScreen(solApplication, gameScreens.mainGameScreen);
+        solInputManager.setScreen(solApplication, gameScreens.oldMainGameScreen);
         if (!solInputManager.isScreenOn(gameScreens.inventoryScreen)) {
             gameScreens.inventoryScreen.setOperations(gameScreens.inventoryScreen.chooseMercenaryScreen);
             solInputManager.addScreen(solApplication, gameScreens.inventoryScreen);
             hero.getMercs().markAllAsSeen();
+        }
+    }
+
+    private final class CollisionWarnDrawerRayCastCallback implements RayCastCallback {
+        private boolean show;
+
+        //TODO code from era when hero was SolShip - does this still work? (what is it supposed to do?)
+        // TODO: Moved from the original MainGameScreen - still don't know what this does.
+        @Override
+        public float reportRayFixture(Fixture fixture, Vector2 point, Vector2 normal, float fraction) {
+            if (fixture.getBody().getUserData() instanceof SolObject) {
+                SolObject o = (SolObject) fixture.getBody().getUserData();
+                if (solApplication.getGame().getHero().getShip() == o) {
+                    return -1;
+                }
+                show = true;
+            }
+            return 0;
         }
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/UIShipControlsScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/UIShipControlsScreen.java
@@ -96,7 +96,7 @@ public class UIShipControlsScreen extends NUIScreenLayer implements ShipUiContro
     @Override
     public void update(float delta) {
         // Hide and disable controls if the main game screen is not visible.
-        boolean mainGameScreenVisible = solApplication.getInputManager().isScreenOn(solApplication.getGame().getScreens().mainGameScreen);
+        boolean mainGameScreenVisible = solApplication.getInputManager().isScreenOn(solApplication.getGame().getScreens().oldMainGameScreen);
         ((AbstractWidget)contents).setVisible(mainGameScreenVisible);
         contents.setEnabled(mainGameScreenVisible);
 

--- a/engine/src/main/java/org/destinationsol/ui/nui/widgets/UIWarnDrawer.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/widgets/UIWarnDrawer.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.destinationsol.ui.nui.widgets;
+
+import org.destinationsol.Const;
+import org.destinationsol.common.SolMath;
+import org.terasology.nui.Canvas;
+import org.terasology.nui.Color;
+import org.terasology.nui.LayoutConfig;
+import org.terasology.nui.UITextureRegion;
+import org.terasology.nui.UIWidget;
+import org.terasology.nui.databinding.Binding;
+import org.terasology.nui.databinding.DefaultBinding;
+import org.terasology.nui.widgets.UISpace;
+
+/**
+ * An informational box that appears in the screen to alert the user to a particular circumstance that has occurred.
+ * The background, background tint, box content and trigger conditions are all configurable.
+ */
+public class UIWarnDrawer extends EmptyIfInvisibleContainer {
+    private static final float FADE_TIME = 1f;
+    @LayoutConfig
+    private UITextureRegion background;
+    @LayoutConfig
+    private Color tint;
+    private float alpha;
+    private Binding<Boolean> shouldWarn = new DefaultBinding<>(false);
+
+    public UIWarnDrawer(String id, UITextureRegion background, Color tint) {
+        super(id, new UISpace());
+        this.background = background;
+        this.tint = tint;
+        this.alpha = 0.0f;
+    }
+
+    public UIWarnDrawer(String id, UITextureRegion background, Color tint, UIWidget content) {
+        super(id, content);
+        this.background = background;
+        this.tint = tint;
+        this.alpha = 0.0f;
+    }
+
+    @Override
+    public void onDraw(Canvas canvas) {
+        canvas.setAlpha(alpha);
+        canvas.drawTexture(background, tint);
+        super.onDraw(canvas);
+    }
+
+    @Override
+    public void update(float delta) {
+        if (isWarning()) {
+            alpha = 1;
+        } else {
+            alpha = SolMath.approach(alpha, 0, Const.REAL_TIME_STEP / FADE_TIME);
+        }
+
+        super.update(delta);
+    }
+
+    /**
+     * Returns the current background tint.
+     * @return the current background tint.
+     */
+    public Color getTint() {
+        return tint;
+    }
+
+    /**
+     * Sets the new background tint.
+     * @param tint the new background tint.
+     */
+    public void setTint(Color tint) {
+        this.tint = tint;
+    }
+
+    /**
+     * Returns the current background texture.
+     * @return the current background texture.
+     */
+    public UITextureRegion getBackground() {
+        return background;
+    }
+
+    /**
+     * Sets the new background texture.
+     * @param background the new background texture.
+     */
+    public void setBackground(UITextureRegion background) {
+        this.background = background;
+    }
+
+    /**
+     * Returns the current transparency of the widget. This is additive relative to the canvas.
+     * @return the current widget transparency.
+     */
+    public float getAlpha() {
+        return alpha;
+    }
+
+    /**
+     * Sets the new widget transparency, relative to the canvas.
+     * The assigned value may be overridden if the widget is currently warning.
+     * @param alpha the new widget transparency.
+     */
+    public void setAlpha(float alpha) {
+        this.alpha = alpha;
+    }
+
+    /**
+     * Returns if the widget is currently warning (full opacity).
+     * @return true, if the widget is currently warning, otherwise false.
+     */
+    public boolean isWarning() {
+        return shouldWarn.get();
+    }
+
+    /**
+     * Sets whether the widget should currently be warning.
+     * @param shouldWarn true, if the widget should currently be warning, otherwise false.
+     */
+    public void setWarn(boolean shouldWarn) {
+        this.shouldWarn.set(shouldWarn);
+    }
+
+    /**
+     * Assigns a binding to the widget's warning value to determine when it should warn.
+     * @param shouldWarn the new warning binding.
+     */
+    public void bindWarn(Binding<Boolean> shouldWarn) {
+        this.shouldWarn = shouldWarn;
+    }
+
+    /**
+     * Returns if the widget is visible.
+     * NOTE: This overridden version also returns true if the widget alpha is zero or less.
+     */
+    @Override
+    public boolean isVisible() {
+        if (!super.isVisible()) {
+            return false;
+        }
+
+        return alpha > 0.0f;
+    }
+}

--- a/engine/src/main/resources/org/destinationsol/assets/skins/mainGameScreen.skin
+++ b/engine/src/main/resources/org/destinationsol/assets/skins/mainGameScreen.skin
@@ -10,8 +10,30 @@
       },
       "font": "engine:main#1"
     },
+    "statsBars": {
+      "elements": {
+        "RelativeLayout": {
+          "fixed-height": 32
+        },
+        "UILabelledIcon": {
+          "fixed-height": 32,
+          "text-align-horizontal": "left",
+          "text-align-vertical": "center",
+          "font": "engine:main#0.75"
+        }
+      }
+    },
     "controlsUIButton": {
       "font": "engine:main#0.95"
+    },
+    "warnDrawers": {
+      "elements": {
+        "UIWarnDrawer": {
+          "min-width": 160,
+          "min-height": 96
+        }
+      },
+      "font": "engine:main#0.8"
     }
   }
 }

--- a/engine/src/main/resources/org/destinationsol/assets/skins/mainGameScreen.skin
+++ b/engine/src/main/resources/org/destinationsol/assets/skins/mainGameScreen.skin
@@ -13,7 +13,7 @@
     "statsBars": {
       "elements": {
         "RelativeLayout": {
-          "fixed-height": 32
+          "fixed-height": 36
         },
         "UILabelledIcon": {
           "fixed-height": 32,

--- a/engine/src/main/resources/org/destinationsol/assets/skins/mainGameScreen.skin
+++ b/engine/src/main/resources/org/destinationsol/assets/skins/mainGameScreen.skin
@@ -31,6 +31,10 @@
         "UIWarnDrawer": {
           "min-width": 160,
           "min-height": 96
+        },
+        "UILabel": {
+          "text-align-horizontal": "center",
+          "text-align-vertical": "middle"
         }
       },
       "font": "engine:main#0.8"

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_desktop.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_desktop.ui
@@ -17,7 +17,7 @@
           },
           "width": 288
         },
-        "verticalSpacing": 8,
+        "verticalSpacing": 0,
         "fillVerticalSpace": false,
         "contents": [
         ]

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_desktop.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_desktop.ui
@@ -6,6 +6,49 @@
     "contents": [
       {
         "type": "ColumnLayout",
+        "id": "statsBars",
+        "family": "statsBars",
+        "layoutInfo": {
+          "position-left": {
+            "offset": 16
+          },
+          "position-top": {
+            "offset": 16
+          },
+          "width": 288
+        },
+        "verticalSpacing": 8,
+        "fillVerticalSpace": false,
+        "contents": [
+        ]
+      },
+      {
+        "type": "FlowLayout",
+        "id": "warnDrawers",
+        "family": "warnDrawers",
+        "horizontalSpacing": 8,
+        "verticalSpacing": 8,
+        "contents": [
+        ],
+        "layoutInfo": {
+          "position-left": {
+            "widget": "statsBars",
+            "target": "RIGHT"
+          },
+          "position-right": {
+            "widget": "menuList",
+            "target": "LEFT"
+          },
+          "position-top": {
+            "offset": 16
+          },
+          "position-bottom": {
+            "target": "MIDDLE"
+          }
+        }
+      },
+      {
+        "type": "ColumnLayout",
         "id": "menuList",
         "layoutInfo": {
           "use-content-width": true,
@@ -20,9 +63,9 @@
         "family": "sideUIButton",
         "contents": [
           {
-          "type": "UIWarnButton",
-          "text": "Menu",
-          "id": "menuButton"
+            "type": "UIWarnButton",
+            "text": "Menu",
+            "id": "menuButton"
           },
           {
             "type": "UIWarnButton",

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_mobile.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_mobile.ui
@@ -20,7 +20,7 @@
           }
         },
         "column-widths": [0.6],
-        "verticalSpacing": 8,
+        "verticalSpacing": 0,
         "fillVerticalSpace": false,
         "contents": [
         ]

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_mobile.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainGameScreen_mobile.ui
@@ -6,12 +6,56 @@
     "contents": [
       {
         "type": "ColumnLayout",
+        "id": "statsBars",
+        "family": "statsBars",
+        "layoutInfo": {
+          "position-left": {
+            "offset": 16
+          },
+          "position-right": {
+            "target": "CENTER"
+          },
+          "position-top": {
+            "offset": 16
+          }
+        },
+        "column-widths": [0.6],
+        "verticalSpacing": 8,
+        "fillVerticalSpace": false,
+        "contents": [
+        ]
+      },
+      {
+        "type": "FlowLayout",
+        "id": "warnDrawers",
+        "family": "warnDrawers",
+        "horizontalSpacing": 8,
+        "verticalSpacing": 8,
+        "contents": [
+        ],
+        "layoutInfo": {
+          "position-left": {
+            "widget": "statsBars",
+            "target": "RIGHT"
+          },
+          "position-right": {
+            "widget": "rightMenuList",
+            "target": "LEFT"
+          },
+          "position-top": {},
+          "position-bottom": {
+            "target": "MIDDLE"
+          }
+        }
+      },
+      {
+        "type": "ColumnLayout",
         "id": "leftMenuList",
         "layoutInfo": {
           "use-content-width": true,
           "use-content-height": true,
           "position-vertical-center": {
-            "offset": -100
+            "offset": 16
           },
           "position-left": {}
         },
@@ -20,9 +64,9 @@
         "family": "sideUIButton",
         "contents": [
           {
-          "type": "UIWarnButton",
-          "text": "Menu",
-          "id": "menuButton"
+            "type": "UIWarnButton",
+            "text": "Menu",
+            "id": "menuButton"
           },
           {
             "type": "UIWarnButton",
@@ -37,8 +81,9 @@
         "layoutInfo": {
           "use-content-width": true,
           "use-content-height": true,
-          "position-vertical-center": {
-            "offset": -100
+          "position-bottom": {
+            "widget": "leftMenuList",
+            "target": "BOTTOM"
           },
           "position-right": {}
         },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request converts all remaining visual functionality of `MainGameScreen` to use NUI instead. This does not cover auxiliary classes, such as `BorderDrawer` and `ZoneNameAnnouncer` but does include `WarnDrawer`. Most of the not covered classes render rotated images, which is not supported under NUI (and so use `UiDrawer` directly instead).

The original `MainGameScreen` class remains for now, due to other dependencies in the code that rely on it, such as input handling.

This pull request also includes a bug-fix for retrieving item examples in `ItemManager`.

# Testing
### Warnings
- Start a new game or continue and existing one (`Imperial Small` is recommended for this)
##### Armour
- Open your inventory and un-equip your armour.
- A "No Armor" warning should be displayed in orange.
##### Shield
- Open your inventory again and un-equip your shield this time.
- A "No Shield" warning should be displayed in orange.
##### Health
- Reduce your health to below 5 or lower (the exact value depends on the ship chosen).
- A "Heavily Damaged" warning should be displayed in red.
- Increase your health back to 5 or above (again, exact value depends on the ship chosen).
- The "Heavily Damaged" warning should fade away.
##### Enemies
- Shoot at your starting station until it becomes hostile
- A "Dangerous Enemy" warning should appear in orange.
### Stats Bars
- Start a new game with the "Loaded Imperial Large" ship
##### Health Bar
- Ram your ship into the starting station.
- You should see the value in your health bar go down.
##### Shield Bar
- Fire on the starting station until it becomes hostile.
- When the starting station shoots your ship, the value in your shield bar should go down.
##### Ammunition Bar
- The icons on the ammunition bars should correspond to the weapons you have equipped.
- Fire your left gun.
- You should see the value of the first ammunition bar go down.
- Fire your right gun.
- You should see the value of the second ammunition bar go down.
- Continuously fire your left gun until it runs out of ammunition.
- You should see an hour-glass icon appear in the ammunition bar, which will steadily increase until it is full again.
### Miscellaneous
- When flying near a planet, you should see some dots in the corner, which roughly indicate the direction towards the planet.
- Then flying on a planet, you should see a compass (I don't know what it does - points towards true north?).

# Potential Future Improvements
 - The `UIWarnDrawer` notifications are not the most visually pleasant. Better placement and design is needed but for now I've tried to retain most lf the original appearance and behaviour.
 - `UIWarnDrawer` notifications start from the middle of the screen on Android, which shouldn't really be the case.
# Breaking Changes
 - The original `GameScreens#mainGameScreen` variable has been re-named to `GameScreens#oldMainGameScreen`.
 - `GameScreens#mainGameScreen` now points to the NUI version of `MainGameScreen` instead.

# Notes
- This supersedes #641.
- This depends on #664.
- You can view the changes made only in this pull request [here](https://github.com/BenjaminAmos/DestinationSol/compare/nui-screen-conversion/new-widgets...BenjaminAmos:DestinationSol:nui-screen-conversion/main-game-screen).