### PR TITLE
fix: constantAllies and constantEnemies are now always friendly or hostile respectively

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
+++ b/engine/src/main/java/org/destinationsol/game/GalaxyFiller.java
@@ -162,7 +162,7 @@ public class GalaxyFiller {
                 int count = (int) (shipConfig.density);
                 for (int i = 0; i < count; i++) {
                     // TODO: Select an appropriate ally faction based on the player faction.
-                    build(game, shipConfig, game.getFactionMan().getBuilderForHull(shipConfig.hull), false, system, angles);
+                    build(game, shipConfig, game.getFactionMan().getGenericAllyFaction(), false, system, angles);
                 }
             }
 
@@ -170,7 +170,7 @@ public class GalaxyFiller {
                 int count = (int) (shipConfig.density);
                 for (int i = 0; i < count; i++) {
                     // TODO: Select an appropriate enemy faction based on the player faction.
-                    build(game, shipConfig, game.getFactionMan().getBuilderForHull(mainStationCfg.hull), false, system, angles);
+                    build(game, shipConfig, game.getFactionMan().getGenericEnemyFaction(), false, system, angles);
                 }
             }
 


### PR DESCRIPTION
# Description
This pull request partially reverts changes in #703 by forcing ships specified in `constantAllies` and `constantEnemies` to use the pre-defined factions to ensure predictable behaviour with regard to hostility.

# Testing
- Start a new game (any ship will do)
- Fly inwards until you encounter a pirate ship
- The pirate ship should be hostile and start shooting at you immediately

# Notes
This fixes #707 .
