### PR TITLE
Attempted macOS AArch64 support

### DIFF
--- a/build-logic/src/main/groovy/destination-sol-constants.gradle
+++ b/build-logic/src/main/groovy/destination-sol-constants.gradle
@@ -3,7 +3,7 @@ ext {
 
     engineVersion = '2.1.0'
     gestaltVersion = '8.0.0-SNAPSHOT'
-    gdxVersion = '1.12.0'
+    gdxVersion = '1.12.1'
     // The LibGDX controllers library is versioned differently to the main LibGDX versions.
     // See https://github.com/libgdx/gdx-controllers/wiki/Compatibility for compatible versions.
     gdxControllersVersion = '2.2.3'

--- a/build-logic/src/main/groovy/destination-sol-constants.gradle
+++ b/build-logic/src/main/groovy/destination-sol-constants.gradle
@@ -3,9 +3,9 @@ ext {
 
     engineVersion = '2.1.0'
     gestaltVersion = '8.0.0-SNAPSHOT'
-    gdxVersion = '1.9.14'
+    gdxVersion = '1.12.0'
     // The LibGDX controllers library is versioned differently to the main LibGDX versions.
     // See https://github.com/libgdx/gdx-controllers/wiki/Compatibility for compatible versions.
-    gdxControllersVersion = '2.1.0'
+    gdxControllersVersion = '2.2.3'
     nuiVersion = '4.0.0-SNAPSHOT'
 }

--- a/build-logic/src/main/groovy/destination-sol-jre.gradle
+++ b/build-logic/src/main/groovy/destination-sol-jre.gradle
@@ -24,7 +24,8 @@ def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jre
 def jreUrlFilenames = [
         lwjreLinux64 : 'linux-amd64.tar.gz',
         lwjre        : 'windows-i586.zip',
-        lwjreOSX     : 'macos-amd64.zip'
+        lwjreOSX     : 'macos-amd64.zip',
+        lwjreOSXArm  : 'macos-aarch64.zip'
 ]
 
 tasks.register('downloadJreAll') {

--- a/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputManager.java
@@ -324,11 +324,13 @@ public class SolInputManager {
         int mouseX = Gdx.input.getX();
         int mouseY = Gdx.input.getY();
         // TODO: look into the usefulness of this, and replace with Gdx.graphics.* with displayDimensions if nothing else
-        int w = Gdx.graphics.getWidth();
-        int h = Gdx.graphics.getHeight();
-        mouseX = (int) MathUtils.clamp((float) mouseX, (float) 0, (float) w);
-        mouseY = (int) MathUtils.clamp((float) mouseY, (float) 0, (float) h);
-        Gdx.input.setCursorPosition(mouseX, mouseY);
+        int screenWidth = Gdx.graphics.getWidth();
+        int screenHeight = Gdx.graphics.getHeight();
+        if (mouseX < 0 || mouseX >= screenWidth || mouseY < 0 || mouseY >= screenHeight) {
+            mouseX = (int) MathUtils.clamp((float) mouseX, (float) 0, (float) screenWidth - 1);
+            mouseY = (int) MathUtils.clamp((float) mouseY, (float) 0, (float) screenHeight - 1);
+            Gdx.input.setCursorPosition(mouseX, mouseY);
+        }
     }
 
     private void updatePointers() {

--- a/engine/src/main/java/org/destinationsol/ui/SolInputProcessor.java
+++ b/engine/src/main/java/org/destinationsol/ui/SolInputProcessor.java
@@ -60,6 +60,11 @@ public class SolInputProcessor implements InputProcessor {
     }
 
     @Override
+    public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
     public boolean touchDragged(int screenX, int screenY, int pointer) {
         inputManager.maybeTouchDragged(screenX, screenY);
         return false;

--- a/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
+++ b/engine/src/main/java/org/destinationsol/ui/nui/NUIManager.java
@@ -169,7 +169,7 @@ public class NUIManager {
         UIText.DEFAULT_CURSOR_TEXTURE = whiteTexture;
 
         // NOTE: SolApplication::addResizeSubscriber is not intended to be static, so use the instance form for compatibility
-        solApplication.addResizeSubscriber(() -> resize(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight()));
+        solApplication.addResizeSubscriber(() -> resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight()));
 
         // Mobile screen densities can vary considerably, so a large digital resolution can be displayed
         // on a very small screen. Due to this, it makes sense to scale the UI roughly proportionally

--- a/launcher/solOSX.sh
+++ b/launcher/solOSX.sh
@@ -5,7 +5,7 @@ ARCH=$(uname -m)
 if [[ "$ARCH" == "x86_64" ]]; then
   JRE=lwjreOSX/bin/java
 elif [[ "$ARCH" == "arm64" ]]; then
-  JRE=lwjreOSArm/bin/java
+  JRE=lwjreOSXArm/bin/java
 else
   echo "Unsupported architecture $ARCH"
   exit 1

--- a/launcher/solOSX.sh
+++ b/launcher/solOSX.sh
@@ -1,2 +1,14 @@
 #!/usr/bin/env bash
-lwjreOSX/bin/java -XstartOnFirstThread -jar libs/solDesktop.jar -noSplash
+
+JRE=lwjreOSX/bin/java
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+  JRE=lwjreOSX/bin/java
+elif [[ "$ARCH" == "arm64" ]]; then
+  JRE=lwjreOSArm/bin/java
+else
+  echo "Unsupported architecture $ARCH"
+  exit 1
+fi
+
+$JRE -XstartOnFirstThread -jar libs/solDesktop.jar -noSplash


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request attempts to add support for macOS on AArch64 devices (M1/M2 macs). The appropriate native JREs should now be downloaded for this architecture and bundled with the game distribution. This should fix #687.

# Testing
- Build a new distribution with `gradlew distZipBundleJREs`.
- Unzip the distribution on a AArch64 macOS device (M1/M2 mac) and run it with `./solOSX.sh`.
- You should be able to play through the game's tutorial in its entirety.

# Notes
- This depends on #688.
- These changes are untested, as I do not possess an AArch64 mac to test with.