### PR TITLE
fix: fix pause key not pausing the game

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/game/screens/MainGameScreen.java
@@ -46,7 +46,6 @@ public class MainGameScreen extends SolUiBaseScreen {
     static final float HELPER_ROW_1 = 1 - 3f * CELL_SZ;
 
     private final ShipUiControl shipControl;
-    private final SolUiControl pauseControl;
     private final CameraKeyboardControl cameraControl;
     private final SolApplication solApplication;
 
@@ -75,8 +74,6 @@ public class MainGameScreen extends SolUiBaseScreen {
                 break;
         }
 
-        pauseControl = new SolUiControl(null, true, gameOptions.getKeyPause());
-        controls.add(pauseControl);
         cameraControl = new CameraKeyboardControl(gameOptions, controls);
     }
 
@@ -125,12 +122,7 @@ public class MainGameScreen extends SolUiBaseScreen {
         if (solApplication.getNuiManager().hasScreenOfType(ConsoleScreen.class)) {
             controls.forEach(x -> x.setEnabled(false));
         } else if (!nuiManager.hasScreen(screens.menuScreen)) {
-            game.setPaused(false);
             controls.forEach(x -> x.setEnabled(true));
-        }
-
-        if (pauseControl.isJustOff()) {
-            game.setPaused(!game.isPaused());
         }
 
         for (SolUiScreen screen : gameOverlayScreens) {


### PR DESCRIPTION
# Description
This pull request fixes the pause key, so that it actually pauses and un-pauses the game again.

What it really does is remove the old pause key handling code in the original `MainGameScreen`, since it was interfering with the new pause key handling code from its NUI equivalent.

# Testing
- Start a new game (or continue an existing one).
- Move your ship around a bit.
- Press the <kbd>P</kbd> key to pause the game.
- Your ship should stop moving and the game should be paused.
- Press the <kbd>P</kbd>key again to un-pause the game.
- Your ship should continue moving.
