### PR TITLE
feat(ui): separate ability icons from their charges

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/AbilityCommonConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/AbilityCommonConfig.java
@@ -15,6 +15,8 @@
  */
 package org.destinationsol.game;
 
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import org.destinationsol.assets.Assets;
 import org.destinationsol.assets.sound.OggSound;
 import org.destinationsol.assets.sound.OggSoundManager;
 import org.destinationsol.assets.sound.PlayableSound;
@@ -23,10 +25,12 @@ import org.destinationsol.game.particle.EffectTypes;
 import org.json.JSONObject;
 
 public class AbilityCommonConfig {
+    public final TextureAtlas.AtlasRegion icon;
     public final EffectConfig effect;
     public final PlayableSound activatedSound;
 
-    public AbilityCommonConfig(EffectConfig effect, PlayableSound activatedSound) {
+    public AbilityCommonConfig(TextureAtlas.AtlasRegion icon, EffectConfig effect, PlayableSound activatedSound) {
+        this.icon = icon;
         this.effect = effect;
         this.activatedSound = activatedSound;
     }
@@ -34,6 +38,7 @@ public class AbilityCommonConfig {
     public static AbilityCommonConfig load(JSONObject node, EffectTypes types, GameColors cols, OggSoundManager soundManager) {
         EffectConfig ec = EffectConfig.load(node.has("effect") ? node.getJSONObject("effect") : null, types, cols);
         OggSound activatedSound = soundManager.getSound(node.getString("activatedSound"));
-        return new AbilityCommonConfig(ec, activatedSound);
+        TextureAtlas.AtlasRegion icon = node.has("icon") ? Assets.getAtlasRegion(node.getString("icon")) : null;
+        return new AbilityCommonConfig(icon, ec, activatedSound);
     }
 }

--- a/engine/src/main/java/org/destinationsol/ui/nui/screens/MainGameScreen.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/screens/MainGameScreen.java
@@ -38,6 +38,7 @@ import org.destinationsol.game.planet.Planet;
 import org.destinationsol.game.screens.BorderDrawer;
 import org.destinationsol.game.screens.GameScreens;
 import org.destinationsol.game.screens.ZoneNameAnnouncer;
+import org.destinationsol.game.ship.ShipAbility;
 import org.destinationsol.game.ship.SolShip;
 import org.destinationsol.ui.SolInputManager;
 import org.destinationsol.ui.UiDrawer;
@@ -237,11 +238,16 @@ public class MainGameScreen extends NUIScreenLayer {
             @Override
             public UITextureRegion get() {
                 Hero hero = solApplication.getGame().getHero();
-                if (hero.getAbility() == null) {
+                ShipAbility ability = hero.getAbility();
+                if (ability == null) {
                     return null;
                 }
 
-                SolItem example = hero.getAbility().getConfig().getChargeExample();
+                if (ability.getCommonConfig().icon != null) {
+                    return Assets.getDSTexture(ability.getCommonConfig().icon.name).getUiTexture();
+                }
+
+                SolItem example = ability.getConfig().getChargeExample();
                 if (example != null) {
                     return Assets.getDSTexture(example.getIcon(solApplication.getGame()).name).getUiTexture();
                 }

--- a/engine/src/main/resources/org/destinationsol/assets/schemas/schemaAbilitiesConfig.json
+++ b/engine/src/main/resources/org/destinationsol/assets/schemas/schemaAbilitiesConfig.json
@@ -11,6 +11,11 @@
       "activatedSound"
     ],
     "properties": {
+      "icon": {
+        "type": "string",
+        "description": "The gestalt id of the icon representing this ability.",
+        "pattern": "^\\w+:\\w+$"
+      },
       "activatedSound": {
         "type": "string",
         "description": "The gestalt id of the sound effect played upon ability activation.",


### PR DESCRIPTION
# Description
This pull request allows for abilities to be assigned a separate icon to that used by its charges. Not all abilities use ability charges. You might also want to have different icons to represent the ability and the charges that it consumes

This is needed to fix an issue where the ability bar was not being displayed for abilities without an associated charge item..

# Testing
- Start a new game with any of the imperial ships (Imperial Large, Imperial Tiny, etc.).
- Verify that the ability bar is present and that it shows how many charges you have next to it.
- Checkout the warp module (`groovyw module get warp`) and switch it to the `ability-icons` branch.
- Verify that the ability bar is present when playing as the `Warp Quasar` ship.

# Notes
- This shouldn't require any changes to existing abilities.