### PR TITLE
feat: display ship preview on new ship screen

### DIFF
--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/NewShipScreen.java
@@ -25,6 +25,8 @@ import org.destinationsol.ui.nui.NUIManager;
 import org.destinationsol.ui.nui.NUIScreenLayer;
 import org.destinationsol.ui.nui.widgets.KeyActivatedButton;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.UITextureRegion;
@@ -37,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NewShipScreen extends NUIScreenLayer {
-
+    private static final Logger logger = LoggerFactory.getLogger(NewShipScreen.class);
     private final SolApplication solApplication;
     private int numberOfSystems = SystemsBuilder.DEFAULT_SYSTEM_COUNT;
     private int playerSpawnConfigIndex = 0;
@@ -67,7 +69,13 @@ public class NewShipScreen extends NUIScreenLayer {
             playerSpawnConfigNames.addAll(playerSpawnConfigs.keySet());
             for (String spawnConfigName : playerSpawnConfigs.keySet()) {
                 JSONObject playerSpawnConfig = playerSpawnConfigs.getJSONObject(spawnConfigName);
-                playerSpawnConfigTextures.add(Assets.getDSTexture(playerSpawnConfig.getString("hull")).getUiTexture());
+                try {
+                    playerSpawnConfigTextures.add(Assets.getDSTexture(playerSpawnConfig.getString("hull")).getUiTexture());
+                } catch (RuntimeException e) {
+                    logger.error("Failed to load ship texture!", e);
+                    // Null values will not render any texture.
+                    playerSpawnConfigTextures.add(null);
+                }
             }
         }
 

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/NewShipScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/mainMenu/NewShipScreen.java
@@ -24,10 +24,13 @@ import org.destinationsol.game.planet.SystemsBuilder;
 import org.destinationsol.ui.nui.NUIManager;
 import org.destinationsol.ui.nui.NUIScreenLayer;
 import org.destinationsol.ui.nui.widgets.KeyActivatedButton;
+import org.json.JSONObject;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.nui.Canvas;
+import org.terasology.nui.UITextureRegion;
 import org.terasology.nui.backends.libgdx.GDXInputUtil;
 import org.terasology.nui.widgets.UIButton;
+import org.terasology.nui.widgets.UIImage;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -39,6 +42,7 @@ public class NewShipScreen extends NUIScreenLayer {
     private int numberOfSystems = SystemsBuilder.DEFAULT_SYSTEM_COUNT;
     private int playerSpawnConfigIndex = 0;
     private List<String> playerSpawnConfigNames = new ArrayList<>();
+    private List<UITextureRegion> playerSpawnConfigTextures = new ArrayList<>();
 
     @Inject
     public NewShipScreen(SolApplication solApplication) {
@@ -59,14 +63,23 @@ public class NewShipScreen extends NUIScreenLayer {
         });
 
         for (ResourceUrn configUrn : Assets.getAssetHelper().listAssets(Json.class, "playerSpawnConfig")) {
-            playerSpawnConfigNames.addAll(Validator.getValidatedJSON(configUrn.toString(), "engine:schemaPlayerSpawnConfig").keySet());
+            JSONObject playerSpawnConfigs = Validator.getValidatedJSON(configUrn.toString(), "engine:schemaPlayerSpawnConfig");
+            playerSpawnConfigNames.addAll(playerSpawnConfigs.keySet());
+            for (String spawnConfigName : playerSpawnConfigs.keySet()) {
+                JSONObject playerSpawnConfig = playerSpawnConfigs.getJSONObject(spawnConfigName);
+                playerSpawnConfigTextures.add(Assets.getDSTexture(playerSpawnConfig.getString("hull")).getUiTexture());
+            }
         }
+
+        UIImage shipPreviewImage = find("shipPreviewImage", UIImage.class);
+        shipPreviewImage.setImage(playerSpawnConfigTextures.get(playerSpawnConfigIndex));
 
         UIButton startingShipButton = find("startingShipButton", UIButton.class);
         startingShipButton.setText("Starting Ship: " + playerSpawnConfigNames.get(playerSpawnConfigIndex));
         startingShipButton.subscribe(button -> {
             playerSpawnConfigIndex = (playerSpawnConfigIndex + 1) % playerSpawnConfigNames.size();
             ((UIButton)button).setText("Starting Ship: " + playerSpawnConfigNames.get(playerSpawnConfigIndex));
+            shipPreviewImage.setImage(playerSpawnConfigTextures.get(playerSpawnConfigIndex));
         });
 
         // NOTE: The original code used getKeyEscape() for both the "OK" and "Cancel" buttons. This was probably a mistake.

--- a/engine/src/main/resources/org/destinationsol/assets/ui/mainMenu/newShipScreen.ui
+++ b/engine/src/main/resources/org/destinationsol/assets/ui/mainMenu/newShipScreen.ui
@@ -11,9 +11,27 @@
                 "layoutInfo": {
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "MIDDLE",
+                        "widget": "shipPreviewImage",
+                        "target": "TOP",
                         "offset": -64
+                    },
+                    "position-bottom": {
+                        "widget": "shipPreviewImage",
+                        "target": "TOP"
                     }
+                }
+            },
+            {
+                "type": "UIImage",
+                "id": "shipPreviewImage",
+                "layoutInfo": {
+                    "position-horizontal-center": {},
+                    "position-top": {
+                        "target": "MIDDLE",
+                        "offset": -80
+                    },
+                    "use-content-width": true,
+                    "use-content-height": true
                 }
             },
             {


### PR DESCRIPTION
# Description
This pull request adds a preview of the player's chosen ship to the new ship screen.
![image](https://user-images.githubusercontent.com/24301287/197759384-258aeca9-8fa5-4faa-bfba-4aef2b1dc649.png)

# Testing
- Start the game
- Select the `New Game` option
- View each starter ship option individually and ensure that the correct corresponding sprites are shown on-screen.
- (As is usual for UI changes, test that elements don't overlap too much at different resolutions)