### PR TITLE
Prevent saving during the tutorial

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/SolGame.java
+++ b/engine/src/main/java/org/destinationsol/game/SolGame.java
@@ -256,7 +256,7 @@ public class SolGame {
         Timer.schedule(new Timer.Task() {
             @Override
             public void run() {
-                if (!hero.isTranscendent()) {
+                if (!hero.isTranscendent() && !isTutorial()) {
                     saveShip();
 //                    Console.getInstance().println("Game saved");
                 }

--- a/engine/src/main/java/org/destinationsol/game/StarPort.java
+++ b/engine/src/main/java/org/destinationsol/game/StarPort.java
@@ -124,7 +124,7 @@ public class StarPort implements SolObject {
         if (ship != null && ship.getMoney() >= FARE && ship.getPosition().dst(position) < .05f * SIZE) {
             ship.setMoney(ship.getMoney() - FARE);
             Transcendent transcendent = new Transcendent(ship, fromPlanet, toPlanet, game);
-            if (transcendent.getShip().getPilot().isPlayer()) {
+            if (transcendent.getShip().getPilot().isPlayer() && !game.isTutorial()) {
                 SaveManager.saveWorld(game.getWorldConfig());
                 game.getHero().setTranscendent(transcendent);
             }
@@ -402,7 +402,7 @@ public class StarPort implements SolObject {
                 ship.setPos(position);
                 ship.setVelocity(new Vector2());
                 SolShip ship = this.ship.toObject(game);
-                if (ship.getPilot().isPlayer()) {
+                if (ship.getPilot().isPlayer() && !game.isTutorial()) {
                     game.getHero().setSolShip(ship, game);
                     SaveManager.saveWorld(game.getWorldConfig());
                 }


### PR DESCRIPTION
# Description
This pull request attempts to fix areas where the game still saves whilst the tutorial is active. This is only a temporary solution and changes to `SaveManager` may provide a more comprehensive one in the future.

# Testing
- Start a new game
- Buy an item
- Exit to the main menu
- Start the tutorial
- Exit the tutorial
- Continue your last game
- The item you bought previously, along with your last save data, should be present

This should fix #699.
