### PR TITLE
Android performance improvements (and sound fix)

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/sound/OggSoundManager.java
+++ b/engine/src/main/java/org/destinationsol/assets/sound/OggSoundManager.java
@@ -227,7 +227,7 @@ public class OggSoundManager implements UpdateAwareSystem {
         float distance = position.dst(cameraPosition) - soundRadius;
         float distanceMultiplier = SolMath.clamp(1 - distance / maxSoundDist);
 
-        return sound.getBaseVolume() * volumeMultiplier * distanceMultiplier * globalVolumeMultiplier;
+        return SolMath.clamp(sound.getBaseVolume() * volumeMultiplier * distanceMultiplier * globalVolumeMultiplier);
     }
 
     /**

--- a/engine/src/main/java/org/destinationsol/game/drawables/DrawableObject.java
+++ b/engine/src/main/java/org/destinationsol/game/drawables/DrawableObject.java
@@ -63,7 +63,7 @@ public class DrawableObject implements SolObject {
             Planet planet = game.getPlanetManager().getNearestPlanet();
             Vector2 planetPosition = planet.getPosition();
             float planetGroundHeight = planet.getGroundHeight();
-            DrawableManager drawableManager = game.getContext().get(DrawableManager.class);
+            DrawableManager drawableManager = game.getDrawableManager();
             for (Drawable drawable : drawables) {
                 if (!(drawable instanceof RectSprite)) {
                     continue;


### PR DESCRIPTION
# Description
This pull request makes some small optimisations to frequently-called parts of the code.
- The `SolContactListener` class should no longer attempt to re-retrieve `SolGame` from the game context in response to every collision.
- `DrawableObject` now uses the instance of `DrawableManager` cached in `SolGame`, rather than retrieving it from the context every update.

It also applies a fix to clamp sound effect volumes to a range of [0, 1]. Values outside of this range are not supported by libGDX and actually cause some sounds to not play at all on one of my Android devices.

# Testing
Follow the reproduction instructions in #556. There should be slightly less stuttering during rapid collisions.

# Notes
The `DrawableManager` fix was based on profiling an Android build and may not neccessarily be a significant factor in overall performance.
