### PR TITLE
Fix tutorial crash when waypoint removed

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/tutorial/TutorialManager.java
+++ b/engine/src/main/java/org/destinationsol/game/tutorial/TutorialManager.java
@@ -228,7 +228,7 @@ public class TutorialManager implements UpdateAwareSystem {
                         solGame.get().getScreens().mapScreen.getCloseButton(),
                         solGame.get().getScreens().mapScreen,
                         "Close the map."),
-                new FlyToHeroFirstWaypointStep("Fly to your waypoint."),
+                new FlyToHeroFirstWaypointStep("Fly to your waypoint.", "Create a waypoint near your ship."),
                 new ChangeTutorialSectionStep("Planets"),
                 new FlyToPlanetSellingMercenariesStep("Head towards a planet.", "Look for the planetary station."),
                 new ChangeTutorialSectionStep("Mercenaries"),

--- a/engine/src/main/java/org/destinationsol/game/tutorial/steps/FlyToHeroFirstWaypointStep.java
+++ b/engine/src/main/java/org/destinationsol/game/tutorial/steps/FlyToHeroFirstWaypointStep.java
@@ -25,24 +25,39 @@ import javax.inject.Inject;
  * A tutorial step that completes when the player ship reaches a nearby spawned waypoint.
  */
 public class FlyToHeroFirstWaypointStep extends FlyToWaypointStep {
+    private final String missingWaypointMessage;
+
     @Inject
     protected FlyToHeroFirstWaypointStep() {
         throw new RuntimeException("Attempted to instantiate TutorialStep via DI. This is not supported.");
     }
 
-    public FlyToHeroFirstWaypointStep(String message) {
+    public FlyToHeroFirstWaypointStep(String message, String missingWaypointMessage) {
         super(Vector2.Zero, message);
+        this.missingWaypointMessage = missingWaypointMessage;
     }
 
     @Override
     public void start() {
-        waypoint = game.getHero().getWaypoints().get(0);
-        setTutorialText(message);
+        Hero hero = game.getHero();
+        if (hero.getWaypoints().isEmpty()) {
+            setTutorialText(missingWaypointMessage);
+        } else {
+            waypoint = game.getHero().getWaypoints().get(0);
+            setTutorialText(message);
+        }
     }
 
     @Override
     public boolean checkComplete(float timeStep) {
         Hero hero = game.getHero();
+        if (hero.getWaypoints().isEmpty()) {
+            setTutorialText(missingWaypointMessage);
+            return false;
+        } else {
+            setTutorialText(message);
+        }
+
         if (!hero.getWaypoints().contains(waypoint) && hero.getWaypoints().size() > 0) {
             // Change the target waypoint just in-case the player removes it.
             waypoint = hero.getWaypoints().get(0);


### PR DESCRIPTION
# Description
This pull request fixes a crash in the tutorial caused by the player removing a waypoint when it is still needed.

# Testing
- Follow the instructions in #690. The game should not crash when closing the map.

# Notes
- This fixes #690.