### PR TITLE
build: use new artifactory url

### DIFF
--- a/build-logic/src/main/groovy/destination-sol-repositories.gradle
+++ b/build-logic/src/main/groovy/destination-sol-repositories.gradle
@@ -32,14 +32,13 @@ repositories {
 
     // Terasology Artifactory for any shared libs
     maven {
-        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         content {
             includeGroupByRegex('org\\.terasology(\\..+)?')
             includeGroupByRegex('org\\.destinationsol(\\..+)?')
             // A copy of jpastebin is hosted here
             includeModule('brianbb', 'jpastebin')
         }
-        allowInsecureProtocol true // TODO: Review this when HTTPS finally supported.
     }
 
     google()

--- a/build-logic/src/main/groovy/gestalt-repositories.gradle
+++ b/build-logic/src/main/groovy/gestalt-repositories.gradle
@@ -15,12 +15,11 @@ repositories {
 
     // Terasology Artifactory for any shared libs
     maven {
-        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         content {
             includeGroupByRegex('org\\.terasology.gestalt(\\..+)?')
             // A copy of Java-semver is hosted here too
             includeModule('com.github.zafarkhaja', 'java-semver')
         }
-        allowInsecureProtocol true // TODO: Review this when HTTPS finally supported.
     }
 }

--- a/build-logic/src/main/groovy/terasology-publish-common.gradle
+++ b/build-logic/src/main/groovy/terasology-publish-common.gradle
@@ -15,11 +15,9 @@ publishing {
     repositories {
         maven {
             name = 'TerasologyOrg'
-            allowInsecureProtocol true // Still no HTTPS on our Artifactory yet...
-
             if (rootProject.hasProperty("publishRepo")) {
                 // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+                url = "https://artifactory.terasology.io/artifactory/$publishRepo"
 
                 logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
             } else {
@@ -38,7 +36,7 @@ publishing {
                 }
 
                 logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                url = "https://artifactory.terasology.io/artifactory/$deducedPublishRepo"
             }
 
             if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,7 @@ repositories {
 
     // Terasology Artifactory for any shared libs
     maven {
-        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-        allowInsecureProtocol true // TODO: Review this when HTTPS finally supported.
+        url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
     }
 
     maven { url "https://maven.google.com" }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -21,8 +21,7 @@ buildscript {
 
         google()
         maven {
-            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-            allowInsecureProtocol true // TODO: Review this when HTTPS finally supported.
+            url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         }
         // Needed for Jsemver, which is a gestalt dependency
         maven { url = 'https://heisluft.de/maven/' }


### PR DESCRIPTION
# Description
This pull request changes the Artifactory URL used for fetching dependencies to `https://artifactory.terasology.io`.

# Testing
- Check that all dependencies can be fetched using `gradlew clean && gradlew build --refresh-dependencies`