### PR TITLE
fix: fix animated sprites being loaded as normal sprites

### DIFF
--- a/engine/src/main/java/org/destinationsol/assets/Assets.java
+++ b/engine/src/main/java/org/destinationsol/assets/Assets.java
@@ -225,7 +225,7 @@ public abstract class Assets {
         }
 
         String animationPath = texturePath + "Animation";
-        if (!assetHelper.get(new ResourceUrn(animationPath), DSTexture.class).isPresent()) {
+        if (!assetHelper.get(new ResourceUrn(animationPath), Json.class).isPresent()) {
             return new Animation<>(Float.MAX_VALUE, getAtlasRegion(texturePath));
         }
 


### PR DESCRIPTION
# Description
This pull request fixes a small typo that prevented the correct loading of animated sprites in-game.

Note that this does not fix the rendering of animated sprites on the main menu, since that is instead a case of it not yet being supported by NUI.

# Testing
Try creating a new animated sprite using the [Using Animated Sprites](https://github.com/MovingBlocks/DestinationSol/wiki/Using-Animated-Sprites) wiki page as a reference.

Alternatively, just drop the following files into `modules/core/assets/ships/imperialBig/` and the `Imperial Big` ship should start flashing in-game:
- [imperialBig.png](https://github.com/user-attachments/assets/8a6ee35c-4348-4de6-b55f-80e8cb77de96)
- [imperialBigAnimation.json](https://github.com/user-attachments/files/18924163/imperialBigAnimation.json)
