### PR TITLE
fix(map): fix incorrect object culling when panning map

### DIFF
--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/MapScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/MapScreen.java
@@ -80,7 +80,7 @@ public class MapScreen extends NUIScreenLayer {
                 SolCam solCam = solApplication.getGame().getCam();
 
                 float camAngle = solCam.getAngle();
-                Vector2 mapCamPos = solCam.getPosition().add(mapDrawer.getMapDrawPositionAdditive());
+                Vector2 mapCamPos = solCam.getPosition().cpy().add(mapDrawer.getMapDrawPositionAdditive());
                 Vector2i mousePosition = event.getMouse().getPosition();
                 // Canvas co-ordinates are relative to the virtual canvas size, rather than the physical canvas size.
                 // The scale factor is therefore needed to convert these virtual co-ordinates into screen co-ordinates.
@@ -225,6 +225,7 @@ public class MapScreen extends NUIScreenLayer {
     public void onAdded() {
         solApplication.getGame().getMapDrawer().setToggled(true);
         waypointOperation = WaypointOperation.NONE;
+        solApplication.getGame().getMapDrawer().getMapDrawPositionAdditive().set(0, 0);
     }
 
     @Override


### PR DESCRIPTION
# Description
The map culling logic was never adapted to cope with a panned map. It only appeared to work because another bug accidentally offset the in-game camera position by the pan offset, rather than calculating the map camera position.

This pull request fixes the bug that caused the panned map position to become the in-game camera position. It then adapts `MapDrawer` to correctly use the panned map position instead.

# Testing
- Start a new game or continue an existing one.
- Open the map.
- Zoom out and have a look at the general contents of the map.
- Zoom in a bit and pan around to find the objects you saw before at the new zoom level.
- Pan at varying zoom levels and ensure that no planets randomly disappear from the map.
- Close the map and fly to any planet.
- Ensure that the planet's sprite on the map changes when near the planet.

# Notes
This fixes #564.