### PR TITLE
fix: fix default faction dispositions not being applied

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/FactionManager.java
+++ b/engine/src/main/java/org/destinationsol/game/FactionManager.java
@@ -217,7 +217,7 @@ public class FactionManager {
      * @return true, if f1 and f2 are enemies, otherwise false.
      */
     public boolean areEnemies(Faction f1, Faction f2) {
-        return f1 != null && f2 != null && f1.getRelation(f2) < 0;
+        return f1 != null && f2 != null && (f1.getRelation(f2) < 0 || f2.getRelation(f1) < 0);
     }
 
     private static class MyRayBack implements RayCastCallback {

--- a/engine/src/main/java/org/destinationsol/game/faction/FactionsConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/FactionsConfigs.java
@@ -60,8 +60,34 @@ public class FactionsConfigs {
                 for (Map.Entry<ResourceUrn, Integer> factionRelation : factionRelations.getValue().entrySet()) {
                     Faction otherFaction = factionConfigs.get(factionRelation.getKey());
                     faction.setRelation(otherFaction, factionRelation.getValue());
-                    if (!otherFaction.isAwareOf(faction)) {
-                        otherFaction.setRelation(faction, factionRelation.getValue());
+                }
+            }
+
+            for (Faction faction : factionConfigs.values()) {
+                for (Faction otherFaction : factionConfigs.values()) {
+                    if (faction.isAwareOf(otherFaction) && otherFaction.isAwareOf(faction)) {
+                        // Asymmetric relationships are explicitly allowed.
+                        continue;
+                    }
+
+                    if (faction.isAwareOf(otherFaction) && !otherFaction.isAwareOf(faction)) {
+                        otherFaction.setRelation(faction, faction.getRelation(otherFaction));
+                    } else if (!faction.isAwareOf(otherFaction) && otherFaction.isAwareOf(faction)) {
+                        faction.setRelation(otherFaction, otherFaction.getRelation(faction));
+                    } else {
+                        int factionRelation = faction.getRelation(otherFaction);
+                        int otherFactionRelation = otherFaction.getRelation(faction);
+
+                        // The simplified rules of uncertain Destination Sol diplomacy:
+                        //   - If both are friendly, the stronger positivity will prevail.
+                        //   - If both are hostile, the stronger hostility will prevail.
+                        //   - If your enemy is hostile to you, you must be hostile to your enemy.
+                        //   - Neutrality is considered friendly.
+                        int relation = (factionRelation >= 0 && otherFactionRelation >= 0) ?
+                                Math.max(factionRelation, otherFactionRelation) :
+                                Math.min(factionRelation, otherFactionRelation);
+                        faction.setRelation(otherFaction, relation);
+                        otherFaction.setRelation(faction, relation);
                     }
                 }
             }


### PR DESCRIPTION
# Description
The original implementation of the faction loading code did not correctly handle factions lacking explicit relations to each other. This lead to situations where a faction could be hostile to another but not reciprocally. Whilst such situations are allowed when explicit (it could lead to interesting gameplay mechanics), it should not be the case by default.

As commented in the new code, this pull request changes how faction relations are initially assigned when neither faction is aware of the other:
```java
// The simplified rules of uncertain Destination Sol diplomacy:
//   - If both are friendly, the stronger positivity will prevail.
//   - If both are hostile, the stronger hostility will prevail.
//   - If your enemy is hostile to you, you must be hostile to your enemy.
//   - Neutrality is considered friendly.
```

# Testing
Try following the instructions in #706 to ensure that the bug is no longer present. Mercenaries hired by the player should be correctly hostile to the player's enemies now.

# Notes
This fixes #706.
