### PR TITLE
Make ship engine parameters editable

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/item/Engine.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Engine.java
@@ -123,9 +123,9 @@ public class Engine implements SolItem {
             JSONObject rootNode = Validator.getValidatedJSON(engineName, "engine:schemaEngine");
 
             boolean isBig = rootNode.getBoolean("big");
-            float rotationAcceleration = isBig ? 100f : 515f;
-            float acceleration = 2f;
-            float maxRotationSpeed = isBig ? 40f : 230f;
+            float rotationAcceleration = (float) rootNode.optDouble("rotationAcceleration", isBig ? 100f : 515f);
+            float acceleration = (float) rootNode.optDouble("acceleration", 2f);
+            float maxRotationSpeed = (float) rootNode.optDouble("maxRotationSpeed", isBig ? 40f : 230f);
 
             // TODO: VAMPCAT: The icon / displayName was initially set to null. Is that correct?
 


### PR DESCRIPTION
# Description
"rotationAcceleration", "acceleration", and "maxRotationSpeed" have been changed from constants/conditional constants to editable engine parameters that can be set in engine JSON files. If not specified, it uses default values. This is useful for changing the way ships turn or accelerate.

# Testing
Equip and fly a ship with a type set to "std" or "big" whose engine does not have any of the three variables specified in it's JSON file for backwards compatibility, and equip and fly a ship with said variables specified and changed in it's engine's JSON file.

# Notes
The code was written by BSA so I could edit my ship's engine parameters. I have no experience with Java and the commit message was written by me based on my understanding of the code from BSA explaining it to me.

### Pre Pull Request Checklist:
<!-- When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones. 
If the code looks good to you and you have already at least some experience writing java, you can even completely skip 
this step -->
- [x] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [x] There are no errors present in the project
- [x] Code has been formatted and indented
- [x] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
