### PR TITLE
build: update distribution bundled JREs to Java 11

### DIFF
--- a/build-logic/src/main/groovy/destination-sol-jre.gradle
+++ b/build-logic/src/main/groovy/destination-sol-jre.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 // Uses Bellsoft Liberica JRE
-def jreVersion = '8u352+8'
+def jreVersion = '11.0.19+7'
 def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
 def jreUrlFilenames = [
         lwjreLinux64 : 'linux-amd64.tar.gz',

--- a/launcher/solOSX.sh
+++ b/launcher/solOSX.sh
@@ -1,4 +1,2 @@
 #!/usr/bin/env bash
-# TODO: Target the embedded JRE again when it'll listen to arguments or otherwise find the magic trick to allow that
-#lwjreOSX/bin/java -XstartOnFirstThread -jar libs/solDesktop.jar -noSplash
-java -XstartOnFirstThread -jar libs/solDesktop.jar -noSplash
+lwjreOSX/bin/java -XstartOnFirstThread -jar libs/solDesktop.jar -noSplash


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request updates the JREs bundled with distributions to Java 11. It should help with some of the issues when running the game on macOS.

# Testing
- Generate a new distribution with `gradlew distZipBundleJREs`
- Try running the distribution on Windows, macOS and a Linux distribution
- Check that the game still functions as it did under Java 8 (going through the tutorial might be useful)

# Notes
- The game is still compiled for Java 8 at the moment. Moving to a later Java version depends on Android support.
