### PR TITLE
fix: damage reputation loss is now proportional rather than constant

### DIFF
--- a/engine/src/main/java/org/destinationsol/game/FactionManager.java
+++ b/engine/src/main/java/org/destinationsol/game/FactionManager.java
@@ -69,13 +69,13 @@ public class FactionManager {
      * @param event the event that occurred.
      * @param <T> the type of event.
      */
-    public <T extends Enum<T> & ReputationEvent> void reportEvent(Faction instigator, Faction target, T event) {
+    public <T extends ReputationEvent> void reportEvent(Faction instigator, Faction target, T event) {
         // TODO: Add support for custom event handlers.
         //       Some examples:
         //       - A pacifist faction is offended by any attacks made by a faction, regardless of the target.
         //       - A merchant faction may randomly give a free bonus when buying items.
         //       - A protective faction may dispatch a fleet to intercept the attacker if one of their ships is attacked.
-        Integer targetReputationImpact = target.getReputationImpact(event);
+        Float targetReputationImpact = target.getReputationImpact(event);
         if (targetReputationImpact != null) {
             target.setRelation(instigator, target.getRelation(instigator) + targetReputationImpact);
         } else {

--- a/engine/src/main/java/org/destinationsol/game/Rubble.java
+++ b/engine/src/main/java/org/destinationsol/game/Rubble.java
@@ -101,7 +101,7 @@ public class Rubble implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/SolObject.java
+++ b/engine/src/main/java/org/destinationsol/game/SolObject.java
@@ -80,12 +80,13 @@ public interface SolObject {
      * no health pool or should be otherwise indestructible, or invincible against some types of damage, this method can
      * be freely left blank.
      *
-     * @param dmg      Damage the object receives.
-     * @param game     Game this object belongs to.
-     * @param position Position the object was hit at, if hit by point-based damage. Null if not applicable, such as fire.
-     * @param dmgType  Type of the damage object receives.
+     * @param dmg        Damage the object receives.
+     * @param game       Game this object belongs to.
+     * @param position   Position the object was hit at, if hit by point-based damage. Null if not applicable, such as fire.
+     * @param dmgType    Type of the damage object receives.
+     * @param instigator Object that damaged this object.
      */
-    void receiveDmg(float dmg, SolGame game, @Nullable Vector2 position, DmgType dmgType);
+    void receiveDmg(float dmg, SolGame game, @Nullable Vector2 position, DmgType dmgType, @Nullable SolObject instigator);
 
     /**
      * Denotes whether this object is affected by gravity.

--- a/engine/src/main/java/org/destinationsol/game/SolObjectEntityWrapper.java
+++ b/engine/src/main/java/org/destinationsol/game/SolObjectEntityWrapper.java
@@ -62,7 +62,7 @@ public class SolObjectEntityWrapper implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
 
     }
 

--- a/engine/src/main/java/org/destinationsol/game/StarPort.java
+++ b/engine/src/main/java/org/destinationsol/game/StarPort.java
@@ -156,8 +156,9 @@ public class StarPort implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         game.getContext().get(SpecialSounds.class).playHit(game, this, position, dmgType);
+        // TODO: Reduce reputation with the origin planet's owning faction when planet ownership is implemented.
     }
 
     @Override
@@ -436,7 +437,7 @@ public class StarPort implements SolObject {
         }
 
         @Override
-        public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+        public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
             game.getContext().get(SpecialSounds.class).playHit(game, this, position, dmgType);
         }
 

--- a/engine/src/main/java/org/destinationsol/game/asteroid/Asteroid.java
+++ b/engine/src/main/java/org/destinationsol/game/asteroid/Asteroid.java
@@ -112,7 +112,7 @@ public class Asteroid implements SolObject {
         } else {
             dmg = absImpulse / mass / DUR;
         }
-        receiveDmg(dmg, game, collPos, DmgType.CRASH);
+        receiveDmg(dmg, game, collPos, DmgType.CRASH, null);
     }
 
     @Override
@@ -149,7 +149,7 @@ public class Asteroid implements SolObject {
         }
 
         float dmg = body.getLinearVelocity().len() * SPD_TO_ATM_DMG * game.getTimeStep();
-        receiveDmg(dmg, game, null, DmgType.FIRE);
+        receiveDmg(dmg, game, null, DmgType.FIRE, null);
         return true;
     }
 
@@ -215,7 +215,7 @@ public class Asteroid implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         life -= dmg;
         game.getContext().get(SpecialSounds.class).playHit(game, this, position, dmgType);
     }

--- a/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
+++ b/engine/src/main/java/org/destinationsol/game/console/commands/DieCommandHandler.java
@@ -38,7 +38,7 @@ public class DieCommandHandler {
         if (!hero.isAlive()) {
             throw new CommandExecutionException("Hero is already dead!");
         }
-        hero.getShip().receivePiercingDmg(hero.getHull().getHullConfig().getMaxLife() + 1f, game, hero.getPosition(), DmgType.CRASH);
+        hero.getShip().receivePiercingDmg(hero.getHull().getHullConfig().getMaxLife() + 1f, game, hero.getPosition(), DmgType.CRASH, null);
         return "Hero killed!";
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/drawables/DrawableObject.java
+++ b/engine/src/main/java/org/destinationsol/game/drawables/DrawableObject.java
@@ -116,7 +116,7 @@ public class DrawableObject implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/faction/DamageInflictedReputationEvent.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/DamageInflictedReputationEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.destinationsol.game.faction;
+
+/**
+ * A reputation-affecting event raised when a ship (or projectile fired by a ship) causes damage to another.
+ */
+public class DamageInflictedReputationEvent implements ReputationEvent {
+    // This constant is calculated based on backwards compatibility with the old "1 hit = -1 reputation" logic,
+    // assuming a normal bullet clip that deals 1.6 units of damage (same as the Heavy Machine Gun at the time).
+    public static final float DAMAGE_REPUTATION_MODIFIER = 1.0f / 1.6f;
+    private final float damageTaken;
+
+    public DamageInflictedReputationEvent(float damageTaken) {
+        this.damageTaken = damageTaken;
+    }
+
+    /**
+     * Returns the quantity of damage caused by the instigator.
+     * @return the quantity of damage caused by the instigator.
+     */
+    public float getDamageTaken() {
+        return damageTaken;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public float getDefaultReputationImpact() {
+        return -(damageTaken * DAMAGE_REPUTATION_MODIFIER);
+    }
+}

--- a/engine/src/main/java/org/destinationsol/game/faction/DefaultReputationEvent.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/DefaultReputationEvent.java
@@ -48,7 +48,7 @@ public enum DefaultReputationEvent implements ReputationEvent {
      * @return the default impact on reputation this event will have in absence of a faction-specific value.
      */
     @Override
-    public int getDefaultReputationImpact() {
+    public float getDefaultReputationImpact() {
         return defaultReputationImpact;
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/faction/Faction.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/Faction.java
@@ -61,17 +61,17 @@ public class Faction {
     /**
      * The default standing that this faction has towards unknown factions.
      */
-    private final int defaultDisposition;
+    private final float defaultDisposition;
     /**
      * The relations held between this faction and other factions.
      */
-    private final Map<Faction, Integer> relations;
+    private final Map<Faction, Float> relations;
     /**
      * The impact that certain events will have on relations with another faction if they instigate a given event.
      * (For example, hitting the ship with a projectile loses reputation, having a negative impact.)
      * @see DefaultReputationEvent
      */
-    private final Map<String, Integer> reputationImpacts;
+    private final Map<String, Float> reputationImpacts;
 
     /**
      * Instantiates a new faction instance.
@@ -84,7 +84,7 @@ public class Faction {
      * @param reputationImpacts the impact certain events should have on relationships between this faction and others.
      */
     public Faction(ResourceUrn id, String name, String description, Color colour, int defaultDisposition,
-                   List<ResourceUrn> shipDesigns, Map<String, Integer> reputationImpacts) {
+                   List<ResourceUrn> shipDesigns, Map<String, Float> reputationImpacts) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -141,7 +141,7 @@ public class Faction {
      * @return the change in reputation, if known, otherwise null.
      * @param <T> the type of event.
      */
-    public <T extends Enum<T> & ReputationEvent> Integer getReputationImpact(T event) {
+    public <T extends ReputationEvent> Float getReputationImpact(T event) {
         return reputationImpacts.get(event.toString());
     }
 
@@ -159,7 +159,7 @@ public class Faction {
      * @param faction the faction to check.
      * @return the reputation value held with this faction.
      */
-    public int getRelation(Faction faction) {
+    public float getRelation(Faction faction) {
         if (faction == this) {
             return MAX_REPUTATION;
         }
@@ -171,7 +171,7 @@ public class Faction {
      * @param faction the faction to assign reputation with.
      * @param disposition the overall disposition of this faction towards the other.
      */
-    public void setRelation(Faction faction, int disposition) {
+    public void setRelation(Faction faction, float disposition) {
         if (faction != this) {
             relations.put(faction, Math.clamp(MIN_REPUTATION, MAX_REPUTATION, disposition));
         }

--- a/engine/src/main/java/org/destinationsol/game/faction/FactionConfig.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/FactionConfig.java
@@ -37,7 +37,7 @@ public final class FactionConfig {
         for (int designNo = 0; designNo < shipDesignsArray.length(); designNo++) {
             shipDesigns.add(new ResourceUrn(shipDesignsArray.getString(designNo)));
         }
-        Map<String, Integer> reputationImpacts = new HashMap<>();
+        Map<String, Float> reputationImpacts = new HashMap<>();
         return new Faction(id, jsonObject.getString("name"),
                 jsonObject.getString("description"),
                 new org.terasology.nui.Color(gdxColour.r, gdxColour.g, gdxColour.b, gdxColour.a),

--- a/engine/src/main/java/org/destinationsol/game/faction/FactionsConfigs.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/FactionsConfigs.java
@@ -75,15 +75,15 @@ public class FactionsConfigs {
                     } else if (!faction.isAwareOf(otherFaction) && otherFaction.isAwareOf(faction)) {
                         faction.setRelation(otherFaction, otherFaction.getRelation(faction));
                     } else {
-                        int factionRelation = faction.getRelation(otherFaction);
-                        int otherFactionRelation = otherFaction.getRelation(faction);
+                        float factionRelation = faction.getRelation(otherFaction);
+                        float otherFactionRelation = otherFaction.getRelation(faction);
 
                         // The simplified rules of uncertain Destination Sol diplomacy:
                         //   - If both are friendly, the stronger positivity will prevail.
                         //   - If both are hostile, the stronger hostility will prevail.
                         //   - If your enemy is hostile to you, you must be hostile to your enemy.
                         //   - Neutrality is considered friendly.
-                        int relation = (factionRelation >= 0 && otherFactionRelation >= 0) ?
+                        float relation = (factionRelation >= 0 && otherFactionRelation >= 0) ?
                                 Math.max(factionRelation, otherFactionRelation) :
                                 Math.min(factionRelation, otherFactionRelation);
                         faction.setRelation(otherFaction, relation);

--- a/engine/src/main/java/org/destinationsol/game/faction/ReputationEvent.java
+++ b/engine/src/main/java/org/destinationsol/game/faction/ReputationEvent.java
@@ -30,5 +30,5 @@ public interface ReputationEvent {
      * Returns the default impact on reputation this event will have in absence of a faction-specific value.
      * @return the default impact on reputation this event will have in absence of a faction-specific value.
      */
-    int getDefaultReputationImpact();
+    float getDefaultReputationImpact();
 }

--- a/engine/src/main/java/org/destinationsol/game/item/Loot.java
+++ b/engine/src/main/java/org/destinationsol/game/item/Loot.java
@@ -117,7 +117,7 @@ public class Loot implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         life -= dmg;
         game.getContext().get(SpecialSounds.class).playHit(game, this, position, dmgType);
     }
@@ -164,7 +164,7 @@ public class Loot implements SolObject {
     public void handleContact(SolObject other, float absImpulse,
                               SolGame game, Vector2 collPos) {
         float dmg = absImpulse / mass / DURABILITY;
-        receiveDmg((int) dmg, game, collPos, DmgType.CRASH);
+        receiveDmg((int) dmg, game, collPos, DmgType.CRASH, null);
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/maze/MazeTileObject.java
+++ b/engine/src/main/java/org/destinationsol/game/maze/MazeTileObject.java
@@ -72,7 +72,7 @@ public class MazeTileObject implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         game.getContext().get(SpecialSounds.class).playHit(game, this, position, dmgType);
     }
 

--- a/engine/src/main/java/org/destinationsol/game/particle/LightObject.java
+++ b/engine/src/main/java/org/destinationsol/game/particle/LightObject.java
@@ -57,7 +57,7 @@ public class LightObject implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/planet/PlanetSprites.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/PlanetSprites.java
@@ -69,7 +69,7 @@ public class PlanetSprites implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/planet/Sky.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/Sky.java
@@ -17,7 +17,6 @@ package org.destinationsol.game.planet;
 
 import com.badlogic.gdx.math.Vector2;
 import org.destinationsol.Const;
-import org.destinationsol.assets.Assets;
 import org.destinationsol.common.SolColor;
 import org.destinationsol.common.SolMath;
 import org.destinationsol.game.ColorSpan;
@@ -122,7 +121,7 @@ public class Sky implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/game/planet/SunSingleton.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/SunSingleton.java
@@ -71,6 +71,6 @@ public class SunSingleton {
         if (SUN_HOT_RAD < toSys) {
             return;
         }
-        obj.receiveDmg(dmg, game, null, DmgType.FIRE);
+        obj.receiveDmg(dmg, game, null, DmgType.FIRE, null);
     }
 }

--- a/engine/src/main/java/org/destinationsol/game/planet/TileObject.java
+++ b/engine/src/main/java/org/destinationsol/game/planet/TileObject.java
@@ -98,7 +98,7 @@ public class TileObject implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         game.getContext().get(SpecialSounds.class).playHit(game, this, position, dmgType);
     }
 

--- a/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
+++ b/engine/src/main/java/org/destinationsol/game/projectile/Projectile.java
@@ -34,7 +34,6 @@ import org.destinationsol.game.SolObjectEntityWrapper;
 import org.destinationsol.game.drawables.Drawable;
 import org.destinationsol.game.drawables.DrawableLevel;
 import org.destinationsol.game.drawables.SpriteManager;
-import org.destinationsol.game.faction.DefaultReputationEvent;
 import org.destinationsol.game.faction.Faction;
 import org.destinationsol.game.item.Shield;
 import org.destinationsol.game.particle.DSParticleEmitter;
@@ -162,10 +161,10 @@ public class Projectile implements SolObject {
                 if (!wasDamageDealt) {
                     if (config.aoeRadius >= 0) { //If AoE is enabled for this Projectile, damage all within the radius.
                         game.getObjectManager().doToAllCloserThan(config.aoeRadius, this, (SolObject obj) ->
-                                obj.receiveDmg(config.dmg, game, body.getPosition(), config.dmgType)
+                                obj.receiveDmg(config.dmg, game, body.getPosition(), config.dmgType, ship)
                         );
                     } else {
-                        obstacle.receiveDmg(config.dmg, game, body.getPosition(), config.dmgType);
+                        obstacle.receiveDmg(config.dmg, game, body.getPosition(), config.dmgType, ship);
                     }
                 }
                 if (config.density > 0) {
@@ -216,9 +215,6 @@ public class Projectile implements SolObject {
         if (config.collisionEffectBackground != null) {
             game.getPartMan().blinks(position, game, config.collisionEffectBackground.size);
         }
-        if (ship.getPilot().isPlayer() && obstacle instanceof SolShip) {
-            game.getFactionMan().reportEvent(ship.getFaction(), ((SolShip) obstacle).getFaction(), DefaultReputationEvent.DAMAGED_SHIP);
-        }
 
         game.getSoundManager().play(game, config.collisionSound, null, this);
     }
@@ -241,7 +237,7 @@ public class Projectile implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         if (config.density > 0) {
             return;
         }

--- a/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/SolShip.java
@@ -16,7 +16,6 @@
 
 package org.destinationsol.game.ship;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
@@ -31,6 +30,8 @@ import org.destinationsol.game.RemoveController;
 import org.destinationsol.game.SolGame;
 import org.destinationsol.game.SolObject;
 import org.destinationsol.game.drawables.Drawable;
+import org.destinationsol.game.faction.DamageInflictedReputationEvent;
+import org.destinationsol.game.faction.DefaultReputationEvent;
 import org.destinationsol.game.faction.Faction;
 import org.destinationsol.game.gun.GunMount;
 import org.destinationsol.game.input.Pilot;
@@ -147,7 +148,7 @@ public class SolShip implements SolObject {
         if (myHull.config.getType() != HullConfig.Type.STATION) {
             float dmg = absImpulse / myHull.getMass() / myHull.config.getDurability();
             dmg *= BASE_DUR_MOD;
-            receiveDmg((int) dmg, game, collPos, DmgType.CRASH);
+            receiveDmg((int) dmg, game, collPos, DmgType.CRASH, null);
         }
     }
 
@@ -411,7 +412,7 @@ public class SolShip implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         Hero hero = game.getHero();
         if (dmg <= 0 || (hero.isInvincible() && hero.getShip() == this)) {
             return;
@@ -426,26 +427,34 @@ public class SolShip implements SolObject {
             }
             dmg *= (1 - myArmor.getPerc());
         }
-        getHitWith(dmg, game, position, dmgType);
+        getHitWith(dmg, game, position, dmgType, instigator);
     }
 
     /**
-     * Like {{@link #receiveDmg(float, SolGame, Vector2, DmgType)} but shield and armor are ignored, the damage goes straight to the hull
+     * Like {{@link SolObject#receiveDmg(float, SolGame, Vector2, DmgType, SolObject)} but shield and armor are ignored, the damage goes straight to the hull
      */
-    public void receivePiercingDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receivePiercingDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         if (dmg <= 0) {
             return;
         }
 
-        getHitWith(dmg, game, position, dmgType);
+        getHitWith(dmg, game, position, dmgType, instigator);
     }
 
-    private void getHitWith(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    private void getHitWith(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
         playHitSound(game, position, dmgType);
+
+        if (instigator instanceof SolShip) {
+            game.getFactionMan().reportEvent(((SolShip) instigator).getFaction(), getFaction(), new DamageInflictedReputationEvent(dmg));
+        }
 
         boolean wasAlive = myHull.life > 0;
         myHull.life -= dmg;
         if (wasAlive && myHull.life <= 0) {
+            if (instigator instanceof SolShip) {
+                game.getFactionMan().reportEvent(((SolShip) instigator).getFaction(), getFaction(), DefaultReputationEvent.DESTROYED_SHIP);
+            }
+
             onDeath(game);
             Vector2 shipPos = getPosition();
             game.getSpecialEffects().explodeShip(game, shipPos, myHull.config.getSize());

--- a/engine/src/main/java/org/destinationsol/game/ship/UnShield.java
+++ b/engine/src/main/java/org/destinationsol/game/ship/UnShield.java
@@ -84,7 +84,7 @@ public class UnShield implements ShipAbility {
             if (shieldLife < amount) {
                 amount = shieldLife;
             }
-            oShip.receiveDmg(amount, game, ownerPos, DmgType.ENERGY);
+            oShip.receiveDmg(amount, game, ownerPos, DmgType.ENERGY, owner);
         }
         DSParticleEmitter src = new DSParticleEmitter(config.cc.effect, MAX_RADIUS, DrawableLevel.PART_BG_0, new Vector2(), true, game, ownerPos, Vector2.Zero, 0);
         game.getPartMan().finish(game, src, ownerPos);

--- a/engine/src/main/java/org/destinationsol/game/tutorial/steps/wrapper/TrackedSolObjectWrapper.java
+++ b/engine/src/main/java/org/destinationsol/game/tutorial/steps/wrapper/TrackedSolObjectWrapper.java
@@ -58,8 +58,8 @@ public class TrackedSolObjectWrapper implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
-        trackedSolObject.receiveDmg(dmg, game, position, dmgType);
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
+        trackedSolObject.receiveDmg(dmg, game, position, dmgType, instigator);
     }
 
     @Override

--- a/engine/src/main/java/org/destinationsol/ui/Waypoint.java
+++ b/engine/src/main/java/org/destinationsol/ui/Waypoint.java
@@ -57,7 +57,7 @@ public class Waypoint implements SolObject {
     }
 
     @Override
-    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType) {
+    public void receiveDmg(float dmg, SolGame game, Vector2 position, DmgType dmgType, SolObject instigator) {
 
     }
 

--- a/engine/src/test/java/org/destinationsol/game/RubbleTest.java
+++ b/engine/src/test/java/org/destinationsol/game/RubbleTest.java
@@ -137,7 +137,7 @@ public class RubbleTest implements AssetsHelperInitializer, Box2DInitializer {
     @Test
     public void receiveDmg() {
         // Rubbles have no health, and thus receiveDamage() just should not crash
-        RUBBLE_CONSTANT.receiveDmg(100, game, null, DmgType.BULLET);
+        RUBBLE_CONSTANT.receiveDmg(100, game, null, DmgType.BULLET, null);
     }
 
     @Test


### PR DESCRIPTION
# Description
This pull request changes reputation loss due to damage to be proportional to the damage inflicted, rather than constant per-hit. It also changes the damage handling code to take into account the instigator of the damage, removing a previous constraint where the projectile code directly managed reputation loss, which was a poor place to handle this in.

It also implements a fixed penalty reputation loss when a ship is destroyed, which was previously referenced in the code but unimplemented.

# Testing
- Start a new game with the `Loaded Imperial Large` ship
- Fire on the starting station until it starts firing back.
- Destroy a few of the guards
- Fly around and verify that other `Imperial` faction ships are now hostile to you

# Notes
This fixes #729.